### PR TITLE
(feat) core: add CDP client (#5)

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -20,6 +20,10 @@ runs:
     - run: pnpm install --frozen-lockfile
       shell: bash
 
+    - name: Install Playwright Chromium
+      run: npx playwright-core install chromium --with-deps
+      shell: bash
+
     - uses: actions/cache@v4
       with:
         path: .turbo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,11 @@ concurrency:
 
 jobs:
   ci:
-    name: Build, Lint & Test
-    runs-on: ubuntu-latest
+    name: Build, Lint & Test (${{ matrix.os }})
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,19 @@ Example: `(feat) mcp: add visit-profile tool`
 
 Reference issues: `(fix) cdp: handle reconnection (#12)`
 
+## Testing
+
+| Tier | Scope | Environment | Dependency |
+|------|-------|-------------|------------|
+| 1 — Unit | Mocked CDP protocol, error handling, request correlation | CI (`vitest run`) | None |
+| 2 — Integration | Real headless Chromium via `playwright-core` | CI (`vitest run`) | Chromium binary (installed by Playwright) |
+| 3 — E2E | Full LinkedHelper app, real LinkedIn interactions | Local only | LinkedHelper (paid app) |
+
+- Tier 1 and 2 run together via `pnpm test` — no separate commands needed.
+- Integration tests use `*.integration.test.ts` suffix.
+- Test helper `src/cdp/testing/launch-chromium.ts` manages Chromium lifecycle.
+- Chromium is installed in CI via `npx playwright-core install chromium --with-deps`.
+
 ## Task Tracking
 
 **Issues**: https://github.com/alexey-pelykh/lhremote/issues

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,6 +34,12 @@
     "@types/node": "catalog:",
     "eslint": "catalog:",
     "typescript": "catalog:",
+    "playwright-core": "catalog:",
     "vitest": "catalog:"
+  },
+  "dependencies": {
+    "devtools-protocol": "^0.0.1577676",
+    "pid-port": "catalog:",
+    "ps-list": "catalog:"
   }
 }

--- a/packages/core/src/cdp/client.integration.test.ts
+++ b/packages/core/src/cdp/client.integration.test.ts
@@ -1,0 +1,109 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { CDPClient } from "./client.js";
+import { CDPEvaluationError } from "./errors.js";
+import {
+  launchChromium,
+  type ChromiumInstance,
+} from "./testing/launch-chromium.js";
+
+describe("CDPClient (integration)", () => {
+  let chromium: ChromiumInstance;
+  let client: CDPClient;
+
+  beforeAll(async () => {
+    chromium = await launchChromium();
+  }, 30_000);
+
+  afterAll(async () => {
+    await chromium.close();
+  });
+
+  afterEach(() => {
+    client.disconnect();
+  });
+
+  describe("connect", () => {
+    it("should connect to a real Chromium page target", async () => {
+      client = new CDPClient(chromium.port);
+      await client.connect();
+
+      expect(client.isConnected).toBe(true);
+    });
+  });
+
+  describe("evaluate", () => {
+    it("should evaluate a JavaScript expression", async () => {
+      client = new CDPClient(chromium.port);
+      await client.connect();
+
+      const result = await client.evaluate<number>("2 + 2");
+
+      expect(result).toBe(4);
+    });
+
+    it("should evaluate expressions returning objects", async () => {
+      client = new CDPClient(chromium.port);
+      await client.connect();
+
+      const result = await client.evaluate<{ a: number; b: string }>(
+        "({ a: 1, b: 'hello' })",
+      );
+
+      expect(result).toEqual({ a: 1, b: "hello" });
+    });
+
+    it("should throw CDPEvaluationError on runtime exception", async () => {
+      client = new CDPClient(chromium.port);
+      await client.connect();
+
+      await expect(
+        client.evaluate("throw new Error('test error')"),
+      ).rejects.toThrow(CDPEvaluationError);
+    });
+
+    it("should await promise results when awaitPromise is true", async () => {
+      client = new CDPClient(chromium.port);
+      await client.connect();
+
+      const result = await client.evaluate<number>(
+        "Promise.resolve(42)",
+        true,
+      );
+
+      expect(result).toBe(42);
+    });
+  });
+
+  describe("navigate", () => {
+    it("should navigate to a data URL", async () => {
+      client = new CDPClient(chromium.port);
+      await client.connect();
+
+      const response = await client.navigate(
+        "data:text/html,<h1>Integration Test</h1>",
+      );
+
+      expect(response.frameId).toEqual(expect.any(String));
+    });
+  });
+
+  describe("events", () => {
+    it("should receive CDP events from the browser", async () => {
+      client = new CDPClient(chromium.port);
+      await client.connect();
+
+      // Enable Page domain to receive events
+      await client.send("Page.enable");
+
+      const eventPromise = client.waitForEvent(
+        "Page.loadEventFired",
+        10_000,
+      );
+
+      await client.navigate("data:text/html,<h1>Event Test</h1>");
+
+      const params = (await eventPromise) as { timestamp: number };
+      expect(params.timestamp).toEqual(expect.any(Number));
+    });
+  });
+});

