### PR TITLE
(fix) launcher: descriptive error when instance port used as cdpPort

### DIFF
--- a/packages/core/src/services/errors.ts
+++ b/packages/core/src/services/errors.ts
@@ -66,6 +66,20 @@ export class InstanceNotRunningError extends ServiceError {
 }
 
 /**
+ * Thrown when the CDP port appears to belong to a LinkedHelper instance
+ * (webview) rather than the launcher process.
+ */
+export class WrongPortError extends ServiceError {
+  constructor(port: number) {
+    super(
+      `CDP port ${String(port)} appears to be a LinkedHelper instance, not the launcher. ` +
+        `Use the launcher port instead (default: 9222).`,
+    );
+    this.name = "WrongPortError";
+  }
+}
+
+/**
  * Thrown when profile extraction times out waiting for data
  * to appear in the database.
  */

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -23,4 +23,5 @@ export {
   LinkedHelperNotRunningError,
   ServiceError,
   StartInstanceError,
+  WrongPortError,
 } from "./errors.js";


### PR DESCRIPTION
## Summary

- Add `WrongPortError` thrown when `cdpPort` points to a LinkedHelper instance instead of the launcher
- Detect `ReferenceError: require is not defined` from `CDPEvaluationError` in all launcher evaluate calls
- Error message explains the user should use the launcher port (default 9222)

Closes #70

## Test plan

- [x] Unit tests for `WrongPortError` thrown from `listAccounts`, `startInstance`, `stopInstance`, `getInstanceStatus`
- [x] Verify unrelated `CDPEvaluationError` messages are not caught
- [x] Verify error message includes the port number
- [x] All 219 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)