### PR TITLE
(feat) core: add service layer for app, launcher, instance, and profile management

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,13 +34,14 @@
     "@types/better-sqlite3": "catalog:",
     "@types/node": "catalog:",
     "eslint": "catalog:",
-    "typescript": "catalog:",
     "playwright-core": "catalog:",
+    "typescript": "catalog:",
     "vitest": "catalog:"
   },
   "dependencies": {
     "better-sqlite3": "catalog:",
     "devtools-protocol": "^0.0.1577676",
+    "get-port": "catalog:",
     "pid-port": "catalog:",
     "ps-list": "catalog:"
   }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export type {
+  Account,
   CurrentPosition,
   Education,
   ExternalId,
@@ -32,3 +33,20 @@ export {
   ProfileNotFoundError,
   ProfileRepository,
 } from "./db/index.js";
+
+export {
+  AppLaunchError,
+  AppNotFoundError,
+  AppService,
+  type AppServiceOptions,
+  ExtractionTimeoutError,
+  extractSlug,
+  InstanceNotRunningError,
+  InstanceService,
+  LauncherService,
+  LinkedHelperNotRunningError,
+  ProfileService,
+  ServiceError,
+  StartInstanceError,
+  type VisitAndExtractOptions,
+} from "./services/index.js";

--- a/packages/core/src/services/app.test.ts
+++ b/packages/core/src/services/app.test.ts
@@ -1,0 +1,297 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { accessSync } from "node:fs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { AppLaunchError, AppNotFoundError } from "./errors.js";
+import { AppService } from "./app.js";
+
+vi.mock("node:child_process", () => ({
+  spawn: vi.fn(),
+}));
+
+vi.mock("node:fs", () => ({
+  accessSync: vi.fn(),
+  constants: { X_OK: 1 },
+}));
+
+vi.mock("../cdp/index.js", () => ({
+  discoverTargets: vi.fn(),
+}));
+
+vi.mock("get-port", () => ({
+  default: vi.fn(),
+}));
+
+import { discoverTargets } from "../cdp/index.js";
+import getPort from "get-port";
+
+const mockedSpawn = vi.mocked(spawn);
+const mockedAccessSync = vi.mocked(accessSync);
+const mockedDiscoverTargets = vi.mocked(discoverTargets);
+const mockedGetPort = vi.mocked(getPort);
+
+/** Use zero probe delay in tests to avoid 3s waits. */
+const FAST_OPTIONS = { launchProbeDelay: 0 };
+
+function makeMockChild(): ChildProcess {
+  const child = {
+    unref: vi.fn(),
+    kill: vi.fn(),
+    on: vi.fn(),
+    removeListener: vi.fn(),
+    pid: 12345,
+  } as unknown as ChildProcess;
+  return child;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  delete process.env["LINKEDHELPER_PATH"];
+});
+
+describe("AppService", () => {
+  describe("cdpPort getter", () => {
+    it("returns the explicit port when provided", () => {
+      const service = new AppService(9222);
+      expect(service.cdpPort).toBe(9222);
+    });
+
+    it("throws when no port assigned and launch() not called", () => {
+      const service = new AppService();
+      expect(() => service.cdpPort).toThrow(/call launch\(\) first/);
+    });
+  });
+
+  describe("findBinary", () => {
+    it("returns the darwin path on macOS", () => {
+      vi.stubGlobal("process", { ...process, platform: "darwin", env: {} });
+      mockedAccessSync.mockReturnValue(undefined);
+
+      const result = AppService.findBinary();
+
+      expect(result).toBe(
+        "/Applications/linked-helper.app/Contents/MacOS/linked-helper",
+      );
+    });
+
+    it("returns the win32 path on Windows", () => {
+      vi.stubGlobal("process", {
+        ...process,
+        platform: "win32",
+        env: { LOCALAPPDATA: "C:\\Users\\test\\AppData\\Local" },
+      });
+      mockedAccessSync.mockReturnValue(undefined);
+
+      const result = AppService.findBinary();
+
+      expect(result).toContain("linked-helper.exe");
+      expect(result).toContain("Local");
+    });
+
+    it("returns the linux path on Linux", () => {
+      vi.stubGlobal("process", { ...process, platform: "linux", env: {} });
+      mockedAccessSync.mockReturnValue(undefined);
+
+      const result = AppService.findBinary();
+
+      expect(result).toBe("/opt/linked-helper/linked-helper");
+    });
+
+    it("uses LINKEDHELPER_PATH env override", () => {
+      vi.stubGlobal("process", {
+        ...process,
+        platform: "darwin",
+        env: { LINKEDHELPER_PATH: "/custom/path/lh" },
+      });
+      mockedAccessSync.mockReturnValue(undefined);
+
+      const result = AppService.findBinary();
+
+      expect(result).toBe("/custom/path/lh");
+    });
+
+    it("throws AppNotFoundError when binary does not exist", () => {
+      vi.stubGlobal("process", { ...process, platform: "darwin", env: {} });
+      mockedAccessSync.mockImplementation(() => {
+        throw new Error("ENOENT");
+      });
+
+      expect(() => AppService.findBinary()).toThrow(AppNotFoundError);
+    });
+  });
+
+  describe("isRunning", () => {
+    it("returns true when CDP endpoint responds", async () => {
+      const service = new AppService(9222);
+      mockedDiscoverTargets.mockResolvedValue([]);
+
+      expect(await service.isRunning()).toBe(true);
+    });
+
+    it("returns false when CDP endpoint is unreachable", async () => {
+      const service = new AppService(9222);
+      mockedDiscoverTargets.mockRejectedValue(new Error("connection refused"));
+
+      expect(await service.isRunning()).toBe(false);
+    });
+
+    it("returns false when no port is assigned", async () => {
+      const service = new AppService();
+
+      expect(await service.isRunning()).toBe(false);
+    });
+  });
+
+  describe("launch", () => {
+    beforeEach(() => {
+      vi.stubGlobal("process", { ...process, platform: "darwin", env: {} });
+    });
+
+    it("skips launch if already running with explicit port", async () => {
+      const service = new AppService(9222, FAST_OPTIONS);
+      mockedDiscoverTargets.mockResolvedValue([]);
+
+      await service.launch();
+
+      expect(mockedSpawn).not.toHaveBeenCalled();
+    });
+
+    it("spawns the binary with explicit CDP port argument", async () => {
+      const service = new AppService(9222, FAST_OPTIONS);
+      mockedDiscoverTargets.mockRejectedValue(new Error("not running"));
+      mockedAccessSync.mockReturnValue(undefined);
+
+      const child = makeMockChild();
+      mockedSpawn.mockReturnValue(child);
+
+      await service.launch();
+
+      expect(mockedSpawn).toHaveBeenCalledWith(
+        "/Applications/linked-helper.app/Contents/MacOS/linked-helper",
+        ["--remote-debugging-port=9222"],
+        { detached: true, stdio: "ignore" },
+      );
+      expect(child.unref).toHaveBeenCalled();
+    });
+
+    it("selects a free port via get-port when no port provided", async () => {
+      const service = new AppService(undefined, FAST_OPTIONS);
+      mockedGetPort.mockResolvedValue(54321);
+      mockedAccessSync.mockReturnValue(undefined);
+
+      const child = makeMockChild();
+      mockedSpawn.mockReturnValue(child);
+
+      await service.launch();
+
+      expect(mockedGetPort).toHaveBeenCalled();
+      expect(mockedSpawn).toHaveBeenCalledWith(
+        expect.any(String),
+        ["--remote-debugging-port=54321"],
+        { detached: true, stdio: "ignore" },
+      );
+      expect(service.cdpPort).toBe(54321);
+    });
+
+    it("reuses assigned port on second launch() call", async () => {
+      const service = new AppService(undefined, FAST_OPTIONS);
+      mockedGetPort.mockResolvedValue(54321);
+      mockedAccessSync.mockReturnValue(undefined);
+
+      const child = makeMockChild();
+      mockedSpawn.mockReturnValue(child);
+      await service.launch();
+
+      expect(service.cdpPort).toBe(54321);
+
+      // Reset call counts for second launch assertions
+      mockedGetPort.mockClear();
+      mockedSpawn.mockClear();
+
+      // Second launch — port is already assigned, app reported as running
+      mockedDiscoverTargets.mockResolvedValue([]);
+      await service.launch();
+
+      // getPort must not be called again — port was already assigned
+      expect(mockedGetPort).not.toHaveBeenCalled();
+      // spawn must not be called again — app is already running
+      expect(mockedSpawn).not.toHaveBeenCalled();
+      expect(service.cdpPort).toBe(54321);
+    });
+
+    it("throws AppLaunchError on spawn error", async () => {
+      const service = new AppService(9222, FAST_OPTIONS);
+      mockedDiscoverTargets.mockRejectedValue(new Error("not running"));
+      mockedAccessSync.mockReturnValue(undefined);
+
+      const child = makeMockChild();
+      (child.on as ReturnType<typeof vi.fn>).mockImplementation(
+        (event: string, handler: (err: Error) => void) => {
+          if (event === "error") {
+            queueMicrotask(() => handler(new Error("ENOENT")));
+          }
+          return child;
+        },
+      );
+      mockedSpawn.mockReturnValue(child);
+
+      await expect(service.launch()).rejects.toThrow(AppLaunchError);
+    });
+  });
+
+  describe("quit", () => {
+    beforeEach(() => {
+      vi.stubGlobal("process", { ...process, platform: "darwin", env: {} });
+    });
+
+    it("sends SIGTERM to spawned process", async () => {
+      const service = new AppService(9222, FAST_OPTIONS);
+      mockedDiscoverTargets.mockRejectedValue(new Error("not running"));
+      mockedAccessSync.mockReturnValue(undefined);
+
+      const child = makeMockChild();
+      mockedSpawn.mockReturnValue(child);
+
+      await service.launch();
+      await service.quit();
+
+      expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+    });
+
+    it("falls back to CDP close when no spawned process", async () => {
+      const service = new AppService(9222);
+      mockedDiscoverTargets.mockResolvedValue([
+        {
+          id: "T1",
+          type: "page",
+          title: "",
+          url: "",
+          description: "",
+          devtoolsFrontendUrl: "",
+        },
+      ]);
+
+      const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+      vi.stubGlobal("fetch", mockFetch);
+
+      await service.quit();
+
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://127.0.0.1:9222/json/close/T1",
+      );
+    });
+
+    it("does not throw when CDP close fails", async () => {
+      const service = new AppService(9222);
+      mockedDiscoverTargets.mockRejectedValue(new Error("not running"));
+
+      await expect(service.quit()).resolves.toBeUndefined();
+    });
+
+    it("does nothing when no port assigned and no child process", async () => {
+      const service = new AppService();
+
+      await expect(service.quit()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/packages/core/src/services/app.ts
+++ b/packages/core/src/services/app.ts
@@ -1,0 +1,193 @@
+import { type ChildProcess, spawn } from "node:child_process";
+import { accessSync, constants } from "node:fs";
+import { join } from "node:path";
+
+import getPort from "get-port";
+
+import { discoverTargets } from "../cdp/index.js";
+import { AppLaunchError, AppNotFoundError } from "./errors.js";
+
+/** Default delay after spawn before checking if the app is reachable (ms). */
+const DEFAULT_LAUNCH_PROBE_DELAY = 3000;
+
+export interface AppServiceOptions {
+  /** Delay in ms after spawn before checking if the app is reachable (default 3000). */
+  launchProbeDelay?: number;
+}
+
+/**
+ * Manages the LinkedHelper application process lifecycle.
+ *
+ * Provides methods to launch, quit, and probe the LinkedHelper
+ * Electron application.  When no explicit CDP port is provided,
+ * a free port is selected automatically at launch time.
+ */
+export class AppService {
+  private assignedPort: number | null;
+  private childProcess: ChildProcess | null = null;
+  private readonly launchProbeDelay: number;
+
+  /**
+   * @param cdpPort - Explicit CDP port.  When omitted, `launch()` will
+   *   select a free port automatically via `get-port`.
+   * @param options - Additional configuration options.
+   */
+  constructor(cdpPort?: number, options?: AppServiceOptions) {
+    this.assignedPort = cdpPort ?? null;
+    this.launchProbeDelay = options?.launchProbeDelay ?? DEFAULT_LAUNCH_PROBE_DELAY;
+  }
+
+  /**
+   * The CDP port currently in use.
+   *
+   * @throws {Error} if neither an explicit port was provided nor
+   *   `launch()` has been called yet.
+   */
+  get cdpPort(): number {
+    if (this.assignedPort === null) {
+      throw new Error("CDP port not yet assigned — call launch() first or provide a port to the constructor");
+    }
+    return this.assignedPort;
+  }
+
+  /**
+   * Launch the LinkedHelper application with CDP enabled.
+   *
+   * If no CDP port was specified in the constructor, a free port
+   * is selected automatically.
+   *
+   * @throws {AppNotFoundError} if the binary cannot be found.
+   * @throws {AppLaunchError} if the process fails to start.
+   */
+  async launch(): Promise<void> {
+    if (this.assignedPort !== null && await this.isRunning()) {
+      return;
+    }
+
+    if (this.assignedPort === null) {
+      this.assignedPort = await getPort();
+    }
+
+    const binary = AppService.findBinary();
+    const args = [`--remote-debugging-port=${String(this.assignedPort)}`];
+
+    const child = spawn(binary, args, {
+      detached: true,
+      stdio: "ignore",
+    });
+
+    child.unref();
+
+    // Wait for an early error (e.g. ENOENT from spawn) before probing
+    await new Promise<void>((resolve, reject) => {
+      const onError = (err: Error) => {
+        cleanup();
+        reject(new AppLaunchError(`Failed to launch LinkedHelper: ${err.message}`, { cause: err }));
+      };
+
+      const timer = setTimeout(() => {
+        cleanup();
+        resolve();
+      }, this.launchProbeDelay);
+
+      function cleanup() {
+        child.removeListener("error", onError);
+        clearTimeout(timer);
+      }
+
+      child.on("error", onError);
+    });
+
+    this.childProcess = child;
+  }
+
+  /**
+   * Quit the LinkedHelper application.
+   *
+   * Sends `SIGTERM` to the spawned process. If the process was not
+   * spawned by this service, attempts to close via CDP.
+   */
+  async quit(): Promise<void> {
+    if (this.childProcess) {
+      this.childProcess.kill("SIGTERM");
+      this.childProcess = null;
+      return;
+    }
+
+    if (this.assignedPort === null) {
+      return;
+    }
+
+    // Fallback: close via CDP Browser.close
+    try {
+      const targets = await discoverTargets(this.assignedPort);
+      const first = targets[0];
+      if (first) {
+        await fetch(
+          `http://127.0.0.1:${String(this.assignedPort)}/json/close/${first.id}`,
+        );
+      }
+    } catch {
+      // App may already be closed
+    }
+  }
+
+  /**
+   * Check whether LinkedHelper is running by probing its CDP endpoint.
+   */
+  async isRunning(): Promise<boolean> {
+    if (this.assignedPort === null) {
+      return false;
+    }
+    try {
+      await discoverTargets(this.assignedPort);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Locate the LinkedHelper binary for the current platform.
+   *
+   * @throws {AppNotFoundError} if the binary does not exist at the
+   *   expected location.
+   */
+  static findBinary(): string {
+    const envPath = process.env["LINKEDHELPER_PATH"];
+    if (envPath) {
+      assertFileExists(envPath);
+      return envPath;
+    }
+
+    const path = getDefaultBinaryPath();
+    assertFileExists(path);
+    return path;
+  }
+}
+
+function getDefaultBinaryPath(): string {
+  switch (process.platform) {
+    case "darwin":
+      return "/Applications/linked-helper.app/Contents/MacOS/linked-helper";
+    case "win32":
+      return join(
+        process.env["LOCALAPPDATA"] ?? join(process.env["USERPROFILE"] ?? "C:\\Users\\Default", "AppData", "Local"),
+        "Programs",
+        "linked-helper",
+        "linked-helper.exe",
+      );
+    default:
+      return "/opt/linked-helper/linked-helper";
+  }
+}
+
+function assertFileExists(path: string): void {
+  try {
+    accessSync(path, constants.X_OK);
+  } catch {
+    throw new AppNotFoundError(
+      `LinkedHelper binary not found at ${path}. Set LINKEDHELPER_PATH to override.`,
+    );
+  }
+}

--- a/packages/core/src/services/errors.test.ts
+++ b/packages/core/src/services/errors.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import {
+  AppLaunchError,
+  AppNotFoundError,
+  ExtractionTimeoutError,
+  InstanceNotRunningError,
+  LinkedHelperNotRunningError,
+  ServiceError,
+  StartInstanceError,
+} from "./errors.js";
+
+describe("Service errors", () => {
+  it("should set correct name for ServiceError", () => {
+    const error = new ServiceError("test");
+    expect(error.name).toBe("ServiceError");
+    expect(error.message).toBe("test");
+    expect(error).toBeInstanceOf(Error);
+  });
+
+  it("should support cause via ErrorOptions", () => {
+    const cause = new TypeError("original");
+    const error = new ServiceError("wrapper", { cause });
+    expect(error.cause).toBe(cause);
+  });
+
+  it("should set correct name for AppNotFoundError", () => {
+    const error = new AppNotFoundError();
+    expect(error.name).toBe("AppNotFoundError");
+    expect(error.message).toContain("binary not found");
+    expect(error).toBeInstanceOf(ServiceError);
+    expect(error).toBeInstanceOf(Error);
+  });
+
+  it("should allow custom message for AppNotFoundError", () => {
+    const error = new AppNotFoundError("custom path");
+    expect(error.message).toBe("custom path");
+  });
+
+  it("should set correct name for AppLaunchError", () => {
+    const error = new AppLaunchError("spawn failed");
+    expect(error.name).toBe("AppLaunchError");
+    expect(error.message).toBe("spawn failed");
+    expect(error).toBeInstanceOf(ServiceError);
+  });
+
+  it("should support cause for AppLaunchError", () => {
+    const cause = new Error("ENOENT");
+    const error = new AppLaunchError("spawn failed", { cause });
+    expect(error.cause).toBe(cause);
+  });
+
+  it("should set correct name for LinkedHelperNotRunningError", () => {
+    const error = new LinkedHelperNotRunningError(9222);
+    expect(error.name).toBe("LinkedHelperNotRunningError");
+    expect(error.message).toContain("9222");
+    expect(error).toBeInstanceOf(ServiceError);
+  });
+
+  it("should set correct name for StartInstanceError", () => {
+    const error = new StartInstanceError(42);
+    expect(error.name).toBe("StartInstanceError");
+    expect(error.message).toContain("42");
+    expect(error).toBeInstanceOf(ServiceError);
+  });
+
+  it("should include reason in StartInstanceError", () => {
+    const error = new StartInstanceError(42, "account is already running");
+    expect(error.message).toContain("account is already running");
+  });
+
+  it("should set correct name for InstanceNotRunningError", () => {
+    const error = new InstanceNotRunningError();
+    expect(error.name).toBe("InstanceNotRunningError");
+    expect(error.message).toBe("Instance not running");
+    expect(error).toBeInstanceOf(ServiceError);
+  });
+
+  it("should allow custom message for InstanceNotRunningError", () => {
+    const error = new InstanceNotRunningError("LinkedIn target not found");
+    expect(error.message).toBe("LinkedIn target not found");
+  });
+
+  it("should set correct name for ExtractionTimeoutError", () => {
+    const error = new ExtractionTimeoutError(
+      "https://www.linkedin.com/in/test",
+      30000,
+    );
+    expect(error.name).toBe("ExtractionTimeoutError");
+    expect(error.message).toContain("30000ms");
+    expect(error.message).toContain("linkedin.com/in/test");
+    expect(error).toBeInstanceOf(ServiceError);
+  });
+});

--- a/packages/core/src/services/errors.ts
+++ b/packages/core/src/services/errors.ts
@@ -1,0 +1,79 @@
+/**
+ * Base class for all service-layer errors.
+ */
+export class ServiceError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "ServiceError";
+  }
+}
+
+/**
+ * Thrown when the LinkedHelper application binary cannot be found
+ * at the expected platform-specific location.
+ */
+export class AppNotFoundError extends ServiceError {
+  constructor(message?: string) {
+    super(
+      message ?? "LinkedHelper application binary not found. Set LINKEDHELPER_PATH to override.",
+    );
+    this.name = "AppNotFoundError";
+  }
+}
+
+/**
+ * Thrown when the LinkedHelper application fails to start.
+ */
+export class AppLaunchError extends ServiceError {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "AppLaunchError";
+  }
+}
+
+/**
+ * Thrown when the LinkedHelper launcher is not reachable via CDP.
+ */
+export class LinkedHelperNotRunningError extends ServiceError {
+  constructor(port: number) {
+    super(
+      `LinkedHelper is not running (no CDP endpoint at port ${String(port)})`,
+    );
+    this.name = "LinkedHelperNotRunningError";
+  }
+}
+
+/**
+ * Thrown when starting a LinkedHelper instance fails.
+ */
+export class StartInstanceError extends ServiceError {
+  constructor(accountId: number, reason?: string) {
+    super(
+      `Failed to start instance for account ${String(accountId)}${reason ? `: ${reason}` : ""}`,
+    );
+    this.name = "StartInstanceError";
+  }
+}
+
+/**
+ * Thrown when an expected LinkedHelper instance is not running.
+ */
+export class InstanceNotRunningError extends ServiceError {
+  constructor(message?: string) {
+    super(message ?? "Instance not running");
+    this.name = "InstanceNotRunningError";
+  }
+}
+
+/**
+ * Thrown when profile extraction times out waiting for data
+ * to appear in the database.
+ */
+export class ExtractionTimeoutError extends ServiceError {
+  constructor(profileUrl: string, timeoutMs: number) {
+    super(
+      `Profile extraction timed out after ${String(timeoutMs)}ms for ${profileUrl}`,
+    );
+    this.name = "ExtractionTimeoutError";
+  }
+}

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -1,0 +1,13 @@
+export { AppService, type AppServiceOptions } from "./app.js";
+export { InstanceService } from "./instance.js";
+export { LauncherService } from "./launcher.js";
+export { ProfileService, extractSlug, type VisitAndExtractOptions } from "./profile.js";
+export {
+  AppLaunchError,
+  AppNotFoundError,
+  ExtractionTimeoutError,
+  InstanceNotRunningError,
+  LinkedHelperNotRunningError,
+  ServiceError,
+  StartInstanceError,
+} from "./errors.js";

--- a/packages/core/src/services/instance.test.ts
+++ b/packages/core/src/services/instance.test.ts
@@ -1,0 +1,227 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { CdpTarget } from "../types/cdp.js";
+import { InstanceNotRunningError, ServiceError } from "./errors.js";
+import { InstanceService } from "./instance.js";
+
+/** Per-instance mock method sets, keyed by the target ID passed to connect(). */
+interface ClientMocks {
+  connect: ReturnType<typeof vi.fn>;
+  disconnect: ReturnType<typeof vi.fn>;
+  send: ReturnType<typeof vi.fn>;
+  navigate: ReturnType<typeof vi.fn>;
+  evaluate: ReturnType<typeof vi.fn>;
+  waitForEvent: ReturnType<typeof vi.fn>;
+  isConnected: ReturnType<typeof vi.fn<() => boolean>>;
+}
+
+/** All created client mocks, in creation order. */
+let clientInstances: ClientMocks[] = [];
+
+/** Lookup by target ID after connect() is called. */
+let clientsByTargetId: Map<string, ClientMocks> = new Map();
+
+vi.mock("../cdp/index.js", () => ({
+  CDPClient: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
+    const mocks: ClientMocks = {
+      connect: vi.fn().mockImplementation(async (targetId?: string) => {
+        if (targetId) {
+          clientsByTargetId.set(targetId, mocks);
+        }
+      }),
+      disconnect: vi.fn(),
+      send: vi.fn().mockResolvedValue(undefined),
+      navigate: vi.fn().mockResolvedValue({ frameId: "F1" }),
+      evaluate: vi.fn().mockResolvedValue(undefined),
+      waitForEvent: vi.fn().mockResolvedValue(undefined),
+      isConnected: vi.fn<() => boolean>().mockReturnValue(true),
+    };
+    clientInstances.push(mocks);
+
+    this.connect = mocks.connect;
+    this.disconnect = mocks.disconnect;
+    this.send = mocks.send;
+    this.navigate = mocks.navigate;
+    this.evaluate = mocks.evaluate;
+    this.waitForEvent = mocks.waitForEvent;
+    Object.defineProperty(this, "isConnected", {
+      get: mocks.isConnected,
+    });
+  }),
+  discoverTargets: vi.fn(),
+}));
+
+import { discoverTargets } from "../cdp/index.js";
+
+const mockedDiscoverTargets = vi.mocked(discoverTargets);
+
+function makeTarget(overrides: Partial<CdpTarget>): CdpTarget {
+  return {
+    description: "",
+    devtoolsFrontendUrl: "",
+    id: "DEFAULT",
+    title: "Test",
+    type: "page",
+    url: "about:blank",
+    webSocketDebuggerUrl: "ws://127.0.0.1:9223/devtools/page/DEFAULT",
+    ...overrides,
+  };
+}
+
+const LINKEDIN_TARGET = makeTarget({
+  id: "LI1",
+  url: "https://www.linkedin.com/feed/",
+  title: "LinkedIn Feed",
+});
+
+const UI_TARGET = makeTarget({
+  id: "UI1",
+  url: "chrome-extension://abc/index.html#/",
+  title: "LinkedHelper",
+});
+
+function getClientMocks(targetId: string): ClientMocks {
+  const mocks = clientsByTargetId.get(targetId);
+  if (!mocks) {
+    throw new Error(`No CDPClient mock found for target ${targetId}`);
+  }
+  return mocks;
+}
+
+beforeEach(() => {
+  clientInstances = [];
+  clientsByTargetId = new Map();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("InstanceService", () => {
+  let service: InstanceService;
+
+  beforeEach(() => {
+    service = new InstanceService(9223);
+  });
+
+  describe("connect", () => {
+    it("discovers targets and connects to both", async () => {
+      mockedDiscoverTargets.mockResolvedValue([LINKEDIN_TARGET, UI_TARGET]);
+
+      await service.connect();
+
+      expect(service.isConnected).toBe(true);
+      expect(clientInstances).toHaveLength(2);
+      expect(clientsByTargetId.has("LI1")).toBe(true);
+      expect(clientsByTargetId.has("UI1")).toBe(true);
+    });
+
+    it("throws InstanceNotRunningError when no LinkedIn target", async () => {
+      mockedDiscoverTargets.mockResolvedValue([UI_TARGET]);
+
+      await expect(service.connect()).rejects.toThrow(
+        InstanceNotRunningError,
+      );
+      await expect(service.connect()).rejects.toThrow(
+        /LinkedIn webview target not found/,
+      );
+    });
+
+    it("throws InstanceNotRunningError when no UI target", async () => {
+      mockedDiscoverTargets.mockResolvedValue([LINKEDIN_TARGET]);
+
+      await expect(service.connect()).rejects.toThrow(
+        InstanceNotRunningError,
+      );
+      await expect(service.connect()).rejects.toThrow(
+        /Instance UI target not found/,
+      );
+    });
+
+    it("throws InstanceNotRunningError when no targets at all", async () => {
+      mockedDiscoverTargets.mockResolvedValue([]);
+
+      await expect(service.connect()).rejects.toThrow(
+        InstanceNotRunningError,
+      );
+      await expect(service.connect()).rejects.toThrow(
+        /LinkedIn webview target not found.*0 CDP target/,
+      );
+    });
+  });
+
+  describe("disconnect", () => {
+    it("disconnects both clients", async () => {
+      mockedDiscoverTargets.mockResolvedValue([LINKEDIN_TARGET, UI_TARGET]);
+      await service.connect();
+
+      service.disconnect();
+
+      const liClient = getClientMocks("LI1");
+      const uiClient = getClientMocks("UI1");
+      expect(liClient.disconnect).toHaveBeenCalledTimes(1);
+      expect(uiClient.disconnect).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not throw when not connected", () => {
+      expect(() => service.disconnect()).not.toThrow();
+    });
+  });
+
+  describe("navigateToProfile", () => {
+    it("calls Page.enable, navigate, and waitForEvent on the LinkedIn client", async () => {
+      mockedDiscoverTargets.mockResolvedValue([LINKEDIN_TARGET, UI_TARGET]);
+      await service.connect();
+
+      await service.navigateToProfile("https://www.linkedin.com/in/test-user");
+
+      const liClient = getClientMocks("LI1");
+      const uiClient = getClientMocks("UI1");
+
+      // LinkedIn client should have received navigation calls
+      expect(liClient.send).toHaveBeenCalledWith("Page.enable");
+      expect(liClient.navigate).toHaveBeenCalledWith(
+        "https://www.linkedin.com/in/test-user",
+      );
+      expect(liClient.waitForEvent).toHaveBeenCalledWith("Page.loadEventFired");
+
+      // UI client should NOT have received any navigation calls
+      expect(uiClient.send).not.toHaveBeenCalled();
+      expect(uiClient.navigate).not.toHaveBeenCalled();
+      expect(uiClient.waitForEvent).not.toHaveBeenCalled();
+    });
+
+    it("throws ServiceError when not connected", async () => {
+      await expect(
+        service.navigateToProfile("https://www.linkedin.com/in/test"),
+      ).rejects.toThrow(ServiceError);
+    });
+  });
+
+  describe("triggerExtraction", () => {
+    it("evaluates SaveCurrentProfile on the UI client only", async () => {
+      mockedDiscoverTargets.mockResolvedValue([LINKEDIN_TARGET, UI_TARGET]);
+      await service.connect();
+
+      await service.triggerExtraction();
+
+      const liClient = getClientMocks("LI1");
+      const uiClient = getClientMocks("UI1");
+
+      // UI client should have received the extraction call
+      expect(uiClient.evaluate).toHaveBeenCalledWith(
+        expect.stringContaining("SaveCurrentProfile"),
+        true,
+      );
+
+      // LinkedIn client should NOT have received any evaluate call
+      expect(liClient.evaluate).not.toHaveBeenCalled();
+    });
+
+    it("throws ServiceError when not connected", async () => {
+      await expect(service.triggerExtraction()).rejects.toThrow(
+        ServiceError,
+      );
+    });
+  });
+});

--- a/packages/core/src/services/instance.ts
+++ b/packages/core/src/services/instance.ts
@@ -1,0 +1,132 @@
+import { CDPClient, discoverTargets } from "../cdp/index.js";
+import type { CdpTarget } from "../types/cdp.js";
+import { InstanceNotRunningError, ServiceError } from "./errors.js";
+
+/**
+ * Controls a running LinkedHelper instance via CDP.
+ *
+ * An instance has two CDP targets on the same port:
+ * - **LinkedIn webview**: The Chromium page rendering linkedin.com
+ * - **Instance UI**: The Electron page hosting the LinkedHelper UI
+ *
+ * This service connects to both targets and provides methods for
+ * profile navigation and data extraction.
+ */
+export class InstanceService {
+  private readonly port: number;
+  private readonly host: string;
+  private linkedInClient: CDPClient | null = null;
+  private uiClient: CDPClient | null = null;
+
+  constructor(port: number, options?: { host?: string }) {
+    this.port = port;
+    this.host = options?.host ?? "127.0.0.1";
+  }
+
+  /**
+   * Connect to both instance CDP targets (LinkedIn page and UI).
+   *
+   * @throws {InstanceNotRunningError} if the expected targets are not found.
+   */
+  async connect(): Promise<void> {
+    const targets = await discoverTargets(this.port, this.host);
+
+    const linkedInTarget = targets.find(isLinkedInTarget);
+    const uiTarget = targets.find(isUiTarget);
+
+    if (!linkedInTarget) {
+      throw new InstanceNotRunningError(
+        `LinkedIn webview target not found among ${String(targets.length)} CDP target(s) on port ${String(this.port)}`,
+      );
+    }
+    if (!uiTarget) {
+      throw new InstanceNotRunningError(
+        `Instance UI target not found among ${String(targets.length)} CDP target(s) on port ${String(this.port)}`,
+      );
+    }
+
+    const liClient = new CDPClient(this.port, { host: this.host });
+    await liClient.connect(linkedInTarget.id);
+
+    const ui = new CDPClient(this.port, { host: this.host });
+    await ui.connect(uiTarget.id);
+
+    this.linkedInClient = liClient;
+    this.uiClient = ui;
+  }
+
+  /**
+   * Disconnect from both targets.
+   */
+  disconnect(): void {
+    this.linkedInClient?.disconnect();
+    this.linkedInClient = null;
+    this.uiClient?.disconnect();
+    this.uiClient = null;
+  }
+
+  /**
+   * Navigate the LinkedIn webview to a profile URL.
+   *
+   * Enables the Page domain, navigates, and waits for the load event.
+   */
+  async navigateToProfile(url: string): Promise<void> {
+    const client = this.ensureLinkedInClient();
+
+    await client.send("Page.enable");
+    await client.navigate(url);
+    await client.waitForEvent("Page.loadEventFired");
+  }
+
+  /**
+   * Trigger the SaveCurrentProfile action via the instance UI.
+   *
+   * This tells LinkedHelper to extract data from the currently
+   * displayed LinkedIn profile and save it to the database.
+   */
+  async triggerExtraction(): Promise<void> {
+    const client = this.ensureUiClient();
+
+    await client.evaluate(
+      `(async () => {
+        const remote = require('@electron/remote');
+        const mws = remote.getGlobal('mainWindowService');
+        return await mws.call('executeSingleAction', 'SaveCurrentProfile', {});
+      })()`,
+      true,
+    );
+  }
+
+  /** Whether both clients are currently connected. */
+  get isConnected(): boolean {
+    return (
+      this.linkedInClient !== null &&
+      this.linkedInClient.isConnected &&
+      this.uiClient !== null &&
+      this.uiClient.isConnected
+    );
+  }
+
+  private ensureLinkedInClient(): CDPClient {
+    if (!this.linkedInClient) {
+      throw new ServiceError("InstanceService is not connected (LinkedIn target)");
+    }
+    return this.linkedInClient;
+  }
+
+  private ensureUiClient(): CDPClient {
+    if (!this.uiClient) {
+      throw new ServiceError("InstanceService is not connected (UI target)");
+    }
+    return this.uiClient;
+  }
+}
+
+function isLinkedInTarget(target: CdpTarget): boolean {
+  return target.type === "page" && target.url.includes("linkedin.com");
+}
+
+function isUiTarget(target: CdpTarget): boolean {
+  return target.type === "page" && target.url.includes("index.html");
+}
+

--- a/packages/core/src/services/launcher.test.ts
+++ b/packages/core/src/services/launcher.test.ts
@@ -1,0 +1,188 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import {
+  LinkedHelperNotRunningError,
+  ServiceError,
+  StartInstanceError,
+} from "./errors.js";
+import { LauncherService } from "./launcher.js";
+
+/**
+ * Shared CDPClient mocks — LauncherService creates exactly one CDPClient,
+ * so per-instance isolation (as in instance.test.ts) is unnecessary here.
+ */
+const mockConnect = vi.fn();
+const mockDisconnect = vi.fn();
+const mockEvaluate = vi.fn();
+const mockIsConnected = vi.fn().mockReturnValue(true);
+
+vi.mock("../cdp/index.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../cdp/index.js")>();
+  return {
+    CDPClient: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
+      this.connect = mockConnect;
+      this.disconnect = mockDisconnect;
+      this.evaluate = mockEvaluate;
+      Object.defineProperty(this, "isConnected", {
+        get: mockIsConnected,
+      });
+    }),
+    CDPConnectionError: original.CDPConnectionError,
+  };
+});
+
+import { CDPConnectionError } from "../cdp/index.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("LauncherService", () => {
+  let service: LauncherService;
+
+  beforeEach(() => {
+    service = new LauncherService(9222);
+    mockConnect.mockResolvedValue(undefined);
+    mockEvaluate.mockResolvedValue(undefined);
+  });
+
+  describe("connect", () => {
+    it("creates a CDPClient and connects", async () => {
+      await service.connect();
+
+      expect(service.isConnected).toBe(true);
+    });
+
+    it("wraps CDPConnectionError into LinkedHelperNotRunningError", async () => {
+      mockConnect.mockRejectedValue(
+        new CDPConnectionError("connection refused"),
+      );
+
+      await expect(service.connect()).rejects.toThrow(
+        LinkedHelperNotRunningError,
+      );
+    });
+
+    it("re-throws non-CDP errors as-is", async () => {
+      mockConnect.mockRejectedValue(new TypeError("unexpected"));
+
+      await expect(service.connect()).rejects.toThrow(TypeError);
+    });
+  });
+
+  describe("disconnect", () => {
+    it("disconnects the CDPClient", async () => {
+      await service.connect();
+      service.disconnect();
+
+      expect(mockDisconnect).toHaveBeenCalled();
+    });
+
+    it("does not throw when not connected", () => {
+      expect(() => service.disconnect()).not.toThrow();
+    });
+  });
+
+  describe("startInstance", () => {
+    it("evaluates the startInstance expression", async () => {
+      await service.connect();
+      mockEvaluate.mockResolvedValue({ success: true });
+
+      await service.startInstance(42);
+
+      expect(mockEvaluate).toHaveBeenCalledWith(
+        expect.stringContaining("startInstance"),
+        true,
+      );
+      expect(mockEvaluate).toHaveBeenCalledWith(
+        expect.stringContaining("42"),
+        true,
+      );
+    });
+
+    it("throws StartInstanceError on failure", async () => {
+      await service.connect();
+      mockEvaluate.mockResolvedValue({
+        success: false,
+        error: "account is already running",
+      });
+
+      await expect(service.startInstance(42)).rejects.toThrow(
+        StartInstanceError,
+      );
+      await expect(service.startInstance(42)).rejects.toThrow(
+        /account is already running/,
+      );
+    });
+
+    it("throws ServiceError when not connected", async () => {
+      await expect(service.startInstance(42)).rejects.toThrow(ServiceError);
+    });
+  });
+
+  describe("stopInstance", () => {
+    it("evaluates the stopInstance expression", async () => {
+      await service.connect();
+
+      await service.stopInstance(42);
+
+      expect(mockEvaluate).toHaveBeenCalledWith(
+        expect.stringContaining("stopInstance"),
+        true,
+      );
+    });
+
+    it("throws ServiceError when not connected", async () => {
+      await expect(service.stopInstance(42)).rejects.toThrow(ServiceError);
+    });
+  });
+
+  describe("getInstanceStatus", () => {
+    it("returns the instance status", async () => {
+      await service.connect();
+      mockEvaluate.mockResolvedValue("running");
+
+      const status = await service.getInstanceStatus(42);
+
+      expect(status).toBe("running");
+    });
+
+    it("returns stopped when status is null", async () => {
+      await service.connect();
+      mockEvaluate.mockResolvedValue("stopped");
+
+      const status = await service.getInstanceStatus(42);
+
+      expect(status).toBe("stopped");
+    });
+  });
+
+  describe("listAccounts", () => {
+    it("returns parsed accounts", async () => {
+      await service.connect();
+      mockEvaluate.mockResolvedValue([
+        { id: 1, liId: 100, name: "Alice", email: "alice@test.com" },
+        { id: 2, liId: 200, name: "Bob" },
+      ]);
+
+      const accounts = await service.listAccounts();
+
+      expect(accounts).toHaveLength(2);
+      expect(accounts).toContainEqual(
+        expect.objectContaining({ name: "Alice" }),
+      );
+      expect(accounts).toContainEqual(
+        expect.objectContaining({ name: "Bob" }),
+      );
+    });
+
+    it("returns empty array when no accounts", async () => {
+      await service.connect();
+      mockEvaluate.mockResolvedValue(null);
+
+      const accounts = await service.listAccounts();
+
+      expect(accounts).toEqual([]);
+    });
+  });
+});

