### PR TITLE
chore: add funding integration

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: alexey-pelykh

--- a/packages/lhremote/package.json
+++ b/packages/lhremote/package.json
@@ -10,6 +10,7 @@
   "author": "Alexey Pelykh (https://github.com/alexey-pelykh)",
   "homepage": "https://github.com/alexey-pelykh/lhremote",
   "bugs": "https://github.com/alexey-pelykh/lhremote/issues",
+  "funding": "https://github.com/sponsors/alexey-pelykh",
   "repository": {
     "type": "git",
     "url": "https://github.com/alexey-pelykh/lhremote.git",


### PR DESCRIPTION
## Summary

- Add `funding` field to the published `packages/lhremote/package.json` so `npm fund` displays the GitHub Sponsors link
- Add `.github/FUNDING.yml` so GitHub renders the "Sponsor" button on the repository page

Closes #59

## Test plan

- [ ] Verify `npm fund` output includes the sponsor URL after install
- [ ] Verify GitHub renders the "Sponsor" button on the repo page after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)