--- a/packages/core/src/cdp/client.test.ts
+++ b/packages/core/src/cdp/client.test.ts
@@ -1,0 +1,357 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  CDPConnectionError,
+  CDPEvaluationError,
+  CDPTimeoutError,
+} from "./errors.js";
+import { CDPClient } from "./client.js";
+
+// Mock discovery so CDPClient.connect() resolves a WebSocket URL
+// without actually hitting a real HTTP endpoint.
+vi.mock("./discovery.js", () => ({
+  discoverTargets: vi.fn(),
+}));
+
+import { discoverTargets } from "./discovery.js";
+
+/**
+ * Minimal mock that simulates the browser-standard WebSocket API
+ * used by Node 22's global WebSocket.
+ */
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+
+  private eventHandlers = new Map<string, Set<(ev: unknown) => void>>();
+
+  readonly url: string;
+  readyState = 0; // CONNECTING
+
+  constructor(url: string | URL) {
+    this.url = typeof url === "string" ? url : url.toString();
+    MockWebSocket.instances.push(this);
+
+    // Simulate async open
+    queueMicrotask(() => {
+      this.readyState = 1; // OPEN
+      this.emit("open", {});
+    });
+  }
+
+  addEventListener(event: string, handler: (ev: unknown) => void): void {
+    let set = this.eventHandlers.get(event);
+    if (!set) {
+      set = new Set();
+      this.eventHandlers.set(event, set);
+    }
+    set.add(handler);
+  }
+
+  send: (data: string) => void = () => {
+    // default no-op, overridden by tests
+  };
+
+  close(): void {
+    this.readyState = 3; // CLOSED
+  }
+
+  // Test helpers
+  emit(event: string, data: unknown): void {
+    const set = this.eventHandlers.get(event);
+    if (set) {
+      for (const handler of set) {
+        handler(data);
+      }
+    }
+  }
+
+  /** Simulate receiving a CDP message from the server. */
+  receiveMessage(obj: Record<string, unknown>): void {
+    this.emit("message", { data: JSON.stringify(obj) });
+  }
+}
+
+// Replace the global WebSocket with our mock
+vi.stubGlobal("WebSocket", MockWebSocket);
+
+const MOCK_TARGETS = [
+  {
+    description: "",
+    devtoolsFrontendUrl: "",
+    id: "PAGE1",
+    type: "page",
+    title: "Test Page",
+    url: "about:blank",
+    webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/page/PAGE1",
+  },
+];
+
+function lastMockWs(): MockWebSocket {
+  const ws = MockWebSocket.instances[MockWebSocket.instances.length - 1];
+  if (!ws) {
+    throw new Error("No MockWebSocket instance created");
+  }
+  return ws;
+}
+
+describe("CDPClient", () => {
+  let client: CDPClient;
+
+  beforeEach(() => {
+    MockWebSocket.instances = [];
+    vi.mocked(discoverTargets).mockResolvedValue(MOCK_TARGETS);
+    client = new CDPClient(9222, { timeout: 500 });
+  });
+
+  afterEach(() => {
+    client.disconnect();
+    vi.restoreAllMocks();
+  });
+
+  describe("connect", () => {
+    it("should connect to the first page target by default", async () => {
+      await client.connect();
+
+      expect(client.isConnected).toBe(true);
+      expect(discoverTargets).toHaveBeenCalledWith(9222, "127.0.0.1");
+      expect(MockWebSocket.instances).toHaveLength(1);
+      expect(lastMockWs().url).toBe(
+        "ws://127.0.0.1:9222/devtools/page/PAGE1",
+      );
+    });
+
+    it("should connect to a specific target by ID", async () => {
+      await client.connect("PAGE1");
+
+      expect(client.isConnected).toBe(true);
+    });
+
+    it("should throw when target ID not found", async () => {
+      await expect(client.connect("NONEXISTENT")).rejects.toThrow(
+        CDPConnectionError,
+      );
+    });
+
+    it("should throw when target has no webSocketDebuggerUrl", async () => {
+      vi.mocked(discoverTargets).mockResolvedValue([
+        {
+          description: "",
+          devtoolsFrontendUrl: "",
+          id: "NOURL",
+          type: "page",
+          title: "No WS",
+          url: "about:blank",
+        },
+      ]);
+
+      await expect(client.connect()).rejects.toThrow(
+        /webSocketDebuggerUrl/,
+      );
+    });
+  });
+
+  describe("send", () => {
+    it("should throw when not connected", async () => {
+      await expect(client.send("Runtime.evaluate")).rejects.toThrow(
+        CDPConnectionError,
+      );
+    });
+
+    it("should correlate request and response by message ID", async () => {
+      await client.connect();
+      const ws = lastMockWs();
+
+      let sentMessage: string | undefined;
+      ws.send = (data: string) => {
+        sentMessage = data;
+      };
+
+      const resultPromise = client.send("Runtime.evaluate", {
+        expression: "1+1",
+      });
+
+      // Wait for send to be called
+      await vi.waitFor(() => expect(sentMessage).toBeDefined());
+
+      const parsed = JSON.parse(sentMessage as string) as {
+        id: number;
+        method: string;
+      };
+      expect(parsed.method).toBe("Runtime.evaluate");
+
+      // Simulate response
+      ws.receiveMessage({
+        id: parsed.id,
+        result: { result: { type: "number", value: 2 } },
+      });
+
+      const result = await resultPromise;
+      expect(result).toEqual({ result: { type: "number", value: 2 } });
+    });
+
+    it("should reject on CDP error response", async () => {
+      await client.connect();
+      const ws = lastMockWs();
+
+      let sentId: number | undefined;
+      ws.send = (data: string) => {
+        sentId = (JSON.parse(data) as { id: number }).id;
+      };
+
+      const resultPromise = client.send("BadMethod");
+
+      await vi.waitFor(() => expect(sentId).toBeDefined());
+
+      ws.receiveMessage({
+        id: sentId,
+        error: { message: "Method not found" },
+      });
+
+      await expect(resultPromise).rejects.toThrow(CDPEvaluationError);
+      await expect(resultPromise).rejects.toThrow(/Method not found/);
+    });
+
+    it("should reject on timeout", async () => {
+      await client.connect();
+      const ws = lastMockWs();
+      ws.send = () => {
+        /* swallow, never respond */
+      };
+
+      await expect(client.send("Slow.method")).rejects.toThrow(
+        CDPTimeoutError,
+      );
+    });
+  });
+
+  describe("evaluate", () => {
+    it("should return evaluated value", async () => {
+      await client.connect();
+      const ws = lastMockWs();
+
+      ws.send = (data: string) => {
+        const msg = JSON.parse(data) as { id: number };
+        queueMicrotask(() => {
+          ws.receiveMessage({
+            id: msg.id,
+            result: { result: { type: "number", value: 42 } },
+          });
+        });
+      };
+
+      const result = await client.evaluate<number>("21 * 2");
+      expect(result).toBe(42);
+    });
+
+    it("should throw CDPEvaluationError on exception", async () => {
+      await client.connect();
+      const ws = lastMockWs();
+
+      ws.send = (data: string) => {
+        const msg = JSON.parse(data) as { id: number };
+        queueMicrotask(() => {
+          ws.receiveMessage({
+            id: msg.id,
+            result: {
+              exceptionDetails: {
+                exception: { description: "ReferenceError: x is not defined" },
+              },
+            },
+          });
+        });
+      };
+
+      await expect(client.evaluate("x")).rejects.toThrow(
+        CDPEvaluationError,
+      );
+      await expect(client.evaluate("x")).rejects.toThrow(
+        /ReferenceError/,
+      );
+    });
+  });
+
+  describe("events", () => {
+    it("should dispatch CDP events to listeners", async () => {
+      await client.connect();
+      const ws = lastMockWs();
+
+      const received: unknown[] = [];
+      client.on("Page.loadEventFired", (params) => {
+        received.push(params);
+      });
+
+      ws.receiveMessage({
+        method: "Page.loadEventFired",
+        params: { timestamp: 12345 },
+      });
+
+      expect(received).toHaveLength(1);
+      expect(received[0]).toEqual({ timestamp: 12345 });
+    });
+
+    it("should remove listeners with off()", async () => {
+      await client.connect();
+      const ws = lastMockWs();
+
+      const received: unknown[] = [];
+      const handler = (params: unknown) => {
+        received.push(params);
+      };
+
+      client.on("Network.requestWillBeSent", handler);
+      ws.receiveMessage({
+        method: "Network.requestWillBeSent",
+        params: { requestId: "1" },
+      });
+
+      client.off("Network.requestWillBeSent", handler);
+      ws.receiveMessage({
+        method: "Network.requestWillBeSent",
+        params: { requestId: "2" },
+      });
+
+      expect(received).toHaveLength(1);
+    });
+
+    it("should resolve waitForEvent on event", async () => {
+      await client.connect();
+      const ws = lastMockWs();
+
+      const eventPromise = client.waitForEvent("Page.loadEventFired", 1000);
+
+      ws.receiveMessage({
+        method: "Page.loadEventFired",
+        params: { timestamp: 99 },
+      });
+
+      const result = await eventPromise;
+      expect(result).toEqual({ timestamp: 99 });
+    });
+
+    it("should reject waitForEvent on timeout", async () => {
+      await client.connect();
+
+      await expect(
+        client.waitForEvent("Never.happens", 50),
+      ).rejects.toThrow(CDPTimeoutError);
+    });
+  });
+
+  describe("disconnect", () => {
+    it("should reject pending requests on disconnect", async () => {
+      await client.connect();
+      const ws = lastMockWs();
+      ws.send = () => {
+        /* swallow */
+      };
+
+      const pendingPromise = client.send("Runtime.evaluate", {
+        expression: "1",
+      });
+
+      client.disconnect();
+
+      await expect(pendingPromise).rejects.toThrow(CDPConnectionError);
+      expect(client.isConnected).toBe(false);
+    });
+  });
+});

