### PR TITLE
Add timeout parameter to visit-and-extract

### DIFF
--- a/packages/cli/src/handlers/visit-and-extract.test.ts
+++ b/packages/cli/src/handlers/visit-and-extract.test.ts
@@ -363,4 +363,46 @@ describe("handleVisitAndExtract", () => {
     expect(LauncherService).toHaveBeenCalledWith(9222);
     expect(discoverInstancePort).toHaveBeenCalledWith(9222);
   });
+
+  it("passes pollTimeout to ProfileService.visitAndExtract", async () => {
+    vi.spyOn(process.stdout, "write").mockReturnValue(true);
+
+    const mockVisitAndExtract = vi.fn().mockResolvedValue(MOCK_PROFILE);
+    mockLauncher();
+    mockInstance();
+    mockDb();
+    vi.mocked(discoverInstancePort).mockResolvedValue(55123);
+    vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+    vi.mocked(ProfileService).mockImplementation(function () {
+      return {
+        visitAndExtract: mockVisitAndExtract,
+      } as unknown as ProfileService;
+    });
+
+    await handleVisitAndExtract(PROFILE_URL, { pollTimeout: 60000 });
+
+    expect(mockVisitAndExtract).toHaveBeenCalledWith(PROFILE_URL, {
+      pollTimeout: 60000,
+    });
+  });
+
+  it("does not pass pollTimeout when not specified", async () => {
+    vi.spyOn(process.stdout, "write").mockReturnValue(true);
+
+    const mockVisitAndExtract = vi.fn().mockResolvedValue(MOCK_PROFILE);
+    mockLauncher();
+    mockInstance();
+    mockDb();
+    vi.mocked(discoverInstancePort).mockResolvedValue(55123);
+    vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+    vi.mocked(ProfileService).mockImplementation(function () {
+      return {
+        visitAndExtract: mockVisitAndExtract,
+      } as unknown as ProfileService;
+    });
+
+    await handleVisitAndExtract(PROFILE_URL, {});
+
+    expect(mockVisitAndExtract).toHaveBeenCalledWith(PROFILE_URL, {});
+  });
 });

--- a/packages/cli/src/handlers/visit-and-extract.ts
+++ b/packages/cli/src/handlers/visit-and-extract.ts
@@ -10,7 +10,7 @@ import {
 
 export async function handleVisitAndExtract(
   profileUrl: string,
-  options: { cdpPort?: number; json?: boolean },
+  options: { cdpPort?: number; pollTimeout?: number; json?: boolean },
 ): Promise<void> {
   if (!isLinkedInProfileUrl(profileUrl)) {
     process.stderr.write(
@@ -72,7 +72,11 @@ export async function handleVisitAndExtract(
     db = new DatabaseClient(dbPath);
 
     const profileService = new ProfileService(instance, db);
-    const profile = await profileService.visitAndExtract(profileUrl);
+    const profile = await profileService.visitAndExtract(profileUrl, {
+      ...(options.pollTimeout !== undefined && {
+        pollTimeout: options.pollTimeout,
+      }),
+    });
 
     if (options.json) {
       process.stdout.write(JSON.stringify(profile, null, 2) + "\n");

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -79,6 +79,11 @@ export function createProgram(): Command {
     .description("Visit a LinkedIn profile and extract data")
     .argument("<profileUrl>", "LinkedIn profile URL")
     .option("--cdp-port <port>", "CDP debugging port", parsePositiveInt)
+    .option(
+      "--poll-timeout <ms>",
+      "Extraction timeout in milliseconds (default: 30000)",
+      parsePositiveInt,
+    )
     .option("--json", "Output as JSON")
     .action(handleVisitAndExtract);
 

--- a/packages/mcp/src/tools/visit-and-extract.test.ts
+++ b/packages/mcp/src/tools/visit-and-extract.test.ts
@@ -494,6 +494,30 @@ describe("registerVisitAndExtract", () => {
     const handler = getHandler("visit-and-extract");
     await handler({ profileUrl: PROFILE_URL, cdpPort: 9222 });
 
-    expect(mockVisitAndExtract).toHaveBeenCalledWith(PROFILE_URL);
+    expect(mockVisitAndExtract).toHaveBeenCalledWith(PROFILE_URL, {});
+  });
+
+  it("passes timeout to ProfileService.visitAndExtract as pollTimeout", async () => {
+    const { server, getHandler } = createMockServer();
+    registerVisitAndExtract(server);
+
+    const mockVisitAndExtract = vi.fn().mockResolvedValue(MOCK_PROFILE);
+    mockLauncher();
+    mockInstance();
+    mockDb();
+    vi.mocked(discoverInstancePort).mockResolvedValue(55123);
+    vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+    vi.mocked(ProfileService).mockImplementation(function () {
+      return {
+        visitAndExtract: mockVisitAndExtract,
+      } as unknown as ProfileService;
+    });
+
+    const handler = getHandler("visit-and-extract");
+    await handler({ profileUrl: PROFILE_URL, cdpPort: 9222, timeout: 60000 });
+
+    expect(mockVisitAndExtract).toHaveBeenCalledWith(PROFILE_URL, {
+      pollTimeout: 60000,
+    });
   });
 });

--- a/packages/mcp/src/tools/visit-and-extract.ts
+++ b/packages/mcp/src/tools/visit-and-extract.ts
@@ -31,8 +31,16 @@ export function registerVisitAndExtract(server: McpServer): void {
         .optional()
         .default(9222)
         .describe("CDP port (default: 9222)"),
+      timeout: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe(
+          "Extraction timeout in milliseconds (default: 30000). Increase for complex profiles or slow networks.",
+        ),
     },
-    async ({ profileUrl, cdpPort }) => {
+    async ({ profileUrl, cdpPort, timeout }) => {
       // Validate LinkedIn URL format
       if (!isLinkedInProfileUrl(profileUrl)) {
         return {
@@ -145,7 +153,9 @@ export function registerVisitAndExtract(server: McpServer): void {
 
         // Run visit-and-extract workflow
         const profileService = new ProfileService(instance, db);
-        const profile = await profileService.visitAndExtract(profileUrl);
+        const profile = await profileService.visitAndExtract(profileUrl, {
+          ...(timeout !== undefined && { pollTimeout: timeout }),
+        });
 
         return {
           content: [


### PR DESCRIPTION
## Summary

- Add optional `timeout` parameter to the `visit-and-extract` MCP tool, passed through as `pollTimeout` to `ProfileService.visitAndExtract()`
- Add `--poll-timeout <ms>` CLI option to the `visit-and-extract` command
- Add tests verifying timeout flows through in both MCP and CLI paths

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)