### PR TITLE
(feat) core: restrict public API to service layer consumers

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,4 @@
+// Types (profile, instance, account — CDP types are internal)
 export type {
   Account,
   CurrentPosition,
@@ -14,26 +15,7 @@ export type {
   StartInstanceResult,
 } from "./types/index.js";
 
-export {
-  CDPClient,
-  CDPConnectionError,
-  CDPError,
-  CDPEvaluationError,
-  CDPTimeoutError,
-  discoverInstancePort,
-  discoverTargets,
-} from "./cdp/index.js";
-
-export {
-  DatabaseClient,
-  DatabaseError,
-  DatabaseNotFoundError,
-  discoverAllDatabases,
-  discoverDatabase,
-  ProfileNotFoundError,
-  ProfileRepository,
-} from "./db/index.js";
-
+// Services
 export {
   AppLaunchError,
   AppNotFoundError,
@@ -50,3 +32,25 @@ export {
   StartInstanceError,
   type VisitAndExtractOptions,
 } from "./services/index.js";
+
+// Data access
+export {
+  DatabaseClient,
+  discoverAllDatabases,
+  discoverDatabase,
+  ProfileRepository,
+} from "./db/index.js";
+
+// Errors (DB + CDP errors can propagate through the service layer)
+export {
+  DatabaseError,
+  DatabaseNotFoundError,
+  ProfileNotFoundError,
+} from "./db/index.js";
+
+export {
+  CDPConnectionError,
+  CDPError,
+  CDPEvaluationError,
+  CDPTimeoutError,
+} from "./cdp/index.js";


### PR DESCRIPTION
## Summary

- Remove CDP internals (`CDPClient`, `discoverTargets`, `discoverInstancePort`) from `@lhremote/core` public API
- MCP and CLI packages consume the service layer — direct CDP access is an internal implementation detail
- Retain all error classes (including CDP errors) since they can propagate through services
- Retain DB access (`DatabaseClient`, `ProfileRepository`, `discoverDatabase`) for direct query consumers
- `exports` field in package.json already restricts deep imports to the single entrypoint

## Test plan

- [x] 170 tests pass (`pnpm test`)
- [x] ESLint clean (`pnpm lint`)
- [x] TypeScript compiles cleanly (`pnpm build`)
- [x] `dist/index.d.ts` contains no CDPClient/discoverTargets/discoverInstancePort
- [ ] CI passes on push

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)