--- a/packages/core/src/cdp/client.ts
+++ b/packages/core/src/cdp/client.ts
@@ -1,0 +1,364 @@
+import type { Protocol } from "devtools-protocol";
+import type { CdpTarget } from "../types/cdp.js";
+import {
+  CDPConnectionError,
+  CDPEvaluationError,
+  CDPTimeoutError,
+} from "./errors.js";
+import { discoverTargets } from "./discovery.js";
+
+/** Default timeout for CDP requests (ms). */
+const DEFAULT_TIMEOUT = 30_000;
+
+/** Maximum reconnection attempts before giving up. */
+const MAX_RECONNECT_ATTEMPTS = 5;
+
+/** Base delay for exponential backoff (ms). */
+const RECONNECT_BASE_DELAY = 500;
+
+interface PendingRequest {
+  resolve: (value: unknown) => void;
+  reject: (reason: unknown) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+type EventListener = (params: unknown) => void;
+
+/**
+ * Chrome DevTools Protocol client.
+ *
+ * Communicates with a CDP-enabled process over WebSocket, providing:
+ * - Request/response correlation via incrementing message IDs
+ * - Event subscription
+ * - Convenience helpers for `Runtime.evaluate` and `Page.navigate`
+ * - Automatic reconnection with exponential backoff
+ */
+export class CDPClient {
+  private readonly port: number;
+  private readonly host: string;
+  private readonly timeout: number;
+
+  private ws: WebSocket | null = null;
+  private nextId = 1;
+  private readonly pending = new Map<number, PendingRequest>();
+  private readonly listeners = new Map<string, Set<EventListener>>();
+
+  private connected = false;
+  private targetId: string | null = null;
+  private reconnecting = false;
+
+  constructor(
+    port: number,
+    options?: { host?: string; timeout?: number },
+  ) {
+    this.port = port;
+    this.host = options?.host ?? "127.0.0.1";
+    this.timeout = options?.timeout ?? DEFAULT_TIMEOUT;
+  }
+
+  /**
+   * Open a WebSocket connection to a CDP target.
+   *
+   * @param targetId - Specific target ID to connect to.  When omitted the
+   *   first `page` target is used.
+   */
+  async connect(targetId?: string): Promise<void> {
+    const wsUrl = await this.resolveWebSocketUrl(targetId);
+    await this.openWebSocket(wsUrl);
+  }
+
+  /**
+   * Close the connection.  Pending requests are rejected.
+   */
+  disconnect(): void {
+    this.connected = false;
+    this.rejectAllPending(new CDPConnectionError("Client disconnected"));
+
+    if (this.ws) {
+      this.ws.close();
+      this.ws = null;
+    }
+  }
+
+  /**
+   * Send a raw CDP method call and wait for the response.
+   *
+   * @param method - CDP method name, e.g. `"Runtime.evaluate"`.
+   * @param params - Method parameters.
+   * @returns The `result` field from the CDP response.
+   */
+  async send(
+    method: string,
+    params?: Record<string, unknown>,
+  ): Promise<unknown> {
+    const ws = this.ws;
+    if (!ws || !this.connected) {
+      throw new CDPConnectionError("Not connected");
+    }
+
+    const id = this.nextId++;
+    const message = JSON.stringify({ id, method, params });
+
+    return new Promise<unknown>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new CDPTimeoutError(`Timed out waiting for response to ${method} (id=${id.toString()})`));
+      }, this.timeout);
+
+      this.pending.set(id, { resolve, reject, timer });
+      ws.send(message);
+    });
+  }
+
+  /**
+   * Evaluate a JavaScript expression via `Runtime.evaluate`.
+   *
+   * @param expression  - JavaScript source to evaluate.
+   * @param awaitPromise - Whether to await a Promise result (default `false`).
+   * @returns The deserialized value from the remote context.
+   */
+  async evaluate<T = unknown>(
+    expression: string,
+    awaitPromise = false,
+  ): Promise<T> {
+    const result = (await this.send("Runtime.evaluate", {
+      expression,
+      awaitPromise,
+      returnByValue: true,
+    })) as {
+      result?: { value?: unknown };
+      exceptionDetails?: { exception?: { description?: string }; text?: string };
+    };
+
+    if (result.exceptionDetails) {
+      const desc =
+        result.exceptionDetails.exception?.description ??
+        result.exceptionDetails.text ??
+        "Unknown evaluation error";
+      throw new CDPEvaluationError(desc);
+    }
+
+    return result.result?.value as T;
+  }
+
+  /**
+   * Navigate the target to the given URL via `Page.navigate`.
+   */
+  async navigate(url: string): Promise<Protocol.Page.NavigateResponse> {
+    return (await this.send("Page.navigate", {
+      url,
+    })) as Protocol.Page.NavigateResponse;
+  }
+
+  /**
+   * Subscribe to a CDP event.
+   *
+   * @param event    - Event name, e.g. `"Page.loadEventFired"`.
+   * @param listener - Callback receiving the event parameters.
+   */
+  on(event: string, listener: EventListener): void {
+    let set = this.listeners.get(event);
+    if (!set) {
+      set = new Set();
+      this.listeners.set(event, set);
+    }
+    set.add(listener);
+  }
+
+  /**
+   * Remove a previously registered event listener.
+   */
+  off(event: string, listener: EventListener): void {
+    this.listeners.get(event)?.delete(listener);
+  }
+
+  /**
+   * Wait for a single occurrence of a CDP event.
+   *
+   * @param event   - Event name.
+   * @param timeout - Maximum wait time in ms (default: client timeout).
+   */
+  async waitForEvent(
+    event: string,
+    timeout?: number,
+  ): Promise<unknown> {
+    const ms = timeout ?? this.timeout;
+
+    return new Promise<unknown>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.off(event, handler);
+        reject(new CDPTimeoutError(`Timed out waiting for event ${event}`));
+      }, ms);
+
+      const handler: EventListener = (params) => {
+        clearTimeout(timer);
+        this.off(event, handler);
+        resolve(params);
+      };
+
+      this.on(event, handler);
+    });
+  }
+
+  /** Whether the client currently has an open connection. */
+  get isConnected(): boolean {
+    return this.connected;
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private
+  // ---------------------------------------------------------------------------
+
+  /**
+   * Resolve a `ws://` URL for the given target ID, or the first page target.
+   */
+  private async resolveWebSocketUrl(
+    targetId?: string,
+  ): Promise<string> {
+    const targets = await discoverTargets(this.port, this.host);
+
+    let target: CdpTarget | undefined;
+    if (targetId) {
+      target = targets.find((t) => t.id === targetId);
+    } else {
+      target = targets.find((t) => t.type === "page");
+    }
+
+    if (!target) {
+      throw new CDPConnectionError(
+        targetId
+          ? `Target ${targetId} not found among ${targets.length.toString()} targets`
+          : `No page target found among ${targets.length.toString()} targets`,
+      );
+    }
+
+    if (!target.webSocketDebuggerUrl) {
+      throw new CDPConnectionError(
+        `Target ${target.id} has no webSocketDebuggerUrl (another debugger may be attached)`,
+      );
+    }
+
+    this.targetId = target.id;
+    return target.webSocketDebuggerUrl;
+  }
+
+  /**
+   * Open a WebSocket and wire up message handling.
+   */
+  private openWebSocket(url: string): Promise<void> {
+    return new Promise<void>((resolve, reject) => {
+      const ws = new WebSocket(url);
+      let settled = false;
+
+      ws.addEventListener("open", () => {
+        if (settled) return;
+        settled = true;
+        this.ws = ws;
+        this.connected = true;
+        resolve();
+      });
+
+      ws.addEventListener("message", (event: MessageEvent) => {
+        const data: unknown = event.data;
+        this.handleMessage(
+          typeof data === "string" ? data : String(data),
+        );
+      });
+
+      ws.addEventListener("close", () => {
+        const wasConnected = this.connected;
+        this.connected = false;
+        this.rejectAllPending(new CDPConnectionError("WebSocket closed"));
+        if (!settled) {
+          settled = true;
+          reject(new CDPConnectionError(`WebSocket closed before opening to ${url}`));
+        } else if (wasConnected) {
+          void this.attemptReconnect();
+        }
+      });
+
+      ws.addEventListener("error", () => {
+        if (!settled) {
+          settled = true;
+          reject(
+            new CDPConnectionError(`WebSocket connection failed to ${url}`),
+          );
+        }
+      });
+    });
+  }
+
+  /**
+   * Handle an incoming WebSocket message — either a method response or an event.
+   */
+  private handleMessage(raw: string): void {
+    let msg: { id?: number; method?: string; params?: unknown; result?: unknown; error?: { message: string } };
+    try {
+      msg = JSON.parse(raw) as typeof msg;
+    } catch {
+      return; // ignore malformed frames
+    }
+
+    // Response to a pending request
+    if (msg.id !== undefined) {
+      const pending = this.pending.get(msg.id);
+      if (pending) {
+        this.pending.delete(msg.id);
+        clearTimeout(pending.timer);
+
+        if (msg.error) {
+          pending.reject(new CDPEvaluationError(msg.error.message));
+        } else {
+          pending.resolve(msg.result);
+        }
+      }
+      return;
+    }
+
+    // Event
+    if (msg.method) {
+      const set = this.listeners.get(msg.method);
+      if (set) {
+        for (const listener of set) {
+          listener(msg.params);
+        }
+      }
+    }
+  }
+
+  /**
+   * Attempt to reconnect with exponential backoff.
+   */
+  private async attemptReconnect(): Promise<void> {
+    if (this.reconnecting || !this.targetId) {
+      return;
+    }
+    this.reconnecting = true;
+
+    for (let attempt = 0; attempt < MAX_RECONNECT_ATTEMPTS; attempt++) {
+      const delay = RECONNECT_BASE_DELAY * 2 ** attempt;
+      await new Promise<void>((r) => setTimeout(r, delay));
+
+      try {
+        await this.connect(this.targetId ?? undefined);
+        this.reconnecting = false;
+        return;
+      } catch {
+        // continue to next attempt
+      }
+    }
+
+    this.reconnecting = false;
+  }
+
+  /**
+   * Reject all pending requests (used on disconnect / close).
+   */
+  private rejectAllPending(error: Error): void {
+    for (const [id, pending] of this.pending) {
+      clearTimeout(pending.timer);
+      pending.reject(error);
+      this.pending.delete(id);
+    }
+  }
+}