--- a/packages/core/src/services/launcher.ts
+++ b/packages/core/src/services/launcher.ts
@@ -1,0 +1,160 @@
+import { CDPClient, CDPConnectionError } from "../cdp/index.js";
+import type {
+  Account,
+  InstanceStatus,
+  StartInstanceResult,
+} from "../types/index.js";
+import {
+  LinkedHelperNotRunningError,
+  ServiceError,
+  StartInstanceError,
+} from "./errors.js";
+
+/** Default CDP port for the LinkedHelper launcher process. */
+const DEFAULT_LAUNCHER_PORT = 9222;
+
+/**
+ * Controls the LinkedHelper launcher process via CDP.
+ *
+ * The launcher is the main Electron window that manages LinkedIn
+ * account instances.  This service connects to it and provides
+ * methods to start/stop instances and query accounts.
+ */
+export class LauncherService {
+  private readonly port: number;
+  private readonly host: string;
+  private client: CDPClient | null = null;
+
+  constructor(
+    port: number = DEFAULT_LAUNCHER_PORT,
+    options?: { host?: string },
+  ) {
+    this.port = port;
+    this.host = options?.host ?? "127.0.0.1";
+  }
+
+  /**
+   * Connect to the LinkedHelper launcher via CDP.
+   *
+   * @throws {LinkedHelperNotRunningError} if the launcher is not reachable.
+   */
+  async connect(): Promise<void> {
+    const client = new CDPClient(this.port, { host: this.host });
+    try {
+      await client.connect();
+    } catch (error) {
+      if (error instanceof CDPConnectionError) {
+        throw new LinkedHelperNotRunningError(this.port);
+      }
+      throw error;
+    }
+    this.client = client;
+  }
+
+  /**
+   * Disconnect from the launcher.
+   */
+  disconnect(): void {
+    this.client?.disconnect();
+    this.client = null;
+  }
+
+  /**
+   * Start a LinkedHelper instance for the given account.
+   *
+   * @throws {StartInstanceError} if the instance fails to start.
+   */
+  async startInstance(accountId: number): Promise<void> {
+    const client = this.ensureConnected();
+
+    const result = await client.evaluate<StartInstanceResult>(
+      `(async () => {
+        const remote = require('@electron/remote');
+        const mws = remote.getGlobal('mainWindowService');
+        return await mws.call('startInstance', {
+          linkedInAccount: { id: ${String(accountId)}, liId: ${String(accountId)} },
+          accountData: { id: ${String(accountId)}, liId: ${String(accountId)} },
+          instanceId: 1,
+          proxy: null,
+          license: null,
+          userId: null,
+          frontendSettings: {},
+          lhAccount: {},
+          zoomDefault: 0.9,
+          shouldBringToFront: true,
+          shouldStartRunningCampaigns: false,
+        });
+      })()`,
+      true,
+    );
+
+    if (!result.success) {
+      throw new StartInstanceError(accountId, result.error);
+    }
+  }
+
+  /**
+   * Stop a running LinkedHelper instance.
+   */
+  async stopInstance(accountId: number): Promise<void> {
+    const client = this.ensureConnected();
+
+    await client.evaluate(
+      `(async () => {
+        const remote = require('@electron/remote');
+        const mws = remote.getGlobal('mainWindowService');
+        return await mws.call('stopInstance', ${String(accountId)});
+      })()`,
+      true,
+    );
+  }
+
+  /**
+   * Query the status of an instance for the given account.
+   */
+  async getInstanceStatus(accountId: number): Promise<InstanceStatus> {
+    const client = this.ensureConnected();
+
+    const status = await client.evaluate<string>(
+      `(async () => {
+        const remote = require('@electron/remote');
+        const mws = remote.getGlobal('mainWindowService');
+        const info = await mws.call('getInstanceStatus', ${String(accountId)});
+        return info?.status ?? 'stopped';
+      })()`,
+      true,
+    );
+
+    return status as InstanceStatus;
+  }
+
+  /**
+   * List all accounts configured in the LinkedHelper Electron store.
+   */
+  async listAccounts(): Promise<Account[]> {
+    const client = this.ensureConnected();
+
+    const accounts = await client.evaluate<Account[]>(
+      `(() => {
+        const remote = require('@electron/remote');
+        const store = remote.getGlobal('electronStore');
+        const accounts = store.get('accounts') ?? [];
+        return accounts;
+      })()`,
+    );
+
+    return accounts ?? [];
+  }
+
+  /** Whether the service is currently connected to the launcher. */
+  get isConnected(): boolean {
+    return this.client !== null && this.client.isConnected;
+  }
+
+  private ensureConnected(): CDPClient {
+    if (!this.client) {
+      throw new ServiceError("LauncherService is not connected");
+    }
+    return this.client;
+  }
+}

