### PR TITLE
docs: add npm badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # lhremote: LinkedHelper Automation Toolkit
 
+[![npm version](https://img.shields.io/npm/v/lhremote?logo=npm)](https://www.npmjs.com/package/lhremote)
+[![npm downloads](https://img.shields.io/npm/dm/lhremote?logo=npm)](https://www.npmjs.com/package/lhremote)
 [![GitHub Repo stars](https://img.shields.io/github/stars/alexey-pelykh/lhremote?style=flat&logo=github)](https://github.com/alexey-pelykh/lhremote)
 [![License](https://img.shields.io/github/license/alexey-pelykh/lhremote)](LICENSE)
 


### PR DESCRIPTION
## Summary
- Add npm version and monthly downloads badges to README
- Badges link to the npmjs.com package page

Closes #58

## Test plan
- [ ] Verify badges render correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)