--- a/packages/core/src/cdp/discovery.integration.test.ts
+++ b/packages/core/src/cdp/discovery.integration.test.ts
@@ -1,0 +1,34 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { discoverTargets } from "./discovery.js";
+import {
+  launchChromium,
+  type ChromiumInstance,
+} from "./testing/launch-chromium.js";
+
+describe("discoverTargets (integration)", () => {
+  let chromium: ChromiumInstance;
+
+  beforeAll(async () => {
+    chromium = await launchChromium();
+  }, 30_000);
+
+  afterAll(async () => {
+    await chromium.close();
+  });
+
+  it("should return targets from a real Chromium instance", async () => {
+    const targets = await discoverTargets(chromium.port);
+
+    expect(targets.length).toBeGreaterThan(0);
+  });
+
+  it("should return targets with expected shape", async () => {
+    const targets = await discoverTargets(chromium.port);
+    const page = targets.find((t) => t.type === "page");
+
+    expect(page).toBeDefined();
+    expect(page?.id).toEqual(expect.any(String));
+    expect(page?.webSocketDebuggerUrl).toEqual(expect.any(String));
+    expect(page?.webSocketDebuggerUrl).toMatch(/^ws:\/\//);
+  });
+});

--- a/packages/core/src/cdp/discovery.test.ts
+++ b/packages/core/src/cdp/discovery.test.ts
@@ -1,0 +1,82 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CdpTarget } from "../types/cdp.js";
+import { CDPConnectionError } from "./errors.js";
+import { discoverTargets } from "./discovery.js";
+
+const MOCK_TARGETS: CdpTarget[] = [
+  {
+    description: "",
+    devtoolsFrontendUrl:
+      "/devtools/inspector.html?ws=127.0.0.1:9222/devtools/page/ABC",
+    id: "ABC",
+    type: "page",
+    title: "LinkedHelper",
+    url: "chrome-extension://abc/index.html",
+    webSocketDebuggerUrl: "ws://127.0.0.1:9222/devtools/page/ABC",
+  },
+  {
+    description: "",
+    devtoolsFrontendUrl:
+      "/devtools/inspector.html?ws=127.0.0.1:9222/devtools/worker/DEF",
+    id: "DEF",
+    type: "service_worker",
+    title: "Service Worker",
+    url: "chrome-extension://abc/sw.js",
+  },
+];
+
+describe("discoverTargets", () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn<(input: string | URL | Request) => Promise<Response>>(),
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should return targets from /json/list endpoint", async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify(MOCK_TARGETS), { status: 200 }),
+    );
+
+    const targets = await discoverTargets(9222);
+
+    expect(fetch).toHaveBeenCalledWith("http://127.0.0.1:9222/json/list");
+    expect(targets).toHaveLength(2);
+    expect(targets[0]?.id).toBe("ABC");
+    expect(targets[1]?.type).toBe("service_worker");
+  });
+
+  it("should use custom host when provided", async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify([]), { status: 200 }),
+    );
+
+    await discoverTargets(9222, "192.168.1.10");
+
+    expect(fetch).toHaveBeenCalledWith(
+      "http://192.168.1.10:9222/json/list",
+    );
+  });
+
+  it("should throw CDPConnectionError when fetch fails", async () => {
+    vi.mocked(fetch).mockRejectedValue(new Error("ECONNREFUSED"));
+
+    await expect(discoverTargets(9222)).rejects.toThrow(CDPConnectionError);
+    await expect(discoverTargets(9222)).rejects.toThrow(
+      /LinkedHelper not running/,
+    );
+  });
+
+  it("should throw CDPConnectionError on non-OK HTTP status", async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response("Not Found", { status: 404 }),
+    );
+
+    await expect(discoverTargets(9222)).rejects.toThrow(CDPConnectionError);
+    await expect(discoverTargets(9222)).rejects.toThrow(/HTTP 404/);
+  });
+});

