### PR TITLE
CI/CD workflows and npm publishing

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,28 @@
+name: Setup
+description: Install pnpm, Node.js, and dependencies
+
+inputs:
+  registry-url:
+    description: Registry URL for publishing
+    required: false
+
+runs:
+  using: composite
+  steps:
+    - uses: pnpm/action-setup@v4
+
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 22
+        cache: pnpm
+        registry-url: ${{ inputs.registry-url }}
+
+    - run: pnpm install --frozen-lockfile
+      shell: bash
+
+    - uses: actions/cache@v4
+      with:
+        path: .turbo
+        key: turbo-${{ runner.os }}-node22-${{ hashFiles('**/pnpm-lock.yaml') }}
+        restore-keys: |
+          turbo-${{ runner.os }}-node22-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  ci:
+    name: Build, Lint & Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+      - run: pnpm build
+      - run: pnpm lint
+      - run: pnpm test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,65 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  # NOTE: validate tests at version 0.0.0, while publish-npm stamps and ships the
+  # tagged version. Accepted trade-off: for TypeScript projects, version rarely
+  # affects build output. If version-dependent behavior is introduced, consider
+  # moving version stamping before validation.
+  validate:
+    name: Validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+      - run: pnpm build
+      - run: pnpm lint
+      - run: pnpm test
+
+  publish-npm:
+    name: Publish to npm
+    needs: validate
+    runs-on: ubuntu-latest
+    environment: npm-publish
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup
+        with:
+          registry-url: https://registry.npmjs.org
+
+      # Trusted publishing requires npm 11.5.1+ for OIDC token exchange
+      - name: Upgrade npm
+        run: npm install -g npm@latest
+
+      - name: Stamp version
+        env:
+          RAW_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          VERSION="${RAW_TAG#v}"
+          # Build metadata (+build) intentionally excluded — only release and pre-release tags accepted
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.-]+)?$'; then
+            echo "::error::Tag '$RAW_TAG' is not a valid semver version"
+            exit 1
+          fi
+          pnpm -r exec npm version "$VERSION" --no-git-tag-version --allow-same-version
+
+      - run: pnpm build
+
+      - name: Verify packages
+        run: pnpm -r publish --dry-run --access public --no-git-checks
+
+      - name: Publish packages
+        run: pnpm -r publish --access public --no-git-checks --report-summary

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # lhremote — Claude Instructions
 
