### PR TITLE
(feat) mcp,cli: implement query-messages tool

### DIFF
--- a/packages/cli/src/handlers/index.ts
+++ b/packages/cli/src/handlers/index.ts
@@ -1,5 +1,6 @@
 export { handleCheckStatus } from "./check-status.js";
 export { handleFindApp } from "./find-app.js";
+export { handleQueryMessages } from "./query-messages.js";
 export { handleQueryProfile } from "./query-profile.js";
 export { handleLaunchApp } from "./launch-app.js";
 export { handleListAccounts } from "./list-accounts.js";

--- a/packages/cli/src/handlers/query-messages.integration.test.ts
+++ b/packages/cli/src/handlers/query-messages.integration.test.ts
@@ -1,0 +1,146 @@
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_PATH = join(
+  __dirname,
+  "../../../core/src/db/testing/fixture.db",
+);
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return {
+    ...actual,
+    discoverAllDatabases: vi.fn(),
+  };
+});
+
+import { discoverAllDatabases } from "@lhremote/core";
+
+import { handleQueryMessages } from "./query-messages.js";
+
+describe("handleQueryMessages (integration)", () => {
+  const originalExitCode = process.exitCode;
+
+  beforeEach(() => {
+    process.exitCode = undefined;
+    vi.mocked(discoverAllDatabases).mockReturnValue(
+      new Map([[1, FIXTURE_PATH]]),
+    );
+  });
+
+  afterEach(() => {
+    process.exitCode = originalExitCode;
+    vi.restoreAllMocks();
+  });
+
+  it("outputs JSON conversation list from fixture", async () => {
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockReturnValue(true);
+
+    await handleQueryMessages({ json: true });
+
+    expect(process.exitCode).toBeUndefined();
+    const output = stdoutSpy.mock.calls
+      .map((call) => String(call[0]))
+      .join("");
+    const body = JSON.parse(output) as {
+      conversations: { id: number; participants: unknown[] }[];
+    };
+    expect(body.conversations.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("outputs JSON thread from fixture", async () => {
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockReturnValue(true);
+
+    await handleQueryMessages({ chatId: 1, json: true });
+
+    expect(process.exitCode).toBeUndefined();
+    const output = stdoutSpy.mock.calls
+      .map((call) => String(call[0]))
+      .join("");
+    const body = JSON.parse(output) as {
+      chat: { id: number };
+      messages: { sendAt: string }[];
+    };
+    expect(body.chat.id).toBe(1);
+    expect(body.messages.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("outputs JSON search results from fixture", async () => {
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockReturnValue(true);
+
+    await handleQueryMessages({ search: "compiler", json: true });
+
+    expect(process.exitCode).toBeUndefined();
+    const output = stdoutSpy.mock.calls
+      .map((call) => String(call[0]))
+      .join("");
+    const body = JSON.parse(output) as {
+      messages: { text: string }[];
+    };
+    expect(body.messages.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("prints human-readable conversation list from fixture", async () => {
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockReturnValue(true);
+
+    await handleQueryMessages({});
+
+    expect(process.exitCode).toBeUndefined();
+    const output = stdoutSpy.mock.calls
+      .map((call) => String(call[0]))
+      .join("");
+    expect(output).toContain("Conversations (");
+    expect(output).toContain("messages)");
+  });
+
+  it("prints human-readable thread from fixture", async () => {
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockReturnValue(true);
+
+    await handleQueryMessages({ chatId: 1 });
+
+    expect(process.exitCode).toBeUndefined();
+    const output = stdoutSpy.mock.calls
+      .map((call) => String(call[0]))
+      .join("");
+    expect(output).toContain("Conversation #1 with");
+    expect(output).toContain("Ada");
+  });
+
+  it("sets exitCode 1 for nonexistent chatId", async () => {
+    vi.spyOn(process.stderr, "write").mockReturnValue(true);
+
+    await handleQueryMessages({ chatId: 999 });
+
+    expect(process.exitCode).toBe(1);
+  });
+
+  it("filters by personId from fixture", async () => {
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockReturnValue(true);
+
+    await handleQueryMessages({ personId: 1, json: true });
+
+    expect(process.exitCode).toBeUndefined();
+    const output = stdoutSpy.mock.calls
+      .map((call) => String(call[0]))
+      .join("");
+    const body = JSON.parse(output) as {
+      conversations: { id: number }[];
+    };
+    expect(body.conversations).toHaveLength(2);
+  });
+});

--- a/packages/cli/src/handlers/query-messages.test.ts
+++ b/packages/cli/src/handlers/query-messages.test.ts
@@ -1,0 +1,343 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return {
+    ...actual,
+    DatabaseClient: vi.fn(),
+    MessageRepository: vi.fn(),
+    discoverAllDatabases: vi.fn(),
+  };
+});
+
+import {
+  type Chat,
+  type ConversationThread,
+  type Message,
+  ChatNotFoundError,
+  DatabaseClient,
+  MessageRepository,
+  discoverAllDatabases,
+} from "@lhremote/core";
+
+import { handleQueryMessages } from "./query-messages.js";
+
+const MOCK_CHAT: Chat = {
+  id: 123,
+  type: "MEMBER_TO_MEMBER",
+  platform: "LINKEDIN",
+  participants: [
+    { personId: 456, firstName: "Jane", lastName: "Doe" },
+  ],
+  messageCount: 12,
+  lastMessage: {
+    text: "Thanks for reaching out!",
+    sendAt: "2025-01-15T10:30:00Z",
+  },
+};
+
+const MOCK_MESSAGE: Message = {
+  id: 1,
+  type: "DEFAULT",
+  text: "Hi Jane, I saw your work on...",
+  subject: null,
+  sendAt: "2025-01-14T09:00:00Z",
+  attachmentsCount: 0,
+  senderPersonId: 789,
+  senderFirstName: "Alexey",
+  senderLastName: "Pelykh",
+};
+
+const MOCK_THREAD: ConversationThread = {
+  chat: MOCK_CHAT,
+  messages: [MOCK_MESSAGE],
+};
+
+function mockDb() {
+  const close = vi.fn();
+  vi.mocked(DatabaseClient).mockImplementation(function () {
+    return { close, db: {} } as unknown as DatabaseClient;
+  });
+  return { close };
+}
+
+function mockRepo(overrides?: {
+  listChats?: Chat[];
+  thread?: ConversationThread;
+  searchMessages?: Message[];
+}) {
+  vi.mocked(MessageRepository).mockImplementation(function () {
+    return {
+      listChats: vi.fn().mockReturnValue(overrides?.listChats ?? [MOCK_CHAT]),
+      getThread: vi.fn().mockReturnValue(overrides?.thread ?? MOCK_THREAD),
+      searchMessages: vi
+        .fn()
+        .mockReturnValue(overrides?.searchMessages ?? [MOCK_MESSAGE]),
+    } as unknown as MessageRepository;
+  });
+}
+
+function mockRepoChatNotFound() {
+  vi.mocked(MessageRepository).mockImplementation(function () {
+    return {
+      listChats: vi.fn().mockReturnValue([]),
+      getThread: vi.fn().mockImplementation((chatId: number) => {
+        throw new ChatNotFoundError(chatId);
+      }),
+      searchMessages: vi.fn().mockReturnValue([]),
+    } as unknown as MessageRepository;
+  });
+}
+
+function setupSuccessPath() {
+  vi.mocked(discoverAllDatabases).mockReturnValue(
+    new Map([[1, "/path/to/db"]]),
+  );
+  mockDb();
+  mockRepo();
+}
+
+describe("handleQueryMessages", () => {
+  const originalExitCode = process.exitCode;
+
+  beforeEach(() => {
+    process.exitCode = undefined;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.exitCode = originalExitCode;
+    vi.restoreAllMocks();
+  });
+
+  it("sets exitCode 1 when no databases found", async () => {
+    const stderrSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockReturnValue(true);
+
+    vi.mocked(discoverAllDatabases).mockReturnValue(new Map());
+
+    await handleQueryMessages({});
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "No LinkedHelper databases found.\n",
+    );
+  });
+
+  it("prints JSON conversation list with --json", async () => {
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockReturnValue(true);
+
+    setupSuccessPath();
+
+    await handleQueryMessages({ json: true });
+
+    expect(process.exitCode).toBeUndefined();
+    const output = stdoutSpy.mock.calls
+      .map((call) => String(call[0]))
+      .join("");
+    expect(JSON.parse(output)).toEqual({
+      conversations: [MOCK_CHAT],
+      total: 1,
+    });
+  });
+
+  it("prints human-friendly conversation list", async () => {
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockReturnValue(true);
+
+    setupSuccessPath();
+
+    await handleQueryMessages({});
+
+    expect(process.exitCode).toBeUndefined();
+    expect(stdoutSpy).toHaveBeenCalledWith("Conversations (1):\n");
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      "\n#123 with Jane Doe (12 messages)\n",
+    );
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      '  Last: "Thanks for reaching out!" — 2025-01-15\n',
+    );
+  });
+
+  it("prints JSON thread with --json and --chat-id", async () => {
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockReturnValue(true);
+
+    setupSuccessPath();
+
+    await handleQueryMessages({ chatId: 123, json: true });
+
+    expect(process.exitCode).toBeUndefined();
+    const output = stdoutSpy.mock.calls
+      .map((call) => String(call[0]))
+      .join("");
+    expect(JSON.parse(output)).toEqual(MOCK_THREAD);
+  });
+
+  it("prints human-friendly thread with --chat-id", async () => {
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockReturnValue(true);
+
+    setupSuccessPath();
+
+    await handleQueryMessages({ chatId: 123 });
+
+    expect(process.exitCode).toBeUndefined();
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      "Conversation #123 with Jane Doe (12 messages):\n",
+    );
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      "\n[2025-01-14 09:00] Alexey Pelykh:\n",
+    );
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      "  Hi Jane, I saw your work on...\n",
+    );
+  });
+
+  it("prints JSON search results with --json and --search", async () => {
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockReturnValue(true);
+
+    setupSuccessPath();
+
+    await handleQueryMessages({ search: "reaching out", json: true });
+
+    expect(process.exitCode).toBeUndefined();
+    const output = stdoutSpy.mock.calls
+      .map((call) => String(call[0]))
+      .join("");
+    expect(JSON.parse(output)).toEqual({
+      messages: [MOCK_MESSAGE],
+      total: 1,
+    });
+  });
+
+  it("prints human-friendly search results with --search", async () => {
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockReturnValue(true);
+
+    setupSuccessPath();
+
+    await handleQueryMessages({ search: "reaching out" });
+
+    expect(process.exitCode).toBeUndefined();
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      'Messages matching "reaching out" (1):\n',
+    );
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      "\n[2025-01-14 09:00] Alexey Pelykh:\n",
+    );
+  });
+
+  it("prints no conversations message when empty", async () => {
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockReturnValue(true);
+
+    vi.mocked(discoverAllDatabases).mockReturnValue(
+      new Map([[1, "/path/to/db"]]),
+    );
+    mockDb();
+    mockRepo({ listChats: [] });
+
+    await handleQueryMessages({});
+
+    expect(process.exitCode).toBeUndefined();
+    expect(stdoutSpy).toHaveBeenCalledWith("No conversations found.\n");
+  });
+
+  it("prints no messages message when search yields nothing", async () => {
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockReturnValue(true);
+
+    vi.mocked(discoverAllDatabases).mockReturnValue(
+      new Map([[1, "/path/to/db"]]),
+    );
+    mockDb();
+    mockRepo({ searchMessages: [] });
+
+    await handleQueryMessages({ search: "nonexistent" });
+
+    expect(process.exitCode).toBeUndefined();
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      'No messages matching "nonexistent".\n',
+    );
+  });
+
+  it("sets exitCode 1 when chat not found", async () => {
+    const stderrSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockReturnValue(true);
+
+    vi.mocked(discoverAllDatabases).mockReturnValue(
+      new Map([[1, "/path/to/db"]]),
+    );
+    mockDb();
+    mockRepoChatNotFound();
+
+    await handleQueryMessages({ chatId: 999 });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("Chat not found.\n");
+  });
+
+  it("closes database after successful query", async () => {
+    vi.spyOn(process.stdout, "write").mockReturnValue(true);
+
+    vi.mocked(discoverAllDatabases).mockReturnValue(
+      new Map([[1, "/path/to/db"]]),
+    );
+    const { close } = mockDb();
+    mockRepo();
+
+    await handleQueryMessages({});
+
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("closes database after failed lookup", async () => {
+    vi.spyOn(process.stderr, "write").mockReturnValue(true);
+
+    vi.mocked(discoverAllDatabases).mockReturnValue(
+      new Map([[1, "/path/to/db"]]),
+    );
+    const { close } = mockDb();
+    mockRepoChatNotFound();
+
+    await handleQueryMessages({ chatId: 999 });
+
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("sets exitCode 1 on unexpected database error", async () => {
+    const stderrSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockReturnValue(true);
+
+    vi.mocked(discoverAllDatabases).mockReturnValue(
+      new Map([[1, "/path/to/db"]]),
+    );
+    mockDb();
+    vi.mocked(MessageRepository).mockImplementation(function () {
+      return {
+        listChats: vi.fn().mockImplementation(() => {
+          throw new Error("database locked");
+        }),
+      } as unknown as MessageRepository;
+    });
+
+    await handleQueryMessages({});
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("database locked\n");
+  });
+});

--- a/packages/cli/src/handlers/query-messages.ts
+++ b/packages/cli/src/handlers/query-messages.ts
@@ -1,0 +1,153 @@
+import {
+  type Chat,
+  type ConversationThread,
+  type Message,
+  ChatNotFoundError,
+  DatabaseClient,
+  discoverAllDatabases,
+  MessageRepository,
+} from "@lhremote/core";
+
+export async function handleQueryMessages(options: {
+  personId?: number;
+  chatId?: number;
+  search?: string;
+  limit?: number;
+  offset?: number;
+  json?: boolean;
+}): Promise<void> {
+  const databases = discoverAllDatabases();
+  if (databases.size === 0) {
+    process.stderr.write("No LinkedHelper databases found.\n");
+    process.exitCode = 1;
+    return;
+  }
+
+  const limit = options.limit ?? 20;
+  const offset = options.offset ?? 0;
+
+  for (const [, dbPath] of databases) {
+    const db = new DatabaseClient(dbPath);
+    try {
+      const repo = new MessageRepository(db);
+
+      if (options.chatId != null) {
+        const thread = repo.getThread(options.chatId, { limit });
+
+        if (options.json) {
+          process.stdout.write(JSON.stringify(thread, null, 2) + "\n");
+        } else {
+          printThread(thread);
+        }
+        return;
+      }
+
+      if (options.search != null) {
+        const messages = repo.searchMessages(options.search, { limit });
+
+        if (options.json) {
+          process.stdout.write(
+            JSON.stringify({ messages, total: messages.length }, null, 2) + "\n",
+          );
+        } else {
+          printSearchResults(messages, options.search);
+        }
+        return;
+      }
+
+      const conversations = repo.listChats({
+        ...(options.personId != null && { personId: options.personId }),
+        limit,
+        offset,
+      });
+
+      if (options.json) {
+        process.stdout.write(
+          JSON.stringify(
+            { conversations, total: conversations.length },
+            null,
+            2,
+          ) + "\n",
+        );
+      } else {
+        printConversationList(conversations);
+      }
+      return;
+    } catch (error) {
+      if (error instanceof ChatNotFoundError) {
+        continue;
+      }
+      const message = error instanceof Error ? error.message : String(error);
+      process.stderr.write(`${message}\n`);
+      process.exitCode = 1;
+      return;
+    } finally {
+      db.close();
+    }
+  }
+
+  process.stderr.write("Chat not found.\n");
+  process.exitCode = 1;
+}
+
+function printConversationList(conversations: Chat[]): void {
+  if (conversations.length === 0) {
+    process.stdout.write("No conversations found.\n");
+    return;
+  }
+
+  process.stdout.write(`Conversations (${String(conversations.length)}):\n`);
+
+  for (const chat of conversations) {
+    const names = chat.participants
+      .map((p) => [p.firstName, p.lastName].filter(Boolean).join(" "))
+      .join(", ");
+    process.stdout.write(
+      `\n#${String(chat.id)} with ${names} (${String(chat.messageCount)} messages)\n`,
+    );
+    if (chat.lastMessage) {
+      const date = chat.lastMessage.sendAt.slice(0, 10);
+      process.stdout.write(
+        `  Last: "${chat.lastMessage.text}" — ${date}\n`,
+      );
+    }
+  }
+}
+
+function printThread(thread: ConversationThread): void {
+  const names = thread.chat.participants
+    .map((p) => [p.firstName, p.lastName].filter(Boolean).join(" "))
+    .join(", ");
+  process.stdout.write(
+    `Conversation #${String(thread.chat.id)} with ${names} (${String(thread.chat.messageCount)} messages):\n`,
+  );
+
+  for (const msg of thread.messages) {
+    const senderName = [msg.senderFirstName, msg.senderLastName]
+      .filter(Boolean)
+      .join(" ");
+    const ts = msg.sendAt.replace("T", " ").slice(0, 16);
+    process.stdout.write(`\n[${ts}] ${senderName}:\n`);
+    process.stdout.write(`  ${msg.text}\n`);
+  }
+}
+
+function printSearchResults(messages: Message[], query: string): void {
+  if (messages.length === 0) {
+    process.stdout.write(`No messages matching "${query}".\n`);
+    return;
+  }
+
+  process.stdout.write(
+    `Messages matching "${query}" (${String(messages.length)}):\n`,
+  );
+
+  for (const msg of messages) {
+    const senderName = [msg.senderFirstName, msg.senderLastName]
+      .filter(Boolean)
+      .join(" ");
+    const ts = msg.sendAt.replace("T", " ").slice(0, 16);
+    process.stdout.write(`\n[${ts}] ${senderName}:\n`);
+    process.stdout.write(`  ${msg.text}\n`);
+  }
+}

--- a/packages/cli/src/program.test.ts
+++ b/packages/cli/src/program.test.ts
@@ -41,8 +41,9 @@ describe("createProgram", () => {
     expect(commandNames).toContain("stop-instance");
     expect(commandNames).toContain("visit-and-extract");
     expect(commandNames).toContain("query-profile");
+    expect(commandNames).toContain("query-messages");
     expect(commandNames).toContain("check-status");
-    expect(commandNames).toHaveLength(9);
+    expect(commandNames).toHaveLength(10);
   });
 
   describe("launch-app", () => {

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -7,6 +7,7 @@ import {
   handleFindApp,
   handleLaunchApp,
   handleListAccounts,
+  handleQueryMessages,
   handleQueryProfile,
   handleQuitApp,
   handleStartInstance,
@@ -22,6 +23,17 @@ function parsePositiveInt(value: string): number {
   const n = Number(value);
   if (!Number.isInteger(n) || n <= 0) {
     throw new InvalidArgumentError(`Expected a positive integer, got "${value}".`);
+  }
+  return n;
+}
+
+/** Parse a string as a non-negative integer, throwing on invalid input. */
+function parseNonNegativeInt(value: string): number {
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < 0) {
+    throw new InvalidArgumentError(
+      `Expected a non-negative integer, got "${value}".`,
+    );
   }
   return n;
 }
@@ -86,6 +98,17 @@ export function createProgram(): Command {
     )
     .option("--json", "Output as JSON")
     .action(handleVisitAndExtract);
+
+  program
+    .command("query-messages")
+    .description("Query messaging history from the local database")
+    .option("--person-id <id>", "Filter by person ID", parsePositiveInt)
+    .option("--chat-id <id>", "Show specific conversation thread", parsePositiveInt)
+    .option("--search <text>", "Search message text")
+    .option("--limit <n>", "Max results (default: 20)", parsePositiveInt)
+    .option("--offset <n>", "Pagination offset (default: 0)", parseNonNegativeInt)
+    .option("--json", "Output as JSON")
+    .action(handleQueryMessages);
 
   program
     .command("query-profile")

--- a/packages/core/src/services/mcp-claude.e2e.test.ts
+++ b/packages/core/src/services/mcp-claude.e2e.test.ts
@@ -177,5 +177,21 @@ describeE2E("MCP tools via Claude CLI", () => {
       },
       120_000,
     );
+
+    it(
+      "query-messages lists conversations from the local database",
+      () => {
+        const result = runClaude(
+          "Use the query-messages tool with no filters to list conversations. " +
+          "Report the raw JSON from the tool response, nothing else.",
+        );
+
+        expect(result.is_error).toBe(false);
+        expect(result.num_turns).toBeGreaterThanOrEqual(2);
+        // The response should contain conversation data
+        expect(result.result).toMatch(/conversations|chatId|participants|messages/i);
+      },
+      120_000,
+    );
   });
 });

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -80,7 +80,8 @@ describe("createServer", () => {
     expect(names).toContain("stop-instance");
     expect(names).toContain("visit-and-extract");
     expect(names).toContain("query-profile");
+    expect(names).toContain("query-messages");
     expect(names).toContain("check-status");
-    expect(names).toHaveLength(9);
+    expect(names).toHaveLength(10);
   });
 });