--- a/packages/core/src/cdp/discovery.ts
+++ b/packages/core/src/cdp/discovery.ts
@@ -1,0 +1,43 @@
+import type { CdpTarget } from "../types/cdp.js";
+import { CDPConnectionError } from "./errors.js";
+
+/**
+ * Default host used for CDP target discovery.
+ */
+const DEFAULT_HOST = "127.0.0.1";
+
+/**
+ * Discover Chrome DevTools Protocol targets exposed at the given port.
+ *
+ * Fetches the `/json/list` HTTP endpoint that Chromium-based browsers
+ * expose for debugging target enumeration.
+ *
+ * @param port  - CDP debugging port (e.g. 9222 for the launcher process).
+ * @param host  - Host to connect to (default `127.0.0.1`).
+ * @returns Array of discovered CDP targets.
+ * @throws {CDPConnectionError} When the endpoint is unreachable.
+ */
+export async function discoverTargets(
+  port: number,
+  host: string = DEFAULT_HOST,
+): Promise<CdpTarget[]> {
+  const url = `http://${host}:${port}/json/list`;
+
+  let response: Response;
+  try {
+    response = await fetch(url);
+  } catch (error) {
+    throw new CDPConnectionError(
+      `Failed to discover CDP targets at ${url}: LinkedHelper not running or CDP not enabled`,
+      { cause: error },
+    );
+  }
+
+  if (!response.ok) {
+    throw new CDPConnectionError(
+      `CDP target discovery returned HTTP ${response.status.toString()} at ${url}`,
+    );
+  }
+
+  return (await response.json()) as CdpTarget[];
+}

--- a/packages/core/src/cdp/errors.test.ts
+++ b/packages/core/src/cdp/errors.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import {
+  CDPConnectionError,
+  CDPError,
+  CDPEvaluationError,
+  CDPTimeoutError,
+} from "./errors.js";
+
+describe("CDP errors", () => {
+  it("should set correct name for CDPError", () => {
+    const error = new CDPError("test");
+    expect(error.name).toBe("CDPError");
+    expect(error.message).toBe("test");
+    expect(error).toBeInstanceOf(Error);
+  });
+
+  it("should set correct name for CDPConnectionError", () => {
+    const error = new CDPConnectionError("connection failed");
+    expect(error.name).toBe("CDPConnectionError");
+    expect(error.message).toBe("connection failed");
+    expect(error).toBeInstanceOf(CDPError);
+    expect(error).toBeInstanceOf(Error);
+  });
+
+  it("should set correct name for CDPTimeoutError", () => {
+    const error = new CDPTimeoutError("timed out");
+    expect(error.name).toBe("CDPTimeoutError");
+    expect(error.message).toBe("timed out");
+    expect(error).toBeInstanceOf(CDPError);
+  });
+
+  it("should set correct name for CDPEvaluationError", () => {
+    const error = new CDPEvaluationError("eval failed");
+    expect(error.name).toBe("CDPEvaluationError");
+    expect(error.message).toBe("eval failed");
+    expect(error).toBeInstanceOf(CDPError);
+  });
+
+  it("should support cause via ErrorOptions", () => {
+    const cause = new TypeError("original");
+    const error = new CDPConnectionError("wrapper", { cause });
+    expect(error.cause).toBe(cause);
+  });
+});

--- a/packages/core/src/cdp/errors.ts
+++ b/packages/core/src/cdp/errors.ts
@@ -1,0 +1,42 @@
+/**
+ * Base class for all CDP-related errors.
+ */
+export class CDPError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "CDPError";
+  }
+}
+
+/**
+ * Thrown when a WebSocket connection to a CDP target cannot be established
+ * or is unexpectedly lost.
+ */
+export class CDPConnectionError extends CDPError {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "CDPConnectionError";
+  }
+}
+
+/**
+ * Thrown when a CDP request does not receive a response within the
+ * configured timeout.
+ */
+export class CDPTimeoutError extends CDPError {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "CDPTimeoutError";
+  }
+}
+
+/**
+ * Thrown when `Runtime.evaluate` (or similar) returns a CDP-level error
+ * or an exception from the evaluated expression.
+ */
+export class CDPEvaluationError extends CDPError {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "CDPEvaluationError";
+  }
+}

--- a/packages/core/src/cdp/index.ts
+++ b/packages/core/src/cdp/index.ts
@@ -1,0 +1,9 @@
+export { CDPClient } from "./client.js";
+export { discoverTargets } from "./discovery.js";
+export { discoverInstancePort } from "./instance-discovery.js";
+export {
+  CDPConnectionError,
+  CDPError,
+  CDPEvaluationError,
+  CDPTimeoutError,
+} from "./errors.js";

--- a/packages/core/src/cdp/instance-discovery.integration.test.ts
+++ b/packages/core/src/cdp/instance-discovery.integration.test.ts
@@ -1,0 +1,48 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { pidToPorts, portToPid } from "pid-port";
+import psList from "ps-list";
+import {
+  launchChromium,
+  type ChromiumInstance,
+} from "./testing/launch-chromium.js";
+
+describe("instance-discovery packages (integration)", () => {
+  let chromium: ChromiumInstance;
+
+  beforeAll(async () => {
+    chromium = await launchChromium();
+  }, 30_000);
+
+  afterAll(async () => {
+    await chromium.close();
+  });
+
+  it("portToPid should find the Chromium process by port", async () => {
+    const pid = await portToPid({ port: chromium.port, host: "*" });
+
+    expect(pid).toEqual(expect.any(Number));
+    expect(pid).toBeGreaterThan(0);
+  });
+
+  it("psList should include the Chromium process with correct ppid", async () => {
+    const processes = await psList();
+    const chromiumProc = processes.find(
+      (p) => p.pid === chromium.process.pid,
+    );
+
+    expect(chromiumProc).toBeDefined();
+    expect(chromiumProc?.ppid).toEqual(expect.any(Number));
+  });
+
+  it("pidToPorts should include the Chromium CDP port", async () => {
+    const pid = await portToPid({ port: chromium.port, host: "*" });
+    if (pid === undefined) {
+      throw new Error("Expected portToPid to return a PID");
+    }
+
+    const ports = await pidToPorts(pid);
+
+    expect(ports).toBeInstanceOf(Set);
+    expect(ports.has(chromium.port)).toBe(true);
+  });
+});

