### PR TITLE
(feat) mcp,cli: implement query-profile tool

### DIFF
--- a/packages/cli/src/handlers/index.ts
+++ b/packages/cli/src/handlers/index.ts
@@ -1,5 +1,6 @@
 export { handleCheckStatus } from "./check-status.js";
 export { handleFindApp } from "./find-app.js";
+export { handleQueryProfile } from "./query-profile.js";
 export { handleLaunchApp } from "./launch-app.js";
 export { handleListAccounts } from "./list-accounts.js";
 export { handleQuitApp } from "./quit-app.js";

--- a/packages/cli/src/handlers/query-profile.test.ts
+++ b/packages/cli/src/handlers/query-profile.test.ts
@@ -1,0 +1,310 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return {
+    ...actual,
+    DatabaseClient: vi.fn(),
+    ProfileRepository: vi.fn(),
+    discoverAllDatabases: vi.fn(),
+  };
+});
+
+import {
+  type Profile,
+  DatabaseClient,
+  ProfileNotFoundError,
+  ProfileRepository,
+  discoverAllDatabases,
+} from "@lhremote/core";
+
+import { handleQueryProfile } from "./query-profile.js";
+
+const MOCK_PROFILE: Profile = {
+  id: 12345,
+  miniProfile: {
+    firstName: "Jane",
+    lastName: "Doe",
+    headline: "Engineering Manager at Acme",
+    avatar: null,
+  },
+  externalIds: [
+    { externalId: "jane-doe-12345", typeGroup: "public", isMemberId: false },
+    { externalId: "987654321", typeGroup: "member", isMemberId: true },
+  ],
+  currentPosition: { company: "Acme Corp", title: "Engineering Manager" },
+  positions: [
+    {
+      company: "Acme Corp",
+      title: "Engineering Manager",
+      startDate: "2020-01",
+      endDate: null,
+      isCurrent: true,
+    },
+  ],
+  education: [
+    {
+      school: "MIT",
+      degree: "BS",
+      field: "CS",
+      startDate: "2014",
+      endDate: "2018",
+    },
+  ],
+  skills: [{ name: "TypeScript" }, { name: "React" }, { name: "Node.js" }],
+  emails: ["jane@acme.com"],
+};
+
+function mockDb() {
+  const close = vi.fn();
+  vi.mocked(DatabaseClient).mockImplementation(function () {
+    return { close, db: {} } as unknown as DatabaseClient;
+  });
+  return { close };
+}
+
+function mockRepo(profile: Profile = MOCK_PROFILE) {
+  vi.mocked(ProfileRepository).mockImplementation(function () {
+    return {
+      findById: vi.fn().mockReturnValue(profile),
+      findByPublicId: vi.fn().mockReturnValue(profile),
+    } as unknown as ProfileRepository;
+  });
+}
+
+function mockRepoNotFound() {
+  vi.mocked(ProfileRepository).mockImplementation(function () {
+    return {
+      findById: vi.fn().mockImplementation((id: number) => {
+        throw new ProfileNotFoundError(id);
+      }),
+      findByPublicId: vi.fn().mockImplementation((slug: string) => {
+        throw new ProfileNotFoundError(slug);
+      }),
+    } as unknown as ProfileRepository;
+  });
+}
+
+function setupSuccessPath() {
+  vi.mocked(discoverAllDatabases).mockReturnValue(
+    new Map([[1, "/path/to/db"]]),
+  );
+  mockDb();
+  mockRepo();
+}
+
+describe("handleQueryProfile", () => {
+  const originalExitCode = process.exitCode;
+
+  beforeEach(() => {
+    process.exitCode = undefined;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.exitCode = originalExitCode;
+    vi.restoreAllMocks();
+  });
+
+  it("sets exitCode 1 when neither --person-id nor --public-id provided", async () => {
+    const stderrSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockReturnValue(true);
+
+    await handleQueryProfile({});
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "Exactly one of --person-id or --public-id must be provided.\n",
+    );
+  });
+
+  it("sets exitCode 1 when both --person-id and --public-id provided", async () => {
+    const stderrSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockReturnValue(true);
+
+    await handleQueryProfile({ personId: 1, publicId: "jane-doe-12345" });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "Exactly one of --person-id or --public-id must be provided.\n",
+    );
+  });
+
+  it("sets exitCode 1 when no databases found", async () => {
+    const stderrSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockReturnValue(true);
+
+    vi.mocked(discoverAllDatabases).mockReturnValue(new Map());
+
+    await handleQueryProfile({ personId: 1 });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "No LinkedHelper databases found.\n",
+    );
+  });
+
+  it("sets exitCode 1 when profile not found", async () => {
+    const stderrSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockReturnValue(true);
+
+    vi.mocked(discoverAllDatabases).mockReturnValue(
+      new Map([[1, "/path/to/db"]]),
+    );
+    mockDb();
+    mockRepoNotFound();
+
+    await handleQueryProfile({ personId: 999 });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("Profile not found.\n");
+  });
+
+  it("prints JSON with --json", async () => {
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockReturnValue(true);
+
+    setupSuccessPath();
+
+    await handleQueryProfile({ personId: 12345, json: true });
+
+    expect(process.exitCode).toBeUndefined();
+    const output = stdoutSpy.mock.calls
+      .map((call) => String(call[0]))
+      .join("");
+    expect(JSON.parse(output)).toEqual(MOCK_PROFILE);
+  });
+
+  it("prints human-friendly output with --person-id", async () => {
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockReturnValue(true);
+
+    setupSuccessPath();
+
+    await handleQueryProfile({ personId: 12345 });
+
+    expect(process.exitCode).toBeUndefined();
+    expect(stdoutSpy).toHaveBeenCalledWith("Jane Doe (#12345)\n");
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      "Engineering Manager at Acme\n",
+    );
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      "\nCurrent: Engineering Manager at Acme Corp\n",
+    );
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      "Skills: TypeScript, React, Node.js\n",
+    );
+    expect(stdoutSpy).toHaveBeenCalledWith("Email: jane@acme.com\n");
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      "\nLinkedIn: linkedin.com/in/jane-doe-12345\n",
+    );
+  });
+
+  it("prints human-friendly output with --public-id", async () => {
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockReturnValue(true);
+
+    setupSuccessPath();
+
+    await handleQueryProfile({ publicId: "jane-doe-12345" });
+
+    expect(process.exitCode).toBeUndefined();
+    expect(stdoutSpy).toHaveBeenCalledWith("Jane Doe (#12345)\n");
+  });
+
+  it("handles profile with no headline or current position", async () => {
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockReturnValue(true);
+
+    const minimalProfile: Profile = {
+      id: 2,
+      miniProfile: {
+        firstName: "Bob",
+        lastName: null,
+        headline: null,
+        avatar: null,
+      },
+      externalIds: [],
+      currentPosition: null,
+      positions: [],
+      education: [],
+      skills: [],
+      emails: [],
+    };
+
+    vi.mocked(discoverAllDatabases).mockReturnValue(
+      new Map([[1, "/path/to/db"]]),
+    );
+    mockDb();
+    mockRepo(minimalProfile);
+
+    await handleQueryProfile({ personId: 2 });
+
+    expect(process.exitCode).toBeUndefined();
+    expect(stdoutSpy).toHaveBeenCalledWith("Bob (#2)\n");
+    const calls = stdoutSpy.mock.calls.map((c) => String(c[0]));
+    expect(calls).not.toContainEqual(expect.stringContaining("Current:"));
+    expect(calls).not.toContainEqual(expect.stringContaining("Skills:"));
+    expect(calls).not.toContainEqual(expect.stringContaining("Email:"));
+    expect(calls).not.toContainEqual(expect.stringContaining("LinkedIn:"));
+  });
+
+  it("closes database after successful lookup", async () => {
+    vi.spyOn(process.stdout, "write").mockReturnValue(true);
+
+    vi.mocked(discoverAllDatabases).mockReturnValue(
+      new Map([[1, "/path/to/db"]]),
+    );
+    const { close } = mockDb();
+    mockRepo();
+
+    await handleQueryProfile({ personId: 12345 });
+
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("closes database after failed lookup", async () => {
+    vi.spyOn(process.stderr, "write").mockReturnValue(true);
+
+    vi.mocked(discoverAllDatabases).mockReturnValue(
+      new Map([[1, "/path/to/db"]]),
+    );
+    const { close } = mockDb();
+    mockRepoNotFound();
+
+    await handleQueryProfile({ personId: 999 });
+
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("sets exitCode 1 on unexpected database error", async () => {
+    const stderrSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockReturnValue(true);
+
+    vi.mocked(discoverAllDatabases).mockReturnValue(
+      new Map([[1, "/path/to/db"]]),
+    );
+    mockDb();
+    vi.mocked(ProfileRepository).mockImplementation(function () {
+      return {
+        findById: vi.fn().mockImplementation(() => {
+          throw new Error("database locked");
+        }),
+      } as unknown as ProfileRepository;
+    });
+
+    await handleQueryProfile({ personId: 1 });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("database locked\n");
+  });
+});

--- a/packages/cli/src/handlers/query-profile.ts
+++ b/packages/cli/src/handlers/query-profile.ts
@@ -1,0 +1,103 @@
+import {
+  type Profile,
+  DatabaseClient,
+  discoverAllDatabases,
+  ProfileNotFoundError,
+  ProfileRepository,
+} from "@lhremote/core";
+
+export async function handleQueryProfile(options: {
+  personId?: number;
+  publicId?: string;
+  json?: boolean;
+}): Promise<void> {
+  const { personId, publicId } = options;
+
+  if ((personId == null) === (publicId == null)) {
+    process.stderr.write(
+      "Exactly one of --person-id or --public-id must be provided.\n",
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const databases = discoverAllDatabases();
+  if (databases.size === 0) {
+    process.stderr.write("No LinkedHelper databases found.\n");
+    process.exitCode = 1;
+    return;
+  }
+
+  let found: Profile | null = null;
+
+  for (const [, dbPath] of databases) {
+    const db = new DatabaseClient(dbPath);
+    try {
+      const repo = new ProfileRepository(db);
+      found =
+        personId != null
+          ? repo.findById(personId)
+          : repo.findByPublicId(publicId as string);
+      break;
+    } catch (error) {
+      if (error instanceof ProfileNotFoundError) {
+        continue;
+      }
+      const message = error instanceof Error ? error.message : String(error);
+      process.stderr.write(`${message}\n`);
+      process.exitCode = 1;
+      return;
+    } finally {
+      db.close();
+    }
+  }
+
+  if (found == null) {
+    process.stderr.write("Profile not found.\n");
+    process.exitCode = 1;
+    return;
+  }
+
+  if (options.json) {
+    process.stdout.write(JSON.stringify(found, null, 2) + "\n");
+  } else {
+    const name = [found.miniProfile.firstName, found.miniProfile.lastName]
+      .filter(Boolean)
+      .join(" ");
+
+    process.stdout.write(`${name} (#${String(found.id)})\n`);
+
+    if (found.miniProfile.headline) {
+      process.stdout.write(`${found.miniProfile.headline}\n`);
+    }
+
+    if (found.currentPosition) {
+      const parts = [
+        found.currentPosition.title,
+        found.currentPosition.company,
+      ].filter(Boolean);
+      if (parts.length > 0) {
+        process.stdout.write(`\nCurrent: ${parts.join(" at ")}\n`);
+      }
+    }
+
+    if (found.skills.length > 0) {
+      process.stdout.write(
+        `Skills: ${found.skills.map((s) => s.name).join(", ")}\n`,
+      );
+    }
+
+    if (found.emails.length > 0) {
+      process.stdout.write(`Email: ${found.emails.join(", ")}\n`);
+    }
+
+    const publicExtId = found.externalIds.find(
+      (e) => e.typeGroup === "public",
+    );
+    if (publicExtId) {
+      process.stdout.write(
+        `\nLinkedIn: linkedin.com/in/${publicExtId.externalId}\n`,
+      );
+    }
+  }
+}

--- a/packages/cli/src/program.test.ts
+++ b/packages/cli/src/program.test.ts
@@ -40,8 +40,9 @@ describe("createProgram", () => {
     expect(commandNames).toContain("start-instance");
     expect(commandNames).toContain("stop-instance");
     expect(commandNames).toContain("visit-and-extract");
+    expect(commandNames).toContain("query-profile");
     expect(commandNames).toContain("check-status");
-    expect(commandNames).toHaveLength(8);
+    expect(commandNames).toHaveLength(9);
   });
 
   describe("launch-app", () => {

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -7,6 +7,7 @@ import {
   handleFindApp,
   handleLaunchApp,
   handleListAccounts,
+  handleQueryProfile,
   handleQuitApp,
   handleStartInstance,
   handleStopInstance,
@@ -80,6 +81,14 @@ export function createProgram(): Command {
     .option("--cdp-port <port>", "CDP debugging port", parsePositiveInt)
     .option("--json", "Output as JSON")
     .action(handleVisitAndExtract);
+
+  program
+    .command("query-profile")
+    .description("Look up a cached profile from the local database")
+    .option("--person-id <id>", "Look up by internal person ID", parsePositiveInt)
+    .option("--public-id <slug>", "Look up by LinkedIn public ID")
+    .option("--json", "Output as JSON")
+    .action(handleQueryProfile);
 
   program
     .command("check-status")

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -79,7 +79,8 @@ describe("createServer", () => {
     expect(names).toContain("start-instance");
     expect(names).toContain("stop-instance");
     expect(names).toContain("visit-and-extract");
+    expect(names).toContain("query-profile");
     expect(names).toContain("check-status");
-    expect(names).toHaveLength(8);
+    expect(names).toHaveLength(9);
   });
 });

--- a/packages/mcp/src/tools/index.ts
+++ b/packages/mcp/src/tools/index.ts
@@ -7,6 +7,7 @@ import { registerListAccounts } from "./list-accounts.js";
 import { registerQuitApp } from "./quit-app.js";
 import { registerStartInstance } from "./start-instance.js";
 import { registerStopInstance } from "./stop-instance.js";
+import { registerQueryProfile } from "./query-profile.js";
 import { registerVisitAndExtract } from "./visit-and-extract.js";
 
 export function registerAllTools(server: McpServer): void {
@@ -17,5 +18,6 @@ export function registerAllTools(server: McpServer): void {
   registerStartInstance(server);
   registerStopInstance(server);
   registerVisitAndExtract(server);
+  registerQueryProfile(server);
   registerCheckStatus(server);
 }

--- a/packages/mcp/src/tools/query-profile.test.ts
+++ b/packages/mcp/src/tools/query-profile.test.ts
@@ -1,0 +1,339 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return {
+    ...actual,
+    DatabaseClient: vi.fn(),
+    ProfileRepository: vi.fn(),
+    discoverAllDatabases: vi.fn(),
+  };
+});
+
+import {
+  type Profile,
+  DatabaseClient,
+  ProfileNotFoundError,
+  ProfileRepository,
+  discoverAllDatabases,
+} from "@lhremote/core";
+
+import { registerQueryProfile } from "./query-profile.js";
+import { createMockServer } from "./testing/mock-server.js";
+
+const MOCK_PROFILE: Profile = {
+  id: 1,
+  miniProfile: {
+    firstName: "Jane",
+    lastName: "Doe",
+    headline: "Engineering Manager",
+    avatar: null,
+  },
+  externalIds: [
+    { externalId: "jane-doe-12345", typeGroup: "public", isMemberId: false },
+    { externalId: "987654321", typeGroup: "member", isMemberId: true },
+  ],
+  currentPosition: { company: "Acme Corp", title: "Engineering Manager" },
+  positions: [
+    {
+      company: "Acme Corp",
+      title: "Engineering Manager",
+      startDate: "2020-01",
+      endDate: null,
+      isCurrent: true,
+    },
+  ],
+  education: [
+    {
+      school: "MIT",
+      degree: "BS",
+      field: "CS",
+      startDate: "2014",
+      endDate: "2018",
+    },
+  ],
+  skills: [{ name: "TypeScript" }, { name: "React" }],
+  emails: ["jane@acme.com"],
+};
+
+function mockDb() {
+  const close = vi.fn();
+  vi.mocked(DatabaseClient).mockImplementation(function () {
+    return { close, db: {} } as unknown as DatabaseClient;
+  });
+  return { close };
+}
+
+function mockRepo(profile: Profile = MOCK_PROFILE) {
+  vi.mocked(ProfileRepository).mockImplementation(function () {
+    return {
+      findById: vi.fn().mockReturnValue(profile),
+      findByPublicId: vi.fn().mockReturnValue(profile),
+    } as unknown as ProfileRepository;
+  });
+}
+
+function mockRepoNotFound() {
+  vi.mocked(ProfileRepository).mockImplementation(function () {
+    return {
+      findById: vi.fn().mockImplementation((id: number) => {
+        throw new ProfileNotFoundError(id);
+      }),
+      findByPublicId: vi.fn().mockImplementation((slug: string) => {
+        throw new ProfileNotFoundError(slug);
+      }),
+    } as unknown as ProfileRepository;
+  });
+}
+
+function setupSuccessPath() {
+  vi.mocked(discoverAllDatabases).mockReturnValue(
+    new Map([[1, "/path/to/db"]]),
+  );
+  mockDb();
+  mockRepo();
+}
+
+describe("registerQueryProfile", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("registers a tool named query-profile", () => {
+    const { server } = createMockServer();
+    registerQueryProfile(server);
+
+    expect(server.tool).toHaveBeenCalledOnce();
+    expect(server.tool).toHaveBeenCalledWith(
+      "query-profile",
+      expect.any(String),
+      expect.any(Object),
+      expect.any(Function),
+    );
+  });
+
+  it("returns profile as JSON when looking up by personId", async () => {
+    const { server, getHandler } = createMockServer();
+    registerQueryProfile(server);
+    setupSuccessPath();
+
+    const handler = getHandler("query-profile");
+    const result = await handler({ personId: 1 });
+
+    expect(result).toEqual({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(MOCK_PROFILE, null, 2),
+        },
+      ],
+    });
+  });
+
+  it("returns profile as JSON when looking up by publicId", async () => {
+    const { server, getHandler } = createMockServer();
+    registerQueryProfile(server);
+    setupSuccessPath();
+
+    const handler = getHandler("query-profile");
+    const result = await handler({ publicId: "jane-doe-12345" });
+
+    expect(result).toEqual({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(MOCK_PROFILE, null, 2),
+        },
+      ],
+    });
+  });
+
+  it("returns error when neither personId nor publicId provided", async () => {
+    const { server, getHandler } = createMockServer();
+    registerQueryProfile(server);
+
+    const handler = getHandler("query-profile");
+    const result = await handler({});
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "Exactly one of personId or publicId must be provided.",
+        },
+      ],
+    });
+  });
+
+  it("returns error when both personId and publicId provided", async () => {
+    const { server, getHandler } = createMockServer();
+    registerQueryProfile(server);
+
+    const handler = getHandler("query-profile");
+    const result = await handler({ personId: 1, publicId: "jane-doe-12345" });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "Exactly one of personId or publicId must be provided.",
+        },
+      ],
+    });
+  });
+
+  it("returns error when no databases found", async () => {
+    const { server, getHandler } = createMockServer();
+    registerQueryProfile(server);
+    vi.mocked(discoverAllDatabases).mockReturnValue(new Map());
+
+    const handler = getHandler("query-profile");
+    const result = await handler({ personId: 1 });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "No LinkedHelper databases found.",
+        },
+      ],
+    });
+  });
+
+  it("returns error when profile not found in any database", async () => {
+    const { server, getHandler } = createMockServer();
+    registerQueryProfile(server);
+    vi.mocked(discoverAllDatabases).mockReturnValue(
+      new Map([[1, "/path/to/db"]]),
+    );
+    mockDb();
+    mockRepoNotFound();
+
+    const handler = getHandler("query-profile");
+    const result = await handler({ personId: 999 });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "Profile not found.",
+        },
+      ],
+    });
+  });
+
+  it("searches multiple databases until profile found", async () => {
+    const { server, getHandler } = createMockServer();
+    registerQueryProfile(server);
+    vi.mocked(discoverAllDatabases).mockReturnValue(
+      new Map([
+        [1, "/path/to/db1"],
+        [2, "/path/to/db2"],
+      ]),
+    );
+
+    const close = vi.fn();
+    vi.mocked(DatabaseClient).mockImplementation(function () {
+      return { close, db: {} } as unknown as DatabaseClient;
+    });
+
+    let callCount = 0;
+    vi.mocked(ProfileRepository).mockImplementation(function () {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          findById: vi.fn().mockImplementation((id: number) => {
+            throw new ProfileNotFoundError(id);
+          }),
+          findByPublicId: vi.fn().mockImplementation((slug: string) => {
+            throw new ProfileNotFoundError(slug);
+          }),
+        } as unknown as ProfileRepository;
+      }
+      return {
+        findById: vi.fn().mockReturnValue(MOCK_PROFILE),
+        findByPublicId: vi.fn().mockReturnValue(MOCK_PROFILE),
+      } as unknown as ProfileRepository;
+    });
+
+    const handler = getHandler("query-profile");
+    const result = await handler({ personId: 1 });
+
+    expect(result).toEqual({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(MOCK_PROFILE, null, 2),
+        },
+      ],
+    });
+    expect(close).toHaveBeenCalledTimes(2);
+  });
+
+  it("closes database after successful lookup", async () => {
+    const { server, getHandler } = createMockServer();
+    registerQueryProfile(server);
+    vi.mocked(discoverAllDatabases).mockReturnValue(
+      new Map([[1, "/path/to/db"]]),
+    );
+    const { close } = mockDb();
+    mockRepo();
+
+    const handler = getHandler("query-profile");
+    await handler({ personId: 1 });
+
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("closes database after failed lookup", async () => {
+    const { server, getHandler } = createMockServer();
+    registerQueryProfile(server);
+    vi.mocked(discoverAllDatabases).mockReturnValue(
+      new Map([[1, "/path/to/db"]]),
+    );
+    const { close } = mockDb();
+    mockRepoNotFound();
+
+    const handler = getHandler("query-profile");
+    await handler({ personId: 999 });
+
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("returns error on unexpected database failure", async () => {
+    const { server, getHandler } = createMockServer();
+    registerQueryProfile(server);
+    vi.mocked(discoverAllDatabases).mockReturnValue(
+      new Map([[1, "/path/to/db"]]),
+    );
+    mockDb();
+    vi.mocked(ProfileRepository).mockImplementation(function () {
+      return {
+        findById: vi.fn().mockImplementation(() => {
+          throw new Error("database locked");
+        }),
+      } as unknown as ProfileRepository;
+    });
+
+    const handler = getHandler("query-profile");
+    const result = await handler({ personId: 1 });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "Failed to query profile: database locked",
+        },
+      ],
+    });
+  });
+});