--- a/packages/core/src/services/profile.test.ts
+++ b/packages/core/src/services/profile.test.ts
@@ -1,0 +1,216 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { Profile } from "../types/index.js";
+import { ExtractionTimeoutError } from "./errors.js";
+import { extractSlug, ProfileService } from "./profile.js";
+
+// Mock InstanceService
+const mockNavigateToProfile = vi.fn();
+const mockTriggerExtraction = vi.fn();
+
+vi.mock("./instance.js", () => ({
+  InstanceService: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
+    this.navigateToProfile = mockNavigateToProfile;
+    this.triggerExtraction = mockTriggerExtraction;
+  }),
+}));
+
+// Mock ProfileRepository (via db/index.js)
+const mockFindByPublicId = vi.fn();
+
+vi.mock("../db/index.js", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../db/index.js")>();
+  return {
+    ProfileRepository: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
+      this.findByPublicId = mockFindByPublicId;
+    }),
+    ProfileNotFoundError: original.ProfileNotFoundError,
+  };
+});
+
+import { ProfileNotFoundError } from "../db/index.js";
+import { InstanceService } from "./instance.js";
+
+const MOCK_PROFILE: Profile = {
+  id: 1,
+  miniProfile: {
+    firstName: "Test",
+    lastName: "User",
+    headline: "Engineer",
+    avatar: null,
+  },
+  externalIds: [],
+  currentPosition: null,
+  positions: [],
+  education: [],
+  skills: [],
+  emails: [],
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("extractSlug", () => {
+  it("extracts slug from standard URL", () => {
+    expect(extractSlug("https://www.linkedin.com/in/john-doe")).toBe(
+      "john-doe",
+    );
+  });
+
+  it("extracts slug from URL with trailing slash", () => {
+    expect(extractSlug("https://www.linkedin.com/in/john-doe/")).toBe(
+      "john-doe",
+    );
+  });
+
+  it("extracts slug from URL with query params", () => {
+    expect(
+      extractSlug("https://www.linkedin.com/in/john-doe?param=1"),
+    ).toBe("john-doe");
+  });
+
+  it("extracts slug from URL without www", () => {
+    expect(extractSlug("https://linkedin.com/in/john-doe")).toBe(
+      "john-doe",
+    );
+  });
+
+  it("throws on URL without /in/ segment", () => {
+    expect(() => extractSlug("https://www.linkedin.com/company/test")).toThrow(
+      /Invalid LinkedIn profile URL/,
+    );
+  });
+
+  it("throws on URL with /in/ but no slug", () => {
+    expect(() => extractSlug("https://www.linkedin.com/in/")).toThrow(
+      /Invalid LinkedIn profile URL/,
+    );
+  });
+});
+
+describe("ProfileService", () => {
+  let service: ProfileService;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockNavigateToProfile.mockResolvedValue(undefined);
+    mockTriggerExtraction.mockResolvedValue(undefined);
+
+    const instance = new InstanceService(9223);
+    service = new ProfileService(instance, {} as never);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns profile on first poll", async () => {
+    mockFindByPublicId.mockReturnValue(MOCK_PROFILE);
+
+    const promise = service.visitAndExtract(
+      "https://www.linkedin.com/in/test-user",
+      { pollInterval: 100, pollTimeout: 5000 },
+    );
+
+    // Advance past settle delay
+    await vi.advanceTimersByTimeAsync(2000);
+    // Advance past first poll interval
+    await vi.advanceTimersByTimeAsync(100);
+
+    const result = await promise;
+
+    expect(mockNavigateToProfile).toHaveBeenCalledWith(
+      "https://www.linkedin.com/in/test-user",
+    );
+    expect(mockTriggerExtraction).toHaveBeenCalled();
+    expect(mockFindByPublicId).toHaveBeenCalledWith("test-user");
+    expect(result).toEqual(MOCK_PROFILE);
+  });
+
+  it("polls until profile appears", async () => {
+    let callCount = 0;
+    mockFindByPublicId.mockImplementation(() => {
+      callCount++;
+      if (callCount < 3) {
+        throw new ProfileNotFoundError("test-user");
+      }
+      return MOCK_PROFILE;
+    });
+
+    const promise = service.visitAndExtract(
+      "https://www.linkedin.com/in/test-user",
+      { pollInterval: 100, pollTimeout: 5000 },
+    );
+
+    // Advance timers enough for settle delay + a few poll cycles
+    await vi.advanceTimersByTimeAsync(2500);
+
+    const result = await promise;
+    expect(result).toEqual(MOCK_PROFILE);
+    expect(callCount).toBeGreaterThanOrEqual(3);
+  });
+
+  it("throws ExtractionTimeoutError when poll times out", async () => {
+    mockFindByPublicId.mockImplementation(() => {
+      throw new ProfileNotFoundError("test-user");
+    });
+
+    const promise = service.visitAndExtract(
+      "https://www.linkedin.com/in/test-user",
+      { pollInterval: 100, pollTimeout: 500 },
+    );
+
+    // Prevent unhandled rejection while advancing timers
+    const caughtPromise = promise.catch((e: unknown) => e);
+
+    // Advance past settle delay + poll timeout
+    await vi.advanceTimersByTimeAsync(3000);
+
+    const error = await caughtPromise;
+    expect(error).toBeInstanceOf(ExtractionTimeoutError);
+  });
+
+  it("re-throws non-ProfileNotFoundError errors", async () => {
+    mockFindByPublicId.mockImplementation(() => {
+      throw new Error("database locked");
+    });
+
+    const promise = service.visitAndExtract(
+      "https://www.linkedin.com/in/test-user",
+      { pollInterval: 100, pollTimeout: 5000 },
+    );
+
+    // Prevent unhandled rejection while advancing timers
+    const caughtPromise = promise.catch((e: unknown) => e);
+
+    // Advance past settle delay so poll starts
+    await vi.advanceTimersByTimeAsync(2100);
+
+    const error = await caughtPromise;
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toBe("database locked");
+  });
+
+  it("calls navigate before triggerExtraction", async () => {
+    const callOrder: string[] = [];
+    mockNavigateToProfile.mockImplementation(async () => {
+      callOrder.push("navigate");
+    });
+    mockTriggerExtraction.mockImplementation(async () => {
+      callOrder.push("extract");
+    });
+    mockFindByPublicId.mockReturnValue(MOCK_PROFILE);
+
+    const promise = service.visitAndExtract(
+      "https://www.linkedin.com/in/test-user",
+      { pollInterval: 100, pollTimeout: 5000 },
+    );
+
+    await vi.advanceTimersByTimeAsync(2100);
+
+    await promise;
+
+    expect(callOrder).toEqual(["navigate", "extract"]);
+  });
+});