--- a/packages/core/src/cdp/instance-discovery.test.ts
+++ b/packages/core/src/cdp/instance-discovery.test.ts
@@ -1,0 +1,102 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { discoverInstancePort } from "./instance-discovery.js";
+
+vi.mock("pid-port", () => ({
+  portToPid: vi.fn(),
+  pidToPorts: vi.fn(),
+}));
+
+vi.mock("ps-list", () => ({
+  default: vi.fn(),
+}));
+
+import { pidToPorts, portToPid } from "pid-port";
+import psList from "ps-list";
+
+describe("discoverInstancePort", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should return null when launcher is not running", async () => {
+    vi.mocked(portToPid).mockRejectedValue(
+      new Error("Could not find a process that uses port `9222`"),
+    );
+
+    const port = await discoverInstancePort(9222);
+    expect(port).toBeNull();
+  });
+
+  it("should return null when portToPid returns undefined", async () => {
+    vi.mocked(portToPid).mockResolvedValue(undefined as never);
+
+    const port = await discoverInstancePort(9222);
+    expect(port).toBeNull();
+  });
+
+  it("should return null when launcher has no children", async () => {
+    vi.mocked(portToPid).mockResolvedValue(12345 as never);
+    vi.mocked(psList).mockResolvedValue([
+      { pid: 99999, name: "other", ppid: 1 },
+    ]);
+
+    const port = await discoverInstancePort(9222);
+    expect(port).toBeNull();
+  });
+
+  it("should discover instance port from child process", async () => {
+    vi.mocked(portToPid).mockResolvedValue(12345 as never);
+    vi.mocked(psList).mockResolvedValue([
+      { pid: 12346, name: "electron", ppid: 12345 },
+      { pid: 99999, name: "other", ppid: 1 },
+    ]);
+    vi.mocked(pidToPorts).mockResolvedValue(new Set([55123]) as never);
+
+    const port = await discoverInstancePort(9222);
+    expect(port).toBe(55123);
+  });
+
+  it("should skip ports matching the launcher port", async () => {
+    vi.mocked(portToPid).mockResolvedValue(12345 as never);
+    vi.mocked(psList).mockResolvedValue([
+      { pid: 12346, name: "electron", ppid: 12345 },
+    ]);
+    vi.mocked(pidToPorts).mockResolvedValue(
+      new Set([9222, 55999]) as never,
+    );
+
+    const port = await discoverInstancePort(9222);
+    expect(port).toBe(55999);
+  });
+
+  it("should use default launcher port 9222", async () => {
+    vi.mocked(portToPid).mockResolvedValue(12345 as never);
+    vi.mocked(psList).mockResolvedValue([
+      { pid: 12346, name: "electron", ppid: 12345 },
+    ]);
+    vi.mocked(pidToPorts).mockResolvedValue(new Set([44444]) as never);
+
+    const port = await discoverInstancePort();
+    expect(port).toBe(44444);
+    expect(portToPid).toHaveBeenCalledWith({ port: 9222, host: "*" });
+  });
+
+  it("should return null when pidToPorts throws", async () => {
+    vi.mocked(portToPid).mockResolvedValue(12345 as never);
+    vi.mocked(psList).mockResolvedValue([
+      { pid: 12346, name: "electron", ppid: 12345 },
+    ]);
+    vi.mocked(pidToPorts).mockRejectedValue(new Error("failed"));
+
+    const port = await discoverInstancePort(9222);
+    expect(port).toBeNull();
+  });
+
+  it("should return null when psList throws", async () => {
+    vi.mocked(portToPid).mockResolvedValue(12345 as never);
+    vi.mocked(psList).mockRejectedValue(new Error("failed"));
+
+    const port = await discoverInstancePort(9222);
+    expect(port).toBeNull();
+  });
+});