--- a/packages/mcp/src/tools/index.ts
+++ b/packages/mcp/src/tools/index.ts
@@ -7,6 +7,7 @@ import { registerListAccounts } from "./list-accounts.js";
 import { registerQuitApp } from "./quit-app.js";
 import { registerStartInstance } from "./start-instance.js";
 import { registerStopInstance } from "./stop-instance.js";
+import { registerQueryMessages } from "./query-messages.js";
 import { registerQueryProfile } from "./query-profile.js";
 import { registerVisitAndExtract } from "./visit-and-extract.js";
 
@@ -18,6 +19,7 @@ export function registerAllTools(server: McpServer): void {
   registerStartInstance(server);
   registerStopInstance(server);
   registerVisitAndExtract(server);
+  registerQueryMessages(server);
   registerQueryProfile(server);
   registerCheckStatus(server);
 }

--- a/packages/mcp/src/tools/query-messages.integration.test.ts
+++ b/packages/mcp/src/tools/query-messages.integration.test.ts
@@ -1,0 +1,141 @@
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_PATH = join(
+  __dirname,
+  "../../../core/src/db/testing/fixture.db",
+);
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return {
+    ...actual,
+    discoverAllDatabases: vi.fn(),
+  };
+});
+
+import { discoverAllDatabases } from "@lhremote/core";
+
+import { registerQueryMessages } from "./query-messages.js";
+import { createMockServer } from "./testing/mock-server.js";
+
+describe("registerQueryMessages (integration)", () => {
+  beforeEach(() => {
+    vi.mocked(discoverAllDatabases).mockReturnValue(
+      new Map([[1, FIXTURE_PATH]]),
+    );
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("lists conversations from the fixture database", async () => {
+    const { server, getHandler } = createMockServer();
+    registerQueryMessages(server);
+
+    const handler = getHandler("query-messages");
+    const result = (await handler({})) as {
+      content: [{ type: string; text: string }];
+      isError?: boolean;
+    };
+
+    expect(result.isError).toBeUndefined();
+    const body = JSON.parse(result.content[0].text) as {
+      conversations: { id: number; participants: unknown[] }[];
+    };
+    expect(body.conversations.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("filters conversations by personId", async () => {
+    const { server, getHandler } = createMockServer();
+    registerQueryMessages(server);
+
+    const handler = getHandler("query-messages");
+    // Person 1 (Ada) participates in chat 1 and chat 2
+    const result = (await handler({ personId: 1 })) as {
+      content: [{ type: string; text: string }];
+    };
+
+    const body = JSON.parse(result.content[0].text) as {
+      conversations: { id: number }[];
+    };
+    expect(body.conversations).toHaveLength(2);
+    const chatIds = body.conversations.map((c) => c.id);
+    expect(chatIds).toContain(1);
+    expect(chatIds).toContain(2);
+  });
+
+  it("retrieves a conversation thread by chatId", async () => {
+    const { server, getHandler } = createMockServer();
+    registerQueryMessages(server);
+
+    const handler = getHandler("query-messages");
+    const result = (await handler({ chatId: 1 })) as {
+      content: [{ type: string; text: string }];
+    };
+
+    const body = JSON.parse(result.content[0].text) as {
+      chat: { id: number; participants: { firstName: string }[] };
+      messages: { text: string; senderFirstName: string; sendAt: string }[];
+    };
+    expect(body.chat.id).toBe(1);
+    expect(body.chat.participants.length).toBeGreaterThanOrEqual(2);
+    expect(body.messages.length).toBeGreaterThanOrEqual(3);
+
+    // Messages should be in chronological order
+    const sendTimes = body.messages.map((m) => m.sendAt);
+    const sorted = [...sendTimes].sort();
+    expect(sendTimes).toEqual(sorted);
+  });
+
+  it("searches messages by text", async () => {
+    const { server, getHandler } = createMockServer();
+    registerQueryMessages(server);
+
+    const handler = getHandler("query-messages");
+    const result = (await handler({ search: "compiler" })) as {
+      content: [{ type: string; text: string }];
+    };
+
+    const body = JSON.parse(result.content[0].text) as {
+      messages: { text: string }[];
+    };
+    expect(body.messages.length).toBeGreaterThanOrEqual(1);
+    for (const msg of body.messages) {
+      expect(msg.text.toLowerCase()).toContain("compiler");
+    }
+  });
+
+  it("returns error for nonexistent chatId", async () => {
+    const { server, getHandler } = createMockServer();
+    registerQueryMessages(server);
+
+    const handler = getHandler("query-messages");
+    const result = (await handler({ chatId: 999 })) as {
+      content: [{ type: string; text: string }];
+      isError?: boolean;
+    };
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toBe("Chat not found.");
+  });
+
+  it("respects limit parameter", async () => {
+    const { server, getHandler } = createMockServer();
+    registerQueryMessages(server);
+
+    const handler = getHandler("query-messages");
+    const result = (await handler({ limit: 1 })) as {
+      content: [{ type: string; text: string }];
+    };
+
+    const body = JSON.parse(result.content[0].text) as {
+      conversations: unknown[];
+    };
+    expect(body.conversations).toHaveLength(1);
+  });
+});

--- a/packages/mcp/src/tools/query-messages.test.ts
+++ b/packages/mcp/src/tools/query-messages.test.ts
@@ -1,0 +1,351 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return {
+    ...actual,
+    DatabaseClient: vi.fn(),
+    MessageRepository: vi.fn(),
+    discoverAllDatabases: vi.fn(),
+  };
+});
+
+import {
+  type Chat,
+  type ConversationThread,
+  type Message,
+  ChatNotFoundError,
+  DatabaseClient,
+  MessageRepository,
+  discoverAllDatabases,
+} from "@lhremote/core";
+
+import { registerQueryMessages } from "./query-messages.js";
+import { createMockServer } from "./testing/mock-server.js";
+
+const MOCK_CHAT: Chat = {
+  id: 123,
+  type: "MEMBER_TO_MEMBER",
+  platform: "LINKEDIN",
+  participants: [
+    { personId: 456, firstName: "Jane", lastName: "Doe" },
+  ],
+  messageCount: 12,
+  lastMessage: {
+    text: "Thanks for reaching out!",
+    sendAt: "2025-01-15T10:30:00Z",
+  },
+};
+
+const MOCK_MESSAGE: Message = {
+  id: 1,
+  type: "DEFAULT",
+  text: "Hi Jane, I saw your work on...",
+  subject: null,
+  sendAt: "2025-01-14T09:00:00Z",
+  attachmentsCount: 0,
+  senderPersonId: 789,
+  senderFirstName: "Alexey",
+  senderLastName: "Pelykh",
+};
+
+const MOCK_THREAD: ConversationThread = {
+  chat: MOCK_CHAT,
+  messages: [MOCK_MESSAGE],
+};
+
+function mockDb() {
+  const close = vi.fn();
+  vi.mocked(DatabaseClient).mockImplementation(function () {
+    return { close, db: {} } as unknown as DatabaseClient;
+  });
+  return { close };
+}
+
+function mockRepo(overrides?: {
+  listChats?: Chat[];
+  thread?: ConversationThread;
+  searchMessages?: Message[];
+}) {
+  vi.mocked(MessageRepository).mockImplementation(function () {
+    return {
+      listChats: vi.fn().mockReturnValue(overrides?.listChats ?? [MOCK_CHAT]),
+      getThread: vi.fn().mockReturnValue(overrides?.thread ?? MOCK_THREAD),
+      searchMessages: vi
+        .fn()
+        .mockReturnValue(overrides?.searchMessages ?? [MOCK_MESSAGE]),
+    } as unknown as MessageRepository;
+  });
+}
+
+function mockRepoChatNotFound() {
+  vi.mocked(MessageRepository).mockImplementation(function () {
+    return {
+      listChats: vi.fn().mockReturnValue([]),
+      getThread: vi.fn().mockImplementation((chatId: number) => {
+        throw new ChatNotFoundError(chatId);
+      }),
+      searchMessages: vi.fn().mockReturnValue([]),
+    } as unknown as MessageRepository;
+  });
+}
+
+function setupSuccessPath() {
+  vi.mocked(discoverAllDatabases).mockReturnValue(
+    new Map([[1, "/path/to/db"]]),
+  );
+  mockDb();
+  mockRepo();
+}
+
+describe("registerQueryMessages", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("registers a tool named query-messages", () => {
+    const { server } = createMockServer();
+    registerQueryMessages(server);
+
+    expect(server.tool).toHaveBeenCalledOnce();
+    expect(server.tool).toHaveBeenCalledWith(
+      "query-messages",
+      expect.any(String),
+      expect.any(Object),
+      expect.any(Function),
+    );
+  });
+
+  it("returns conversations list when no filters provided", async () => {
+    const { server, getHandler } = createMockServer();
+    registerQueryMessages(server);
+    setupSuccessPath();
+
+    const handler = getHandler("query-messages");
+    const result = await handler({});
+
+    expect(result).toEqual({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(
+            { conversations: [MOCK_CHAT], total: 1 },
+            null,
+            2,
+          ),
+        },
+      ],
+    });
+  });
+
+  it("returns conversations filtered by personId", async () => {
+    const { server, getHandler } = createMockServer();
+    registerQueryMessages(server);
+    setupSuccessPath();
+
+    const handler = getHandler("query-messages");
+    const result = await handler({ personId: 456 });
+
+    expect(result).toEqual({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(
+            { conversations: [MOCK_CHAT], total: 1 },
+            null,
+            2,
+          ),
+        },
+      ],
+    });
+  });
+
+  it("returns conversation thread when chatId provided", async () => {
+    const { server, getHandler } = createMockServer();
+    registerQueryMessages(server);
+    setupSuccessPath();
+
+    const handler = getHandler("query-messages");
+    const result = await handler({ chatId: 123 });
+
+    expect(result).toEqual({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(MOCK_THREAD, null, 2),
+        },
+      ],
+    });
+  });
+
+  it("returns search results when search provided", async () => {
+    const { server, getHandler } = createMockServer();
+    registerQueryMessages(server);
+    setupSuccessPath();
+
+    const handler = getHandler("query-messages");
+    const result = await handler({ search: "reaching out" });
+
+    expect(result).toEqual({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(
+            { messages: [MOCK_MESSAGE], total: 1 },
+            null,
+            2,
+          ),
+        },
+      ],
+    });
+  });
+
+  it("returns error when no databases found", async () => {
+    const { server, getHandler } = createMockServer();
+    registerQueryMessages(server);
+    vi.mocked(discoverAllDatabases).mockReturnValue(new Map());
+
+    const handler = getHandler("query-messages");
+    const result = await handler({});
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "No LinkedHelper databases found.",
+        },
+      ],
+    });
+  });
+
+  it("returns error when chat not found in any database", async () => {
+    const { server, getHandler } = createMockServer();
+    registerQueryMessages(server);
+    vi.mocked(discoverAllDatabases).mockReturnValue(
+      new Map([[1, "/path/to/db"]]),
+    );
+    mockDb();
+    mockRepoChatNotFound();
+
+    const handler = getHandler("query-messages");
+    const result = await handler({ chatId: 999 });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "Chat not found.",
+        },
+      ],
+    });
+  });
+
+  it("closes database after successful query", async () => {
+    const { server, getHandler } = createMockServer();
+    registerQueryMessages(server);
+    vi.mocked(discoverAllDatabases).mockReturnValue(
+      new Map([[1, "/path/to/db"]]),
+    );
+    const { close } = mockDb();
+    mockRepo();
+
+    const handler = getHandler("query-messages");
+    await handler({});
+
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("closes database after failed lookup", async () => {
+    const { server, getHandler } = createMockServer();
+    registerQueryMessages(server);
+    vi.mocked(discoverAllDatabases).mockReturnValue(
+      new Map([[1, "/path/to/db"]]),
+    );
+    const { close } = mockDb();
+    mockRepoChatNotFound();
+
+    const handler = getHandler("query-messages");
+    await handler({ chatId: 999 });
+
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("returns error on unexpected database failure", async () => {
+    const { server, getHandler } = createMockServer();
+    registerQueryMessages(server);
+    vi.mocked(discoverAllDatabases).mockReturnValue(
+      new Map([[1, "/path/to/db"]]),
+    );
+    mockDb();
+    vi.mocked(MessageRepository).mockImplementation(function () {
+      return {
+        listChats: vi.fn().mockImplementation(() => {
+          throw new Error("database locked");
+        }),
+      } as unknown as MessageRepository;
+    });
+
+    const handler = getHandler("query-messages");
+    const result = await handler({});
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "Failed to query messages: database locked",
+        },
+      ],
+    });
+  });
+
+  it("chatId takes priority over search and personId", async () => {
+    const { server, getHandler } = createMockServer();
+    registerQueryMessages(server);
+    setupSuccessPath();
+
+    const handler = getHandler("query-messages");
+    const result = await handler({
+      chatId: 123,
+      search: "hello",
+      personId: 456,
+    });
+
+    expect(result).toEqual({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(MOCK_THREAD, null, 2),
+        },
+      ],
+    });
+  });
+
+  it("search takes priority over personId", async () => {
+    const { server, getHandler } = createMockServer();
+    registerQueryMessages(server);
+    setupSuccessPath();
+
+    const handler = getHandler("query-messages");
+    const result = await handler({ search: "reaching out", personId: 456 });
+
+    expect(result).toEqual({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(
+            { messages: [MOCK_MESSAGE], total: 1 },
+            null,
+            2,
+          ),
+        },
+      ],
+    });
+  });
+});