-> Remote automation toolkit for LinkedHelper.com
+> Automation toolkit for LinkedHelper.com
 
 ## Conventions
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# lhremote: LinkedHelper Remote Control
+# lhremote: LinkedHelper Automation Toolkit
 
 [![GitHub Repo stars](https://img.shields.io/github/stars/alexey-pelykh/lhremote?style=flat&logo=github)](https://github.com/alexey-pelykh/lhremote)
 [![License](https://img.shields.io/github/license/alexey-pelykh/lhremote)](LICENSE)

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,19 @@
+# @lhremote/cli
+
+CLI for [lhremote](https://github.com/alexey-pelykh/lhremote) — LinkedHelper automation toolkit.
+
+## Installation
+
+```bash
+npm install -g @lhremote/cli
+```
+
+## Usage
+
+```bash
+lhremote --help
+```
+
+## License
+
+[AGPL-3.0-only](https://github.com/alexey-pelykh/lhremote/blob/main/LICENSE)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,17 +1,34 @@
 {
   "name": "@lhremote/cli",
   "version": "0.0.0",
-  "private": true,
+  "description": "CLI for LinkedHelper automation",
   "type": "module",
+  "engines": {
+    "node": ">=22"
+  },
+  "license": "AGPL-3.0-only",
+  "author": "Alexey Pelykh (https://github.com/alexey-pelykh)",
+  "homepage": "https://github.com/alexey-pelykh/lhremote/tree/main/packages/cli",
+  "bugs": "https://github.com/alexey-pelykh/lhremote/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/alexey-pelykh/lhremote.git",
+    "directory": "packages/cli"
+  },
   "bin": {
     "lhremote": "./dist/cli.js"
   },
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc",
+    "test": "echo 'No tests configured'",
+    "lint": "echo 'No linter configured'",
     "dev": "tsc --watch"
   },
   "dependencies": {
-    "@lhremote/core": "workspace:*"
+    "@lhremote/core": "workspace:^"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,0 +1,13 @@
+# @lhremote/core
+
+Core library for [lhremote](https://github.com/alexey-pelykh/lhremote) — LinkedHelper automation toolkit.
+
+## Installation
+
+```bash
+npm install @lhremote/core
+```
+
+## License
+
+[AGPL-3.0-only](https://github.com/alexey-pelykh/lhremote/blob/main/LICENSE)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,16 +1,33 @@
 {
   "name": "@lhremote/core",
   "version": "0.0.0",
-  "private": true,
+  "description": "Core library for LinkedHelper automation",
   "type": "module",
+  "engines": {
+    "node": ">=22"
+  },
+  "license": "AGPL-3.0-only",
+  "author": "Alexey Pelykh (https://github.com/alexey-pelykh)",
+  "homepage": "https://github.com/alexey-pelykh/lhremote/tree/main/packages/core",
+  "bugs": "https://github.com/alexey-pelykh/lhremote/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/alexey-pelykh/lhremote.git",
+    "directory": "packages/core"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }
   },
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc",
+    "test": "echo 'No tests configured'",
+    "lint": "echo 'No linter configured'",
     "dev": "tsc --watch"
   },
   "devDependencies": {

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -1,0 +1,13 @@
+# @lhremote/mcp
+
+MCP server for [lhremote](https://github.com/alexey-pelykh/lhremote) — LinkedHelper automation toolkit.
+
+## Installation
+
+```bash
+npm install @lhremote/mcp
+```
+
+## License
+
+[AGPL-3.0-only](https://github.com/alexey-pelykh/lhremote/blob/main/LICENSE)

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,20 +1,37 @@
 {
   "name": "@lhremote/mcp",
   "version": "0.0.0",
-  "private": true,
+  "description": "MCP server for LinkedHelper automation",
   "type": "module",
+  "engines": {
+    "node": ">=22"
+  },
+  "license": "AGPL-3.0-only",
+  "author": "Alexey Pelykh (https://github.com/alexey-pelykh)",
+  "homepage": "https://github.com/alexey-pelykh/lhremote/tree/main/packages/mcp",
+  "bugs": "https://github.com/alexey-pelykh/lhremote/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/alexey-pelykh/lhremote.git",
+    "directory": "packages/mcp"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
     }
   },
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc",
+    "test": "echo 'No tests configured'",
+    "lint": "echo 'No linter configured'",
     "dev": "tsc --watch"
   },
   "dependencies": {
-    "@lhremote/core": "workspace:*"
+    "@lhremote/core": "workspace:^"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,7 +27,7 @@ importers:
   packages/cli:
     dependencies:
       '@lhremote/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
     devDependencies:
       '@types/node':
@@ -49,7 +49,7 @@ importers:
   packages/mcp:
     dependencies:
       '@lhremote/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../core
     devDependencies:
       '@types/node':


### PR DESCRIPTION
## Summary

- CI workflow: build, lint, and test on PRs and main pushes
- Release workflow: triggered by GitHub Releases, validates then publishes to npm via OIDC trusted publishing
- Publishing-ready package.json config: `license`, `repository`, `files`, `workspace:^`
- Explicit placeholder `test` and `lint` scripts (no silent Turbo skipping)
- Package READMEs for npm registry pages

## CI/CD Architecture

```
PR/Push to main:
  checkout → setup (pnpm + Node 22 + Turbo cache) → build → lint → test

GitHub Release published:
  validate (build + lint + test)
      └──> publish-npm (OIDC trusted publishing, version stamped from tag)
```

**Release flow**: Create a GitHub Release with a `v*` tag → workflow validates, stamps version from tag into all packages, publishes to npm with `--access public`.

**Required setup**: Configure npm trusted publishing (OIDC) via `npm-publish` GitHub environment. No `NPM_TOKEN` secret needed.

## Test plan

- [ ] CI workflow runs on this PR (build + lint + test)
- [ ] After merge, create a test GitHub Release to verify publishing pipeline

🤖 Generated with [Claude Code](https://claude.ai/code)