--- a/packages/core/src/cdp/instance-discovery.ts
+++ b/packages/core/src/cdp/instance-discovery.ts
@@ -1,0 +1,93 @@
+import { pidToPorts, portToPid } from "pid-port";
+import psList from "ps-list";
+
+/**
+ * Default CDP port used by the LinkedHelper launcher process.
+ */
+const DEFAULT_LAUNCHER_PORT = 9222;
+
+/**
+ * Discover the dynamic CDP port of a running LinkedHelper instance process.
+ *
+ * LinkedHelper spawns a separate Electron process for each LinkedIn account.
+ * That process listens for CDP connections on a dynamic port that changes
+ * every session.  This function discovers the port cross-platform using
+ * `pid-port` and `ps-list`.
+ *
+ * The heuristic is:
+ * 1. Find the launcher PID by looking for a process listening on `launcherPort`.
+ * 2. Find child processes of the launcher.
+ * 3. Among those children, find one listening on a TCP port that is NOT the
+ *    launcher port — that is the instance's CDP port.
+ *
+ * @param launcherPort - The known launcher CDP port (default 9222).
+ * @returns The dynamic instance CDP port, or `null` if no running instance was found.
+ */
+export async function discoverInstancePort(
+  launcherPort: number = DEFAULT_LAUNCHER_PORT,
+): Promise<number | null> {
+  const launcherPid = await findPidListeningOn(launcherPort);
+  if (launcherPid === null) {
+    return null;
+  }
+
+  const childPids = await findChildPids(launcherPid);
+  if (childPids.length === 0) {
+    return null;
+  }
+
+  for (const pid of childPids) {
+    const port = await findListeningPort(pid, launcherPort);
+    if (port !== null) {
+      return port;
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Find the PID of a process listening on the given TCP port.
+ */
+async function findPidListeningOn(port: number): Promise<number | null> {
+  try {
+    const pid = await portToPid({ port, host: "*" });
+    return pid ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Find PIDs of child processes for the given parent PID.
+ */
+async function findChildPids(parentPid: number): Promise<number[]> {
+  try {
+    const processes = await psList();
+    return processes
+      .filter((p) => p.ppid === parentPid)
+      .map((p) => p.pid);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Find a TCP listening port for the given PID, excluding `excludePort`.
+ */
+async function findListeningPort(
+  pid: number,
+  excludePort: number,
+): Promise<number | null> {
+  try {
+    const ports = await pidToPorts(pid);
+    for (const port of ports) {
+      if (port !== excludePort) {
+        return port;
+      }
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}

--- a/packages/core/src/cdp/testing/launch-chromium.ts
+++ b/packages/core/src/cdp/testing/launch-chromium.ts
@@ -1,0 +1,116 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { chromium } from "playwright-core";
+import { discoverTargets } from "../discovery.js";
+
+/** Result of launching a test Chromium instance. */
+export interface ChromiumInstance {
+  /** CDP debugging port. */
+  port: number;
+  /** The spawned Chromium process. */
+  process: ChildProcess;
+  /** Gracefully shut down the Chromium instance. */
+  close: () => Promise<void>;
+}
+
+/**
+ * Find a free TCP port by briefly binding to port 0.
+ */
+async function findFreePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.listen(0, "127.0.0.1", () => {
+      const addr = server.address();
+      if (addr === null || typeof addr === "string") {
+        server.close();
+        reject(new Error("Failed to get port from server address"));
+        return;
+      }
+      const { port } = addr;
+      server.close(() => {
+        resolve(port);
+      });
+    });
+    server.on("error", reject);
+  });
+}
+
+/**
+ * Launch a headless Chromium instance with CDP enabled on a random free port.
+ *
+ * Uses the Chromium binary installed by `playwright-core`.  The instance
+ * is configured for test isolation (temp profile, no sandbox).
+ *
+ * @param options.timeout - Maximum time (ms) to wait for CDP to become
+ *   available (default 10 000).
+ * @returns A {@link ChromiumInstance} handle.
+ */
+export async function launchChromium(options?: {
+  timeout?: number;
+}): Promise<ChromiumInstance> {
+  const timeout = options?.timeout ?? 10_000;
+  const port = await findFreePort();
+  const userDataDir = join(
+    tmpdir(),
+    `lhremote-cdp-test-${port.toString()}-${Date.now().toString(36)}`,
+  );
+
+  const executablePath = chromium.executablePath();
+  const child = spawn(
+    executablePath,
+    [
+      `--remote-debugging-port=${port.toString()}`,
+      `--user-data-dir=${userDataDir}`,
+      "--headless",
+      "--no-sandbox",
+      "--disable-gpu",
+      "--disable-extensions",
+      "--use-mock-keychain",
+    ],
+    { stdio: "ignore" },
+  );
+
+  // Wait for CDP endpoint to become available
+  const deadline = Date.now() + timeout;
+  let ready = false;
+  while (Date.now() < deadline) {
+    try {
+      const targets = await discoverTargets(port);
+      if (targets.length > 0) {
+        ready = true;
+        break;
+      }
+    } catch {
+      // Not ready yet
+    }
+    await new Promise<void>((r) => setTimeout(r, 100));
+  }
+
+  if (!ready) {
+    child.kill("SIGKILL");
+    throw new Error(
+      `Chromium CDP endpoint did not become available on port ${port.toString()} within ${timeout.toString()}ms`,
+    );
+  }
+
+  const close = async (): Promise<void> => {
+    if (child.exitCode !== null) {
+      return;
+    }
+    child.kill("SIGTERM");
+    await new Promise<void>((resolve) => {
+      const timer = setTimeout(() => {
+        child.kill("SIGKILL");
+        resolve();
+      }, 5_000);
+      child.on("exit", () => {
+        clearTimeout(timer);
+        resolve();
+      });
+    });
+  };
+
+  return { port, process: child, close };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -12,3 +12,13 @@ export type {
   StartInstanceParams,
   StartInstanceResult,
 } from "./types/index.js";
+
+export {
+  CDPClient,
+  CDPConnectionError,
+  CDPError,
+  CDPEvaluationError,
+  CDPTimeoutError,
+  discoverInstancePort,
+  discoverTargets,
+} from "./cdp/index.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,15 @@ catalogs:
     eslint:
       specifier: ^9.39.2
       version: 9.39.2
+    pid-port:
+      specifier: ^2.0.1
+      version: 2.0.1
+    playwright-core:
+      specifier: ^1.52.0
+      version: 1.58.1
+    ps-list:
+      specifier: ^9.0.0
+      version: 9.0.0
     typescript:
       specifier: ^5.7.3
       version: 5.9.3
@@ -65,6 +74,16 @@ importers:
         version: 4.0.18(@types/node@22.19.7)
 
   packages/core:
+    dependencies:
+      devtools-protocol:
+        specifier: ^0.0.1577676
+        version: 0.0.1577676
+      pid-port:
+        specifier: 'catalog:'
+        version: 2.0.1
+      ps-list:
+        specifier: 'catalog:'
+        version: 9.0.0
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -72,6 +91,9 @@ importers:
       eslint:
         specifier: 'catalog:'
         version: 9.39.2
+      playwright-core:
+        specifier: 'catalog:'
+        version: 1.58.1
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -438,6 +460,13 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@sec-ant/readable-stream@0.4.1':
+    resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
+
+  '@sindresorhus/merge-streams@4.0.0':
+    resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
+    engines: {node: '>=18'}
+
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
@@ -615,6 +644,9 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  devtools-protocol@0.0.1577676:
+    resolution: {integrity: sha512-zhEeM6qv/5HpW4zq3cyGJNi93aF7PeVKJAtY65136SNt5J3Gd0qO31ghfSEBTLY1GWN0dXShwd2RxaTYGPhYBQ==}
+
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
@@ -678,6 +710,10 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  execa@9.6.1:
+    resolution: {integrity: sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA==}
+    engines: {node: ^18.19.0 || >=20.5.0}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -700,6 +736,10 @@ packages:
       picomatch:
         optional: true
 
+  figures@6.1.0:
+    resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
+    engines: {node: '>=18'}
+
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
@@ -720,6 +760,10 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  get-stream@9.0.1:
+    resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
+    engines: {node: '>=18'}
+
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
@@ -731,6 +775,10 @@ packages:
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  human-signals@8.0.1:
+    resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
+    engines: {node: '>=18.18.0'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -755,6 +803,18 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
+
+  is-stream@4.0.1:
+    resolution: {integrity: sha512-Dnz92NInDqYckGEUJv689RbRiTSEHCQ7wOVeALbkOz999YpqT46yMRIGtSNl2iCL1waAZSx40+h59NV/EwzV/A==}
+    engines: {node: '>=18'}
+
+  is-unicode-supported@2.1.0:
+    resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
+    engines: {node: '>=18'}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -807,6 +867,10 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  npm-run-path@6.0.0:
+    resolution: {integrity: sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==}
+    engines: {node: '>=18'}
+
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
@@ -826,6 +890,10 @@ packages:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
 
+  parse-ms@4.0.0:
+    resolution: {integrity: sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==}
+    engines: {node: '>=18'}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -833,6 +901,10 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-key@4.0.0:
+    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
+    engines: {node: '>=12'}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -843,6 +915,15 @@ packages:
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
+
+  pid-port@2.0.1:
+    resolution: {integrity: sha512-pnLo01AmMclw8l+/gfknsP2N351oe8VkVmCLFUvJZ11NRPPmghJrv0OcwsdgPQxsZkFYwm6hPWW0JKmXYCaXAw==}
+    engines: {node: '>=20'}
+
+  playwright-core@1.58.1:
+    resolution: {integrity: sha512-bcWzOaTxcW+VOOGBCQgnaKToLJ65d6AqfLVKEWvexyS3AS6rbXl+xdpYRMGSRBClPvyj44njOWoxjNdL/H9UNg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
@@ -856,6 +937,14 @@ packages:
     resolution: {integrity: sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==}
     engines: {node: '>=14'}
     hasBin: true
+
+  pretty-ms@9.3.0:
+    resolution: {integrity: sha512-gjVS5hOP+M3wMm5nmNOucbIrqudzs9v/57bWRHQWLYklXqoXKrVfYW2W9+glfGsqtPgpiz5WwyEEB+ksXIx3gQ==}
+    engines: {node: '>=18'}
+
+  ps-list@9.0.0:
+    resolution: {integrity: sha512-lxMEoIL/BQlk2KunFzxwUPwMvjFH7x7cmvzSLsSHpyMXl9FFfLUlfKrYwFc4wx/ZaIxxuXC4n8rjQ1CX/tkXVQ==}
+    engines: {node: '>=20'}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -886,6 +975,10 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -895,6 +988,10 @@ packages:
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  strip-final-newline@4.0.0:
+    resolution: {integrity: sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==}
+    engines: {node: '>=18'}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -977,6 +1074,10 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  unicorn-magic@0.3.0:
+    resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
+    engines: {node: '>=18'}
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
@@ -1072,6 +1173,10 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  yoctocolors@2.1.2:
+    resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
+    engines: {node: '>=18'}
 
 snapshots:
 
@@ -1287,6 +1392,10 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.57.1':
     optional: true
 
+  '@sec-ant/readable-stream@0.4.1': {}
+
+  '@sindresorhus/merge-streams@4.0.0': {}
+
   '@standard-schema/spec@1.1.0': {}
 
   '@types/chai@5.2.3':
@@ -1495,6 +1604,8 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  devtools-protocol@0.0.1577676: {}
+
   es-module-lexer@1.7.0: {}
 
   esbuild@0.27.2:
@@ -1602,6 +1713,21 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  execa@9.6.1:
+    dependencies:
+      '@sindresorhus/merge-streams': 4.0.0
+      cross-spawn: 7.0.6
+      figures: 6.1.0
+      get-stream: 9.0.1
+      human-signals: 8.0.1
+      is-plain-obj: 4.1.0
+      is-stream: 4.0.1
+      npm-run-path: 6.0.0
+      pretty-ms: 9.3.0
+      signal-exit: 4.1.0
+      strip-final-newline: 4.0.0
+      yoctocolors: 2.1.2
+
   expect-type@1.3.0: {}
 
   fast-deep-equal@3.1.3: {}
@@ -1613,6 +1739,10 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  figures@6.1.0:
+    dependencies:
+      is-unicode-supported: 2.1.0
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -1633,6 +1763,11 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  get-stream@9.0.1:
+    dependencies:
+      '@sec-ant/readable-stream': 0.4.1
+      is-stream: 4.0.1
+
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
@@ -1640,6 +1775,8 @@ snapshots:
   globals@14.0.0: {}
 
   has-flag@4.0.0: {}
+
+  human-signals@8.0.1: {}
 
   ignore@5.3.2: {}
 
@@ -1657,6 +1794,12 @@ snapshots:
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-plain-obj@4.1.0: {}
+
+  is-stream@4.0.1: {}
+
+  is-unicode-supported@2.1.0: {}
 
   isexe@2.0.0: {}
 
@@ -1703,6 +1846,11 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  npm-run-path@6.0.0:
+    dependencies:
+      path-key: 4.0.0
+      unicorn-magic: 0.3.0
+
   obug@2.1.1: {}
 
   optionator@0.9.4:
@@ -1726,15 +1874,25 @@ snapshots:
     dependencies:
       callsites: 3.1.0
 
+  parse-ms@4.0.0: {}
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
+
+  path-key@4.0.0: {}
 
   pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
 
   picomatch@4.0.3: {}
+
+  pid-port@2.0.1:
+    dependencies:
+      execa: 9.6.1
+
+  playwright-core@1.58.1: {}
 
   postcss@8.5.6:
     dependencies:
@@ -1745,6 +1903,12 @@ snapshots:
   prelude-ls@1.2.1: {}
 
   prettier@3.8.1: {}
+
+  pretty-ms@9.3.0:
+    dependencies:
+      parse-ms: 4.0.0
+
+  ps-list@9.0.0: {}
 
   punycode@2.3.1: {}
 
@@ -1791,11 +1955,15 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  signal-exit@4.1.0: {}
+
   source-map-js@1.2.1: {}
 
   stackback@0.0.2: {}
 
   std-env@3.10.0: {}
+
+  strip-final-newline@4.0.0: {}
 
   strip-json-comments@3.1.1: {}
 
@@ -1864,6 +2032,8 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  unicorn-magic@0.3.0: {}
+
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
@@ -1929,3 +2099,5 @@ snapshots:
   word-wrap@1.2.5: {}
 
   yocto-queue@0.1.0: {}
+
+  yoctocolors@2.1.2: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,3 +9,6 @@ catalog:
   prettier: "^3.8.1"
   typescript-eslint: "^8.54.0"
   eslint-config-prettier: "^10.1.8"
+  playwright-core: "^1.52.0"
+  pid-port: "^2.0.1"
+  ps-list: "^9.0.0"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,5 +3,6 @@ import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
     passWithNoTests: true,
+    exclude: ["**/node_modules/**", "**/dist/**"],
   },
 });


### PR DESCRIPTION
## Summary

- **CDPClient** class: WebSocket-based CDP communication with request/response correlation via message IDs, event subscription (`on`/`off`/`waitForEvent`), reconnection with exponential backoff, and convenience methods for `Runtime.evaluate` and `Page.navigate`
- **Target discovery** (`discoverTargets`): Fetches CDP targets from Chrome's HTTP `/json/list` endpoint
- **Instance port discovery** (`discoverInstancePort`): Discovers dynamic CDP ports of LinkedHelper instance processes — **cross-platform** using `pid-port` (sindresorhus) + `ps-list` (sindresorhus), no deprecated `wmic`
- **Error hierarchy**: `CDPError` → `CDPConnectionError`, `CDPTimeoutError`, `CDPEvaluationError`
- **Integration tests**: Real headless Chromium (via `playwright-core`) validates CDPClient, target discovery, and cross-platform process/port discovery packages
- **CI matrix**: Runs on ubuntu-latest, macos-latest, windows-latest
- Also excludes `dist/` from Vitest test discovery

## Cross-platform instance discovery

Replaced Unix-only `lsof`/`pgrep` with:

| Package | What | Windows method |
|---------|------|----------------|
| `pid-port` v2.0.1 | Port↔PID mapping | `netstat -ano` |
| `ps-list` v9.0.0 | Process list with ppid | `fastlist.exe` (no wmic) |

Both ESM-native, actively maintained by sindresorhus. Avoids deprecated `wmic` (removed from Windows Server 2025).

## Test plan

### Tier 1 — Unit (mocked, fast)

- [x] Error classes: names, inheritance, cause chaining (5 tests)
- [x] `discoverTargets` with mocked `fetch` (4 tests)
- [x] `discoverInstancePort` with mocked `pid-port`/`ps-list` (8 tests)
- [x] `CDPClient` with mock WebSocket — connect, send, evaluate, events, disconnect (15 tests)

### Tier 2 — Integration (real headless Chromium)

- [x] `discoverTargets` against real Chromium: target enumeration, shape validation (2 tests)
- [x] `CDPClient` against real Chromium: connect, evaluate primitives/objects/promises, runtime errors, navigate, Page events (7 tests)
- [x] Instance discovery packages against real Chromium: `portToPid`, `psList`, `pidToPorts` (3 tests)

### Result

- [x] All 56 tests pass, lint clean, build clean
- [x] CI runs on ubuntu, macos, windows with Chromium via `npx playwright-core install chromium --with-deps`

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)