--- a/packages/mcp/src/tools/query-messages.ts
+++ b/packages/mcp/src/tools/query-messages.ts
@@ -1,0 +1,142 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  ChatNotFoundError,
+  DatabaseClient,
+  discoverAllDatabases,
+  MessageRepository,
+} from "@lhremote/core";
+import { z } from "zod";
+
+export function registerQueryMessages(server: McpServer): void {
+  server.tool(
+    "query-messages",
+    "Query messaging history from the local LinkedHelper database. List conversations, read threads, or search messages.",
+    {
+      personId: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe("Filter conversations by person ID"),
+      chatId: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe("Get a specific conversation thread"),
+      search: z
+        .string()
+        .optional()
+        .describe("Search message text (LIKE match)"),
+      limit: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe("Max results (default: 20)"),
+      offset: z
+        .number()
+        .int()
+        .nonnegative()
+        .optional()
+        .describe("Pagination offset (default: 0)"),
+    },
+    async ({ personId, chatId, search, limit, offset }) => {
+      const databases = discoverAllDatabases();
+      if (databases.size === 0) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: "No LinkedHelper databases found.",
+            },
+          ],
+        };
+      }
+
+      const effectiveLimit = limit ?? 20;
+      const effectiveOffset = offset ?? 0;
+
+      for (const [, dbPath] of databases) {
+        const db = new DatabaseClient(dbPath);
+        try {
+          const repo = new MessageRepository(db);
+
+          if (chatId != null) {
+            const thread = repo.getThread(chatId, {
+              limit: effectiveLimit,
+            });
+            return {
+              content: [
+                {
+                  type: "text" as const,
+                  text: JSON.stringify(thread, null, 2),
+                },
+              ],
+            };
+          }
+
+          if (search != null) {
+            const messages = repo.searchMessages(search, {
+              limit: effectiveLimit,
+            });
+            return {
+              content: [
+                {
+                  type: "text" as const,
+                  text: JSON.stringify({ messages, total: messages.length }, null, 2),
+                },
+              ],
+            };
+          }
+
+          const conversations = repo.listChats({
+            ...(personId != null && { personId }),
+            limit: effectiveLimit,
+            offset: effectiveOffset,
+          });
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: JSON.stringify(
+                  { conversations, total: conversations.length },
+                  null,
+                  2,
+                ),
+              },
+            ],
+          };
+        } catch (error) {
+          if (error instanceof ChatNotFoundError) {
+            continue;
+          }
+          const message =
+            error instanceof Error ? error.message : String(error);
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: `Failed to query messages: ${message}`,
+              },
+            ],
+          };
+        } finally {
+          db.close();
+        }
+      }
+
+      return {
+        isError: true,
+        content: [
+          {
+            type: "text" as const,
+            text: "Chat not found.",
+          },
+        ],
+      };
+    },
+  );
+}


### PR DESCRIPTION
## Summary

- Add `query-messages` MCP tool and CLI command for querying messaging history from the LinkedHelper database
- Supports listing conversations (optionally filtered by person ID), reading threads by chat ID, and searching messages by text
- Includes unit and integration test coverage for both MCP tool and CLI handler

## Test plan

- [x] Unit tests for MCP tool (12 tests) — registration, conversation list, thread retrieval, search, error handling, parameter priority, db cleanup
- [x] Unit tests for CLI handler (13 tests) — JSON/human output for all modes, empty results, error handling, db cleanup
- [x] Integration tests for MCP tool (6 tests) — real fixture database through full DatabaseClient + MessageRepository path
- [x] Integration tests for CLI handler (7 tests) — real fixture database with both JSON and human-readable output verification
- [x] Existing server/program registration tests updated for new tool count
- [x] All tests pass (`pnpm test`)

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)