### PR TITLE
Add find-app tool to detect running LinkedHelper instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This project is brought to you by [Alexey Pelykh](https://github.com/alexey-pely
 
 lhremote lets AI assistants (Claude, etc.) control LinkedHelper through the [Model Context Protocol](https://modelcontextprotocol.io). It can:
 
+- Detect running LinkedHelper instances and their CDP connection details
 - Launch and quit the LinkedHelper application
 - List configured LinkedIn accounts
 - Start and stop LinkedHelper instances
@@ -53,7 +54,7 @@ Add to your Claude Desktop configuration (`claude_desktop_config.json`):
 
 Once configured, Claude can use the tools directly. A typical workflow:
 
-1. **launch-app** - Launch LinkedHelper with CDP enabled
+1. **find-app** - Detect a running LinkedHelper instance (or **launch-app** to start one)
 2. **list-accounts** - See available LinkedIn accounts
 3. **start-instance** - Start an instance for an account
 4. **visit-and-extract** - Visit a profile and get structured data
@@ -65,6 +66,7 @@ Once configured, Claude can use the tools directly. A typical workflow:
 The `lhremote` command provides the same functionality as the MCP server:
 
 ```sh
+lhremote find-app [--json]
 lhremote launch-app [--cdp-port <port>]
 lhremote quit-app [--cdp-port <port>]
 lhremote list-accounts [--cdp-port <port>] [--json]
@@ -75,6 +77,14 @@ lhremote check-status [--cdp-port <port>] [--json]
 ```
 
 ## MCP Tools
+
+### find-app
+
+Detect running LinkedHelper application instances and their CDP connection details. Useful when the app is already running and you need to discover which port to connect on.
+
+*No parameters.*
+
+Returns an array of discovered instances, each with `pid`, `cdpPort`, and `connectable` status.
 
 ### launch-app
 

--- a/packages/cli/src/handlers/find-app.ts
+++ b/packages/cli/src/handlers/find-app.ts
@@ -1,0 +1,32 @@
+import { findApp } from "@lhremote/core";
+
+export async function handleFindApp(options: {
+  json?: boolean;
+}): Promise<void> {
+  try {
+    const apps = await findApp();
+
+    if (options.json) {
+      process.stdout.write(JSON.stringify(apps, null, 2) + "\n");
+      return;
+    }
+
+    if (apps.length === 0) {
+      process.stdout.write("No running LinkedHelper instances found\n");
+      return;
+    }
+
+    for (const app of apps) {
+      const port =
+        app.cdpPort !== null ? `CDP port ${String(app.cdpPort)}` : "no CDP port";
+      const status = app.connectable ? "connectable" : "not connectable";
+      process.stdout.write(
+        `PID ${String(app.pid)} — ${port} — ${status}\n`,
+      );
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/packages/cli/src/handlers/index.ts
+++ b/packages/cli/src/handlers/index.ts
@@ -1,4 +1,5 @@
 export { handleCheckStatus } from "./check-status.js";
+export { handleFindApp } from "./find-app.js";
 export { handleLaunchApp } from "./launch-app.js";
 export { handleListAccounts } from "./list-accounts.js";
 export { handleQuitApp } from "./quit-app.js";

--- a/packages/cli/src/program.test.ts
+++ b/packages/cli/src/program.test.ts
@@ -33,6 +33,7 @@ describe("createProgram", () => {
     const program = createProgram();
     const commandNames = program.commands.map((c) => c.name());
 
+    expect(commandNames).toContain("find-app");
     expect(commandNames).toContain("launch-app");
     expect(commandNames).toContain("quit-app");
     expect(commandNames).toContain("list-accounts");
@@ -40,7 +41,7 @@ describe("createProgram", () => {
     expect(commandNames).toContain("stop-instance");
     expect(commandNames).toContain("visit-and-extract");
     expect(commandNames).toContain("check-status");
-    expect(commandNames).toHaveLength(7);
+    expect(commandNames).toHaveLength(8);
   });
 
   describe("launch-app", () => {

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -4,6 +4,7 @@ import { Command, InvalidArgumentError } from "commander";
 
 import {
   handleCheckStatus,
+  handleFindApp,
   handleLaunchApp,
   handleListAccounts,
   handleQuitApp,
@@ -32,6 +33,12 @@ export function createProgram(): Command {
     .name("lhremote")
     .description("CLI for LinkedHelper automation")
     .version(version);
+
+  program
+    .command("find-app")
+    .description("Detect running LinkedHelper instances")
+    .option("--json", "Output as JSON")
+    .action(handleFindApp);
 
   program
     .command("launch-app")

--- a/packages/core/src/cdp/app-discovery.test.ts
+++ b/packages/core/src/cdp/app-discovery.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { findApp } from "./app-discovery.js";
+
+vi.mock("pid-port", () => ({
+  pidToPorts: vi.fn(),
+}));
+
+vi.mock("ps-list", () => ({
+  default: vi.fn(),
+}));
+
+import { pidToPorts } from "pid-port";
+import psList from "ps-list";
+
+describe("findApp", () => {
+  beforeEach(() => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      new Response("[]", { status: 200 }),
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should return empty array when no LinkedHelper process is running", async () => {
+    vi.mocked(psList).mockResolvedValue([
+      { pid: 100, name: "chrome", ppid: 1 },
+      { pid: 200, name: "node", ppid: 1 },
+    ]);
+
+    const result = await findApp();
+    expect(result).toEqual([]);
+  });
+
+  it("should return empty array when psList throws", async () => {
+    vi.mocked(psList).mockRejectedValue(new Error("permission denied"));
+
+    const result = await findApp();
+    expect(result).toEqual([]);
+  });
+
+  it("should discover a linked-helper process with CDP port", async () => {
+    vi.mocked(psList).mockResolvedValue([
+      { pid: 1000, name: "linked-helper", ppid: 1 },
+    ]);
+    vi.mocked(pidToPorts).mockResolvedValue(new Set([9222]) as never);
+
+    const result = await findApp();
+    expect(result).toEqual([
+      { pid: 1000, cdpPort: 9222, connectable: true },
+    ]);
+  });
+
+  it("should discover a linked-helper.exe process on Windows", async () => {
+    vi.mocked(psList).mockResolvedValue([
+      { pid: 2000, name: "linked-helper.exe", ppid: 1 },
+    ]);
+    vi.mocked(pidToPorts).mockResolvedValue(new Set([9333]) as never);
+
+    const result = await findApp();
+    expect(result).toEqual([
+      { pid: 2000, cdpPort: 9333, connectable: true },
+    ]);
+  });
+
+  it("should discover multiple LinkedHelper processes", async () => {
+    vi.mocked(psList).mockResolvedValue([
+      { pid: 1000, name: "linked-helper", ppid: 1 },
+      { pid: 2000, name: "linked-helper", ppid: 1 },
+    ]);
+    vi.mocked(pidToPorts)
+      .mockResolvedValueOnce(new Set([9222]) as never)
+      .mockResolvedValueOnce(new Set([9333]) as never);
+
+    const result = await findApp();
+    expect(result).toEqual([
+      { pid: 1000, cdpPort: 9222, connectable: true },
+      { pid: 2000, cdpPort: 9333, connectable: true },
+    ]);
+  });
+
+  it("should return connectable false when CDP probe fails", async () => {
+    vi.mocked(psList).mockResolvedValue([
+      { pid: 1000, name: "linked-helper", ppid: 1 },
+    ]);
+    vi.mocked(pidToPorts).mockResolvedValue(new Set([9222]) as never);
+    vi.mocked(globalThis.fetch).mockRejectedValue(
+      new Error("ECONNREFUSED"),
+    );
+
+    const result = await findApp();
+    expect(result).toEqual([
+      { pid: 1000, cdpPort: 9222, connectable: false },
+    ]);
+  });
+
+  it("should return cdpPort null when pidToPorts throws", async () => {
+    vi.mocked(psList).mockResolvedValue([
+      { pid: 1000, name: "linked-helper", ppid: 1 },
+    ]);
+    vi.mocked(pidToPorts).mockRejectedValue(new Error("failed"));
+
+    const result = await findApp();
+    expect(result).toEqual([
+      { pid: 1000, cdpPort: null, connectable: false },
+    ]);
+  });
+
+  it("should return cdpPort null when process has no listening ports", async () => {
+    vi.mocked(psList).mockResolvedValue([
+      { pid: 1000, name: "linked-helper", ppid: 1 },
+    ]);
+    vi.mocked(pidToPorts).mockResolvedValue(new Set() as never);
+
+    const result = await findApp();
+    expect(result).toEqual([
+      { pid: 1000, cdpPort: null, connectable: false },
+    ]);
+  });
+
+  it("should find CDP port among multiple listening ports", async () => {
+    vi.mocked(psList).mockResolvedValue([
+      { pid: 1000, name: "linked-helper", ppid: 1 },
+    ]);
+    vi.mocked(pidToPorts).mockResolvedValue(
+      new Set([8080, 9222]) as never,
+    );
+
+    vi.mocked(globalThis.fetch).mockImplementation(async (input) => {
+      const url = String(input);
+      if (url.includes(":8080/")) {
+        throw new Error("ECONNREFUSED");
+      }
+      return new Response("[]", { status: 200 });
+    });
+
+    const result = await findApp();
+    expect(result).toEqual([
+      { pid: 1000, cdpPort: 9222, connectable: true },
+    ]);
+  });
+
+  it("should not match processes with similar but different names", async () => {
+    vi.mocked(psList).mockResolvedValue([
+      { pid: 100, name: "linked-helper-updater", ppid: 1 },
+      { pid: 200, name: "my-linked-helper", ppid: 1 },
+    ]);
+
+    const result = await findApp();
+    expect(result).toEqual([]);
+  });
+});

--- a/packages/core/src/cdp/app-discovery.ts
+++ b/packages/core/src/cdp/app-discovery.ts
@@ -1,0 +1,89 @@
+import { pidToPorts } from "pid-port";
+import psList from "ps-list";
+
+/**
+ * Known LinkedHelper binary names across platforms.
+ */
+const BINARY_NAMES = ["linked-helper", "linked-helper.exe"];
+
+/**
+ * Result of discovering a running LinkedHelper application process.
+ */
+export interface DiscoveredApp {
+  /** OS process ID. */
+  pid: number;
+
+  /** CDP port the process is listening on, or `null` if none detected. */
+  cdpPort: number | null;
+
+  /** Whether the CDP endpoint responded to a probe. */
+  connectable: boolean;
+}
+
+/**
+ * Scan the system for running LinkedHelper application processes.
+ *
+ * For each matching process, attempts to detect a CDP debugging port
+ * by inspecting its listening TCP ports and probing them with an HTTP
+ * request to the CDP `/json/list` endpoint.
+ *
+ * @returns An array of discovered LinkedHelper processes (may be empty).
+ */
+export async function findApp(): Promise<DiscoveredApp[]> {
+  const processes = await listLinkedHelperProcesses();
+  if (processes.length === 0) {
+    return [];
+  }
+
+  return Promise.all(processes.map(probeProcess));
+}
+
+/**
+ * List PIDs of processes whose name matches a known LinkedHelper binary.
+ */
+async function listLinkedHelperProcesses(): Promise<number[]> {
+  try {
+    const all = await psList();
+    return all
+      .filter((p) => BINARY_NAMES.includes(p.name))
+      .map((p) => p.pid);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Probe a single process for CDP connectivity.
+ */
+async function probeProcess(pid: number): Promise<DiscoveredApp> {
+  let ports: Set<number>;
+  try {
+    ports = await pidToPorts(pid);
+  } catch {
+    return { pid, cdpPort: null, connectable: false };
+  }
+
+  for (const port of ports) {
+    if (await isCdpPort(port)) {
+      return { pid, cdpPort: port, connectable: true };
+    }
+  }
+
+  // Process is running but no CDP port detected (or none responding)
+  const firstPort = [...ports][0] ?? null;
+  return { pid, cdpPort: firstPort, connectable: false };
+}
+
+/**
+ * Check whether a port exposes a CDP `/json/list` endpoint.
+ */
+async function isCdpPort(port: number): Promise<boolean> {
+  try {
+    const response = await fetch(
+      `http://127.0.0.1:${String(port)}/json/list`,
+    );
+    return response.ok;
+  } catch {
+    return false;
+  }
+}

--- a/packages/core/src/cdp/index.ts
+++ b/packages/core/src/cdp/index.ts
@@ -4,6 +4,7 @@ export {
   discoverInstancePort,
   killInstanceProcesses,
 } from "./instance-discovery.js";
+export { findApp, type DiscoveredApp } from "./app-discovery.js";
 export {
   CDPConnectionError,
   CDPError,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -62,4 +62,6 @@ export {
   CDPEvaluationError,
   CDPTimeoutError,
   discoverInstancePort,
+  findApp,
+  type DiscoveredApp,
 } from "./cdp/index.js";

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -72,6 +72,7 @@ describe("createServer", () => {
     const { tools } = await c.listTools();
     const names = tools.map((t) => t.name);
 
+    expect(names).toContain("find-app");
     expect(names).toContain("launch-app");
     expect(names).toContain("quit-app");
     expect(names).toContain("list-accounts");
@@ -79,6 +80,6 @@ describe("createServer", () => {
     expect(names).toContain("stop-instance");
     expect(names).toContain("visit-and-extract");
     expect(names).toContain("check-status");
-    expect(names).toHaveLength(7);
+    expect(names).toHaveLength(8);
   });
 });

--- a/packages/mcp/src/tools/find-app.ts
+++ b/packages/mcp/src/tools/find-app.ts
@@ -1,0 +1,44 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { findApp } from "@lhremote/core";
+
+export function registerFindApp(server: McpServer): void {
+  server.tool(
+    "find-app",
+    "Detect running LinkedHelper application instances and their CDP connection details",
+    {},
+    async () => {
+      try {
+        const apps = await findApp();
+
+        if (apps.length === 0) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: "No running LinkedHelper instances found",
+              },
+            ],
+          };
+        }
+
+        return {
+          content: [
+            { type: "text" as const, text: JSON.stringify(apps, null, 2) },
+          ],
+        };
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : String(error);
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: `Failed to find LinkedHelper: ${message}`,
+            },
+          ],
+        };
+      }
+    },
+  );
+}

--- a/packages/mcp/src/tools/index.ts
+++ b/packages/mcp/src/tools/index.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import { registerCheckStatus } from "./check-status.js";
+import { registerFindApp } from "./find-app.js";
 import { registerLaunchApp } from "./launch-app.js";
 import { registerListAccounts } from "./list-accounts.js";
 import { registerQuitApp } from "./quit-app.js";
@@ -9,6 +10,7 @@ import { registerStopInstance } from "./stop-instance.js";
 import { registerVisitAndExtract } from "./visit-and-extract.js";
 
 export function registerAllTools(server: McpServer): void {
+  registerFindApp(server);
   registerLaunchApp(server);
   registerQuitApp(server);
   registerListAccounts(server);


### PR DESCRIPTION
## Summary
- Adds `findApp()` core function that scans system processes for LinkedHelper binaries, detects CDP ports, and probes connectivity
- Registers `find-app` MCP tool (no parameters, returns JSON array of discovered instances)
- Adds `find-app` CLI command with `--json` flag for structured output
- Includes 10 unit tests covering all discovery scenarios

Closes #63

## Test plan
- [x] Unit tests pass (10 new tests in `app-discovery.test.ts`)
- [x] Existing test suites updated and passing (329 total across all packages)
- [x] Build succeeds across all 4 packages
- [ ] Manual: Run `lhremote find-app` with LinkedHelper running to verify real discovery
- [ ] Manual: Run `lhremote find-app --json` to verify JSON output format

🤖 Generated with [Claude Code](https://claude.com/claude-code)