--- a/packages/mcp/src/tools/query-profile.ts
+++ b/packages/mcp/src/tools/query-profile.ts
@@ -1,0 +1,102 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  DatabaseClient,
+  discoverAllDatabases,
+  ProfileNotFoundError,
+  ProfileRepository,
+} from "@lhremote/core";
+import { z } from "zod";
+
+export function registerQueryProfile(server: McpServer): void {
+  server.tool(
+    "query-profile",
+    "Look up a cached LinkedIn profile from the local database without visiting LinkedIn. Returns name, positions, education, skills, and emails.",
+    {
+      personId: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe("Look up by internal person ID"),
+      publicId: z
+        .string()
+        .optional()
+        .describe(
+          "Look up by LinkedIn public ID (profile URL slug, e.g. jane-doe-12345)",
+        ),
+    },
+    async ({ personId, publicId }) => {
+      if ((personId == null) === (publicId == null)) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: "Exactly one of personId or publicId must be provided.",
+            },
+          ],
+        };
+      }
+
+      const databases = discoverAllDatabases();
+      if (databases.size === 0) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: "No LinkedHelper databases found.",
+            },
+          ],
+        };
+      }
+
+      for (const [, dbPath] of databases) {
+        const db = new DatabaseClient(dbPath);
+        try {
+          const repo = new ProfileRepository(db);
+          const profile =
+            personId != null
+              ? repo.findById(personId)
+              : repo.findByPublicId(publicId as string);
+
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: JSON.stringify(profile, null, 2),
+              },
+            ],
+          };
+        } catch (error) {
+          if (error instanceof ProfileNotFoundError) {
+            continue;
+          }
+          const message =
+            error instanceof Error ? error.message : String(error);
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: `Failed to query profile: ${message}`,
+              },
+            ],
+          };
+        } finally {
+          db.close();
+        }
+      }
+
+      return {
+        isError: true,
+        content: [
+          {
+            type: "text" as const,
+            text: "Profile not found.",
+          },
+        ],
+      };
+    },
+  );
+}


### PR DESCRIPTION
## Summary

- Add `query-profile` MCP tool and CLI command that looks up cached LinkedIn profiles from the local database without visiting LinkedIn
- Searches across all discovered LinkedHelper databases, returning the first match
- Supports lookup by internal person ID or LinkedIn public ID (profile URL slug)
- CLI provides human-readable output (name, headline, current position, skills, email, LinkedIn URL) and `--json` option

## Test plan

- [x] MCP tool unit tests: lookup by personId, lookup by publicId, parameter validation, not found, no databases, multi-database search, cleanup, unexpected errors (11 tests)
- [x] CLI handler unit tests: both lookup paths, parameter validation, human-readable output, JSON output, minimal profile, cleanup, errors (11 tests)
- [x] Updated program and server registration tests to include the new command
- [x] All 351 tests pass across all packages

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)