--- a/packages/core/src/services/profile.ts
+++ b/packages/core/src/services/profile.ts
@@ -1,0 +1,114 @@
+import type { Profile } from "../types/index.js";
+import type { DatabaseClient } from "../db/index.js";
+import { ProfileNotFoundError, ProfileRepository } from "../db/index.js";
+import type { InstanceService } from "./instance.js";
+import { ExtractionTimeoutError } from "./errors.js";
+
+/** Default interval between database polls (ms). */
+const DEFAULT_POLL_INTERVAL = 1000;
+
+/** Default maximum time to wait for extraction (ms). */
+const DEFAULT_POLL_TIMEOUT = 30_000;
+
+/** Delay after triggering extraction before first poll (ms). */
+const EXTRACTION_SETTLE_DELAY = 2000;
+
+export interface VisitAndExtractOptions {
+  /** Interval between database polls in ms (default 1000). */
+  pollInterval?: number;
+  /** Maximum time to wait for extraction in ms (default 30000). */
+  pollTimeout?: number;
+}
+
+/**
+ * Orchestrates the visit-and-extract workflow.
+ *
+ * Navigates an instance to a LinkedIn profile, triggers extraction,
+ * then polls the database until the profile data appears.
+ */
+export class ProfileService {
+  private readonly instance: InstanceService;
+  private readonly profileRepo: ProfileRepository;
+
+  constructor(instance: InstanceService, db: DatabaseClient) {
+    this.instance = instance;
+    this.profileRepo = new ProfileRepository(db);
+  }
+
+  /**
+   * Visit a LinkedIn profile and extract its data.
+   *
+   * 1. Navigate the instance to the profile URL
+   * 2. Wait for the page to settle
+   * 3. Trigger SaveCurrentProfile extraction
+   * 4. Poll the database until profile data appears
+   *
+   * @param profileUrl - Full LinkedIn profile URL (e.g. `https://www.linkedin.com/in/slug`)
+   * @returns The extracted profile data.
+   * @throws {ExtractionTimeoutError} if the data does not appear within the timeout.
+   */
+  async visitAndExtract(
+    profileUrl: string,
+    options?: VisitAndExtractOptions,
+  ): Promise<Profile> {
+    const slug = extractSlug(profileUrl);
+    const pollInterval = options?.pollInterval ?? DEFAULT_POLL_INTERVAL;
+    const pollTimeout = options?.pollTimeout ?? DEFAULT_POLL_TIMEOUT;
+
+    await this.instance.navigateToProfile(profileUrl);
+    await delay(EXTRACTION_SETTLE_DELAY);
+    await this.instance.triggerExtraction();
+
+    return this.pollForProfile(slug, pollInterval, pollTimeout, profileUrl);
+  }
+
+  private async pollForProfile(
+    slug: string,
+    interval: number,
+    timeout: number,
+    profileUrl: string,
+  ): Promise<Profile> {
+    const deadline = Date.now() + timeout;
+
+    while (Date.now() < deadline) {
+      try {
+        return this.profileRepo.findByPublicId(slug);
+      } catch (error) {
+        if (!(error instanceof ProfileNotFoundError)) {
+          throw error;
+        }
+      }
+
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) break;
+      await delay(Math.min(interval, remaining));
+    }
+
+    throw new ExtractionTimeoutError(profileUrl, timeout);
+  }
+}
+
+/**
+ * Extract the public ID slug from a LinkedIn profile URL.
+ *
+ * Handles URLs like:
+ * - `https://www.linkedin.com/in/john-doe`
+ * - `https://www.linkedin.com/in/john-doe/`
+ * - `https://linkedin.com/in/john-doe?param=1`
+ */
+export function extractSlug(profileUrl: string): string {
+  const url = new URL(profileUrl);
+  const segments = url.pathname.split("/").filter(Boolean);
+  const inIndex = segments.indexOf("in");
+  const slug = inIndex !== -1 ? segments[inIndex + 1] : undefined;
+  if (!slug) {
+    throw new Error(
+      `Invalid LinkedIn profile URL: ${profileUrl} (expected /in/{slug})`,
+    );
+  }
+  return slug;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/core/src/types/account.test.ts
+++ b/packages/core/src/types/account.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import type { Account } from "./account.js";
+
+describe("Account type", () => {
+  it("should allow constructing a full Account", () => {
+    const account: Account = {
+      id: 1,
+      liId: 363386,
+      name: "Test Account",
+      email: "test@example.com",
+    };
+
+    expect(account.id).toBe(1);
+    expect(account.liId).toBe(363386);
+    expect(account.name).toBe("Test Account");
+    expect(account.email).toBe("test@example.com");
+  });
+
+  it("should allow Account without optional email", () => {
+    const account: Account = {
+      id: 2,
+      liId: 100000,
+      name: "No Email",
+    };
+
+    expect(account.email).toBeUndefined();
+  });
+});

--- a/packages/core/src/types/account.ts
+++ b/packages/core/src/types/account.ts
@@ -1,0 +1,12 @@
+/**
+ * A LinkedHelper account as stored in the Electron store.
+ *
+ * Each account corresponds to a LinkedIn identity managed by
+ * LinkedHelper and has its own database partition.
+ */
+export interface Account {
+  id: number;
+  liId: number;
+  name: string;
+  email?: string | undefined;
+}

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -15,3 +15,5 @@ export type {
   StartInstanceParams,
   StartInstanceResult,
 } from "./instance.js";
+
+export type { Account } from "./account.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ catalogs:
     eslint:
       specifier: ^9.39.2
       version: 9.39.2
+    get-port:
+      specifier: ^7.1.0
+      version: 7.1.0
     pid-port:
       specifier: ^2.0.1
       version: 2.0.1
@@ -87,6 +90,9 @@ importers:
       devtools-protocol:
         specifier: ^0.0.1577676
         version: 0.0.1577676
+      get-port:
+        specifier: 'catalog:'
+        version: 7.1.0
       pid-port:
         specifier: 'catalog:'
         version: 2.0.1
@@ -817,6 +823,10 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  get-port@7.1.0:
+    resolution: {integrity: sha512-QB9NKEeDg3xxVwCCwJQ9+xycaz6pBB6iQ76wiWMl1927n0Kir6alPiP+yuiICLLU4jpMe08dXfpebuQppFA2zw==}
+    engines: {node: '>=16'}
 
   get-stream@9.0.1:
     resolution: {integrity: sha512-kVCxPF3vQM/N0B1PmoqVUqgHP+EeVjmZSQn+1oCRPxd2P21P2F19lIgbR3HBosbB1PUhOAoctJnfEn2GbN2eZA==}
@@ -1946,6 +1956,8 @@ snapshots:
 
   fsevents@2.3.3:
     optional: true
+
+  get-port@7.1.0: {}
 
   get-stream@9.0.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,3 +14,4 @@ catalog:
   ps-list: "^9.0.0"
   better-sqlite3: "^11.9.1"
   "@types/better-sqlite3": "^7.6.13"
+  get-port: "^7.1.0"


### PR DESCRIPTION
## Summary

- Adds `services/` module to `@lhremote/core` orchestrating CDP + SQLite for LinkedHelper automation
- **AppService**: app lifecycle (launch/quit/isRunning) with dynamic free-port selection via `get-port` and configurable probe delay
- **LauncherService**: launcher CDP connection, account listing, instance start/stop/status
- **InstanceService**: dual-target CDP connections (LinkedIn webview + instance UI), profile navigation, extraction triggers with diagnostic error messages
- **ProfileService**: visit-and-extract orchestration with configurable DB polling
- **Error hierarchy**: `ServiceError` base with 6 specific subclasses including contextual diagnostics (port, target count)
- **Account type**: new `Account` interface for LinkedHelper accounts

## Test plan

- [x] 170 unit/integration tests pass (`pnpm test`)
- [x] ESLint clean (`pnpm lint`)
- [x] TypeScript compiles cleanly (`pnpm build`)
- [x] Per-instance CDPClient mock isolation verifies correct target routing in InstanceService
- [ ] CI passes on push

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)