### PR TITLE
(fix) lhremote: include README in published npm package

### DIFF
--- a/packages/lhremote/.gitignore
+++ b/packages/lhremote/.gitignore
@@ -1,0 +1,2 @@
+# Copied from repo root by prepack script
+README.md

--- a/packages/lhremote/package.json
+++ b/packages/lhremote/package.json
@@ -29,6 +29,7 @@
     "dist"
   ],
   "scripts": {
+    "prepack": "cp ../../README.md .",
     "build": "tsc",
     "test": "vitest run",
     "lint": "eslint src/",


### PR DESCRIPTION
## Summary

- Add `prepack` script to `packages/lhremote/package.json` that copies root `README.md` into the package directory before packing
- Add `.gitignore` to prevent the copied README from being committed

The `lhremote` npm package had no README because `packages/lhremote/` lacked a `README.md` file. The root README is the appropriate content for the npm listing since it documents the `lhremote` CLI and MCP tools. Using `prepack` avoids maintaining a duplicate file.

Verified with `npm pack --dry-run` — README.md (8.2kB) is now included in the tarball.

Closes #57

## Test plan

- [x] `npm pack --dry-run` in `packages/lhremote/` shows `README.md` in tarball contents
- [x] All existing tests pass (`pnpm test` — 319 tests)
- [x] Copied README is git-ignored and not committed

🤖 Generated with [Claude Code](https://claude.com/claude-code)