### PR TITLE
Set package versions to 0.1.0

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lhremote/cli",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "CLI for LinkedHelper automation",
   "type": "module",
   "engines": {

--- a/packages/cli/src/program.test.ts
+++ b/packages/cli/src/program.test.ts
@@ -1,6 +1,11 @@
+import { createRequire } from "node:module";
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { createProgram } from "./program.js";
+
+const require = createRequire(import.meta.url);
+const { version } = require("../package.json") as { version: string };
 
 describe("createProgram", () => {
   const originalExitCode = process.exitCode;
@@ -21,7 +26,7 @@ describe("createProgram", () => {
 
   it("reads version from package.json", () => {
     const program = createProgram();
-    expect(program.version()).toBe("0.0.0");
+    expect(program.version()).toBe(version);
   });
 
   it("registers all expected subcommands", () => {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lhremote/core",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "Core library for LinkedHelper automation",
   "type": "module",
   "engines": {

--- a/packages/lhremote/package.json
+++ b/packages/lhremote/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lhremote",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "LinkedHelper automation toolkit — CLI & MCP server",
   "type": "module",
   "engines": {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lhremote/mcp",
-  "version": "0.0.0",
+  "version": "0.1.0",
   "description": "MCP server for LinkedHelper automation",
   "type": "module",
   "engines": {

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -1,8 +1,13 @@
+import { createRequire } from "node:module";
+
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { afterEach, describe, expect, it } from "vitest";
 
 import { createServer } from "./server.js";
+
+const require = createRequire(import.meta.url);
+const { version } = require("../package.json") as { version: string };
 
 let server: McpServer | undefined;
 let client: Client | undefined;
@@ -50,7 +55,7 @@ describe("createServer", () => {
 
     const info = c.getServerVersion();
     expect(info).toEqual(
-      expect.objectContaining({ name: "@lhremote/mcp", version: "0.0.0" }),
+      expect.objectContaining({ name: "@lhremote/mcp", version }),
     );
   });
 


### PR DESCRIPTION
## Summary
- Set all package versions from `0.0.0` to `0.1.0` (`@lhremote/core`, `@lhremote/cli`, `@lhremote/mcp`, `lhremote`)
- Fix tests that hardcoded `0.0.0` to read version from `package.json` dynamically
- Verified with `pnpm -r publish --dry-run --access public --no-git-checks`

## Note
Published tarballs currently include test files (`*.test.js`, `*.e2e.test.js`) since TypeScript compiles tests into `dist/`. This is a pre-existing issue — worth a follow-up to exclude tests from published packages.

## Next steps (after merge)
1. Create GitHub Release with tag `v0.1.0`
2. Release workflow publishes to npm via OIDC trusted publishing
3. Verify `npm install @lhremote/mcp` and `npx @lhremote/mcp`

Closes #18

## Test plan
- [x] `pnpm build` succeeds
- [x] `pnpm test` — all 319 tests pass
- [x] `pnpm -r publish --dry-run --access public --no-git-checks` succeeds for all 4 packages
- [x] CI passes on all 3 platforms (ubuntu, macos, windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)