### PR TITLE
(fix) profile: decode percent-encoded Unicode slugs

### DIFF
--- a/packages/core/src/services/profile.test.ts
+++ b/packages/core/src/services/profile.test.ts
@@ -76,6 +76,28 @@ describe("extractSlug", () => {
     );
   });
 
+  it("decodes percent-encoded Unicode slug", () => {
+    expect(
+      extractSlug(
+        "https://www.linkedin.com/in/caf%C3%A9-d%C3%A9veloppeur-123456",
+      ),
+    ).toBe("café-développeur-123456");
+  });
+
+  it("decodes percent-encoded slug with trailing slash", () => {
+    expect(
+      extractSlug(
+        "https://www.linkedin.com/in/caf%C3%A9-d%C3%A9veloppeur-123456/",
+      ),
+    ).toBe("café-développeur-123456");
+  });
+
+  it("passes through already-decoded Unicode slug", () => {
+    expect(
+      extractSlug("https://www.linkedin.com/in/café-développeur-123456"),
+    ).toBe("café-développeur-123456");
+  });
+
   it("throws on URL without /in/ segment", () => {
     expect(() => extractSlug("https://www.linkedin.com/company/test")).toThrow(
       /Invalid LinkedIn profile URL/,

--- a/packages/core/src/services/profile.ts
+++ b/packages/core/src/services/profile.ts
@@ -106,7 +106,7 @@ export function extractSlug(profileUrl: string): string {
       `Invalid LinkedIn profile URL: ${profileUrl} (expected /in/{slug})`,
     );
   }
-  return slug;
+  return decodeURIComponent(slug);
 }
 
 function delay(ms: number): Promise<void> {


### PR DESCRIPTION
## Summary

- `extractSlug()` now applies `decodeURIComponent()` to the slug extracted from the URL pathname
- `URL.pathname` preserves percent-encoding (`%C3%A9` stays as-is), but LinkedHelper stores decoded Unicode in `person_external_ids` (e.g. `adèle-feron`, not `ad%C3%A8le-feron`), causing the poll query to never match and time out
- Note: the issue description incorrectly states that `URL.pathname` *decodes* percent-encoding — it actually *preserves* it. The real mismatch is that the DB stores decoded Unicode while the code was passing the still-encoded slug

## Test plan

- [x] Added unit tests for percent-encoded Unicode slug extraction
- [x] Added unit test for already-decoded Unicode slug passthrough
- [x] All existing tests pass (`pnpm test` — 8 packages green)
- [ ] E2E: `visit-and-extract https://www.linkedin.com/in/<unicode-slug>` completes without timeout

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)