### PR TITLE
Implement scrape-messaging-history tool

### DIFF
--- a/packages/cli/src/handlers/index.ts
+++ b/packages/cli/src/handlers/index.ts
@@ -2,6 +2,7 @@ export { handleCheckStatus } from "./check-status.js";
 export { handleFindApp } from "./find-app.js";
 export { handleQueryMessages } from "./query-messages.js";
 export { handleQueryProfile } from "./query-profile.js";
+export { handleScrapeMessagingHistory } from "./scrape-messaging-history.js";
 export { handleLaunchApp } from "./launch-app.js";
 export { handleListAccounts } from "./list-accounts.js";
 export { handleQuitApp } from "./quit-app.js";

--- a/packages/cli/src/handlers/scrape-messaging-history.ts
+++ b/packages/cli/src/handlers/scrape-messaging-history.ts
@@ -1,0 +1,117 @@
+import {
+  type Account,
+  type MessageStats,
+  DatabaseClient,
+  discoverDatabase,
+  discoverInstancePort,
+  InstanceService,
+  LauncherService,
+  MessageRepository,
+} from "@lhremote/core";
+
+export async function handleScrapeMessagingHistory(options: {
+  cdpPort?: number;
+  json?: boolean;
+}): Promise<void> {
+  const cdpPort = options.cdpPort ?? 9222;
+
+  // Connect to launcher to find the running account
+  const launcher = new LauncherService(cdpPort);
+
+  let accountId: number;
+  try {
+    await launcher.connect();
+    const accounts = await launcher.listAccounts();
+    if (accounts.length === 0) {
+      process.stderr.write("No accounts found.\n");
+      process.exitCode = 1;
+      return;
+    }
+    if (accounts.length > 1) {
+      process.stderr.write(
+        "Multiple accounts found. Cannot determine which instance to use.\n",
+      );
+      process.exitCode = 1;
+      return;
+    }
+    accountId = (accounts[0] as Account).id;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+    return;
+  } finally {
+    launcher.disconnect();
+  }
+
+  // Discover instance CDP port
+  const instancePort = await discoverInstancePort(cdpPort);
+  if (instancePort === null) {
+    process.stderr.write(
+      "No LinkedHelper instance is running. Use start-instance first.\n",
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  // Connect to instance, execute action, then query stats
+  // Use a 5-minute timeout — scraping messaging history is long-running
+  const instance = new InstanceService(instancePort, { timeout: 300_000 });
+  let db: DatabaseClient | null = null;
+
+  try {
+    await instance.connect();
+
+    process.stderr.write("Scraping messaging history from LinkedIn...\n");
+
+    // Execute the scrape action (may take several minutes)
+    await instance.executeAction("ScrapeMessagingHistory");
+
+    process.stderr.write("Done.\n");
+
+    // Query stats from the database
+    const dbPath = discoverDatabase(accountId);
+    db = new DatabaseClient(dbPath);
+    const repo = new MessageRepository(db);
+    const stats = repo.getMessageStats();
+
+    if (options.json) {
+      process.stdout.write(
+        JSON.stringify(
+          { success: true, actionType: "ScrapeMessagingHistory", stats },
+          null,
+          2,
+        ) + "\n",
+      );
+    } else {
+      printStats(stats);
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+  } finally {
+    instance.disconnect();
+    db?.close();
+  }
+}
+
+function printStats(stats: MessageStats): void {
+  process.stdout.write(`\nDatabase now contains:\n`);
+  process.stdout.write(
+    `  ${String(stats.totalChats)} conversations\n`,
+  );
+  process.stdout.write(
+    `  ${String(stats.totalMessages)} messages\n`,
+  );
+
+  if (stats.earliestMessage && stats.latestMessage) {
+    const earliest = stats.earliestMessage.slice(0, 10);
+    const latest = stats.latestMessage.slice(0, 10);
+    process.stdout.write(`  Date range: ${earliest} — ${latest}\n`);
+  }
+
+  process.stdout.write(
+    `\nUse \`lhremote query-messages\` to browse conversations.\n`,
+  );
+}

--- a/packages/cli/src/program.test.ts
+++ b/packages/cli/src/program.test.ts
@@ -42,8 +42,9 @@ describe("createProgram", () => {
     expect(commandNames).toContain("visit-and-extract");
     expect(commandNames).toContain("query-profile");
     expect(commandNames).toContain("query-messages");
+    expect(commandNames).toContain("scrape-messaging-history");
     expect(commandNames).toContain("check-status");
-    expect(commandNames).toHaveLength(10);
+    expect(commandNames).toHaveLength(11);
   });
 
   describe("launch-app", () => {

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -9,6 +9,7 @@ import {
   handleListAccounts,
   handleQueryMessages,
   handleQueryProfile,
+  handleScrapeMessagingHistory,
   handleQuitApp,
   handleStartInstance,
   handleStopInstance,
@@ -117,6 +118,15 @@ export function createProgram(): Command {
     .option("--public-id <slug>", "Look up by LinkedIn public ID")
     .option("--json", "Output as JSON")
     .action(handleQueryProfile);
+
+  program
+    .command("scrape-messaging-history")
+    .description(
+      "Scrape messaging history from LinkedIn into the local database",
+    )
+    .option("--cdp-port <port>", "CDP debugging port", parsePositiveInt)
+    .option("--json", "Output as JSON")
+    .action(handleScrapeMessagingHistory);
 
   program
     .command("check-status")

--- a/packages/core/src/services/instance.ts
+++ b/packages/core/src/services/instance.ts
@@ -33,12 +33,14 @@ const CONNECT_POLL_INTERVAL = 1_000;
 export class InstanceService {
   private readonly port: number;
   private readonly host: string;
+  private readonly timeout: number | undefined;
   private linkedInClient: CDPClient | null = null;
   private uiClient: CDPClient | null = null;
 
-  constructor(port: number, options?: { host?: string }) {
+  constructor(port: number, options?: { host?: string; timeout?: number }) {
     this.port = port;
     this.host = options?.host ?? "127.0.0.1";
+    this.timeout = options?.timeout;
   }
 
   /**
@@ -80,10 +82,14 @@ export class InstanceService {
       );
     }
 
-    const liClient = new CDPClient(this.port, { host: this.host });
+    const clientOptions = this.timeout !== undefined
+      ? { host: this.host, timeout: this.timeout }
+      : { host: this.host };
+
+    const liClient = new CDPClient(this.port, clientOptions);
     await liClient.connect(linkedInTarget.id);
 
-    const ui = new CDPClient(this.port, { host: this.host });
+    const ui = new CDPClient(this.port, clientOptions);
     await ui.connect(uiTarget.id);
 
     this.linkedInClient = liClient;

--- a/packages/core/src/services/mcp-claude.e2e.test.ts
+++ b/packages/core/src/services/mcp-claude.e2e.test.ts
@@ -193,5 +193,22 @@ describeE2E("MCP tools via Claude CLI", () => {
       },
       120_000,
     );
+
+    it(
+      "scrape-messaging-history scrapes and returns stats",
+      () => {
+        const result = runClaude(
+          "Use the scrape-messaging-history tool to scrape messaging history. " +
+          "Report the raw JSON from the tool response, nothing else.",
+          300_000,
+        );
+
+        expect(result.is_error).toBe(false);
+        expect(result.num_turns).toBeGreaterThanOrEqual(2);
+        // The response should contain scrape results with stats
+        expect(result.result).toMatch(/ScrapeMessagingHistory|totalChats|totalMessages|stats/i);
+      },
+      360_000,
+    );
   });
 });

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -81,7 +81,8 @@ describe("createServer", () => {
     expect(names).toContain("visit-and-extract");
     expect(names).toContain("query-profile");
     expect(names).toContain("query-messages");
+    expect(names).toContain("scrape-messaging-history");
     expect(names).toContain("check-status");
-    expect(names).toHaveLength(10);
+    expect(names).toHaveLength(11);
   });
 });

--- a/packages/mcp/src/tools/index.ts
+++ b/packages/mcp/src/tools/index.ts
@@ -9,6 +9,7 @@ import { registerStartInstance } from "./start-instance.js";
 import { registerStopInstance } from "./stop-instance.js";
 import { registerQueryMessages } from "./query-messages.js";
 import { registerQueryProfile } from "./query-profile.js";
+import { registerScrapeMessagingHistory } from "./scrape-messaging-history.js";
 import { registerVisitAndExtract } from "./visit-and-extract.js";
 
 export function registerAllTools(server: McpServer): void {
@@ -21,5 +22,6 @@ export function registerAllTools(server: McpServer): void {
   registerVisitAndExtract(server);
   registerQueryMessages(server);
   registerQueryProfile(server);
+  registerScrapeMessagingHistory(server);
   registerCheckStatus(server);
 }

--- a/packages/mcp/src/tools/scrape-messaging-history.test.ts
+++ b/packages/mcp/src/tools/scrape-messaging-history.test.ts
@@ -1,0 +1,415 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return {
+    ...actual,
+    LauncherService: vi.fn(),
+    InstanceService: vi.fn(),
+    DatabaseClient: vi.fn(),
+    MessageRepository: vi.fn(),
+    discoverInstancePort: vi.fn(),
+    discoverDatabase: vi.fn(),
+  };
+});
+
+import {
+  type Account,
+  type MessageStats,
+  DatabaseClient,
+  discoverDatabase,
+  discoverInstancePort,
+  InstanceNotRunningError,
+  InstanceService,
+  LauncherService,
+  LinkedHelperNotRunningError,
+  MessageRepository,
+} from "@lhremote/core";
+
+import { registerScrapeMessagingHistory } from "./scrape-messaging-history.js";
+import { createMockServer } from "./testing/mock-server.js";
+
+const MOCK_STATS: MessageStats = {
+  totalMessages: 2500,
+  totalChats: 150,
+  earliestMessage: "2024-01-15T09:00:00Z",
+  latestMessage: "2025-01-15T12:00:00Z",
+};
+
+function mockLauncher(overrides: Record<string, unknown> = {}) {
+  const disconnect = vi.fn();
+  vi.mocked(LauncherService).mockImplementation(function () {
+    return {
+      connect: vi.fn().mockResolvedValue(undefined),
+      disconnect,
+      listAccounts: vi
+        .fn()
+        .mockResolvedValue([{ id: 1, liId: 1, name: "Alice" } as Account]),
+      ...overrides,
+    } as unknown as LauncherService;
+  });
+  return { disconnect };
+}
+
+function mockInstance(overrides: Record<string, unknown> = {}) {
+  const disconnect = vi.fn();
+  vi.mocked(InstanceService).mockImplementation(function () {
+    return {
+      connect: vi.fn().mockResolvedValue(undefined),
+      disconnect,
+      executeAction: vi.fn().mockResolvedValue(undefined),
+      ...overrides,
+    } as unknown as InstanceService;
+  });
+  return { disconnect };
+}
+
+function mockDb() {
+  const close = vi.fn();
+  vi.mocked(DatabaseClient).mockImplementation(function () {
+    return { close, db: {} } as unknown as DatabaseClient;
+  });
+  return { close };
+}
+
+function mockRepo(stats: MessageStats = MOCK_STATS) {
+  vi.mocked(MessageRepository).mockImplementation(function () {
+    return {
+      getMessageStats: vi.fn().mockReturnValue(stats),
+    } as unknown as MessageRepository;
+  });
+}
+
+function setupSuccessPath() {
+  mockLauncher();
+  mockInstance();
+  mockDb();
+  mockRepo();
+  vi.mocked(discoverInstancePort).mockResolvedValue(55123);
+  vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+}
+
+describe("registerScrapeMessagingHistory", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("registers a tool named scrape-messaging-history", () => {
+    const { server } = createMockServer();
+    registerScrapeMessagingHistory(server);
+
+    expect(server.tool).toHaveBeenCalledOnce();
+    expect(server.tool).toHaveBeenCalledWith(
+      "scrape-messaging-history",
+      expect.any(String),
+      expect.any(Object),
+      expect.any(Function),
+    );
+  });
+
+  it("returns stats on success", async () => {
+    const { server, getHandler } = createMockServer();
+    registerScrapeMessagingHistory(server);
+    setupSuccessPath();
+
+    const handler = getHandler("scrape-messaging-history");
+    const result = await handler({ cdpPort: 9222 });
+
+    expect(result).toEqual({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(
+            {
+              success: true,
+              actionType: "ScrapeMessagingHistory",
+              stats: MOCK_STATS,
+            },
+            null,
+            2,
+          ),
+        },
+      ],
+    });
+  });
+
+  it("executes ScrapeMessagingHistory action", async () => {
+    const { server, getHandler } = createMockServer();
+    registerScrapeMessagingHistory(server);
+
+    mockLauncher();
+    const executeAction = vi.fn().mockResolvedValue(undefined);
+    mockInstance({ executeAction });
+    mockDb();
+    mockRepo();
+    vi.mocked(discoverInstancePort).mockResolvedValue(55123);
+    vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+
+    const handler = getHandler("scrape-messaging-history");
+    await handler({ cdpPort: 9222 });
+
+    expect(executeAction).toHaveBeenCalledWith("ScrapeMessagingHistory");
+  });
+
+  it("returns error when LinkedHelper not running", async () => {
+    const { server, getHandler } = createMockServer();
+    registerScrapeMessagingHistory(server);
+
+    vi.mocked(LauncherService).mockImplementation(function () {
+      return {
+        connect: vi
+          .fn()
+          .mockRejectedValue(new LinkedHelperNotRunningError(9222)),
+        disconnect: vi.fn(),
+      } as unknown as LauncherService;
+    });
+
+    const handler = getHandler("scrape-messaging-history");
+    const result = await handler({ cdpPort: 9222 });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "LinkedHelper is not running. Use launch-app first.",
+        },
+      ],
+    });
+  });
+
+  it("returns error when launcher connect fails with unknown error", async () => {
+    const { server, getHandler } = createMockServer();
+    registerScrapeMessagingHistory(server);
+
+    vi.mocked(LauncherService).mockImplementation(function () {
+      return {
+        connect: vi.fn().mockRejectedValue(new Error("connection refused")),
+        disconnect: vi.fn(),
+      } as unknown as LauncherService;
+    });
+
+    const handler = getHandler("scrape-messaging-history");
+    const result = await handler({ cdpPort: 9222 });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "Failed to connect to LinkedHelper: connection refused",
+        },
+      ],
+    });
+  });
+
+  it("returns error when no accounts found", async () => {
+    const { server, getHandler } = createMockServer();
+    registerScrapeMessagingHistory(server);
+
+    mockLauncher({
+      listAccounts: vi.fn().mockResolvedValue([]),
+    });
+
+    const handler = getHandler("scrape-messaging-history");
+    const result = await handler({ cdpPort: 9222 });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [{ type: "text", text: "No accounts found." }],
+    });
+  });
+
+  it("returns error when multiple accounts found", async () => {
+    const { server, getHandler } = createMockServer();
+    registerScrapeMessagingHistory(server);
+
+    mockLauncher({
+      listAccounts: vi.fn().mockResolvedValue([
+        { id: 1, liId: 1, name: "Alice" },
+        { id: 2, liId: 2, name: "Bob" },
+      ]),
+    });
+
+    const handler = getHandler("scrape-messaging-history");
+    const result = await handler({ cdpPort: 9222 });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "Multiple accounts found. Cannot determine which instance to use.",
+        },
+      ],
+    });
+  });
+
+  it("returns error when no instance is running", async () => {
+    const { server, getHandler } = createMockServer();
+    registerScrapeMessagingHistory(server);
+
+    mockLauncher();
+    vi.mocked(discoverInstancePort).mockResolvedValue(null);
+
+    const handler = getHandler("scrape-messaging-history");
+    const result = await handler({ cdpPort: 9222 });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "No LinkedHelper instance is running. Use start-instance first.",
+        },
+      ],
+    });
+  });
+
+  it("returns error when instance connect fails", async () => {
+    const { server, getHandler } = createMockServer();
+    registerScrapeMessagingHistory(server);
+
+    mockLauncher();
+    vi.mocked(discoverInstancePort).mockResolvedValue(55123);
+    vi.mocked(InstanceService).mockImplementation(function () {
+      return {
+        connect: vi
+          .fn()
+          .mockRejectedValue(
+            new InstanceNotRunningError("LinkedIn webview target not found"),
+          ),
+        disconnect: vi.fn(),
+      } as unknown as InstanceService;
+    });
+
+    const handler = getHandler("scrape-messaging-history");
+    const result = await handler({ cdpPort: 9222 });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "No LinkedHelper instance is running. Use start-instance first.",
+        },
+      ],
+    });
+  });
+
+  it("returns error on action execution failure", async () => {
+    const { server, getHandler } = createMockServer();
+    registerScrapeMessagingHistory(server);
+
+    mockLauncher();
+    mockInstance({
+      executeAction: vi.fn().mockRejectedValue(new Error("action timed out")),
+    });
+    vi.mocked(discoverInstancePort).mockResolvedValue(55123);
+
+    const handler = getHandler("scrape-messaging-history");
+    const result = await handler({ cdpPort: 9222 });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "Failed to scrape messaging history: action timed out",
+        },
+      ],
+    });
+  });
+
+  it("disconnects launcher after account lookup", async () => {
+    const { server, getHandler } = createMockServer();
+    registerScrapeMessagingHistory(server);
+
+    const { disconnect: launcherDisconnect } = mockLauncher();
+    mockInstance();
+    mockDb();
+    mockRepo();
+    vi.mocked(discoverInstancePort).mockResolvedValue(55123);
+    vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+
+    const handler = getHandler("scrape-messaging-history");
+    await handler({ cdpPort: 9222 });
+
+    expect(launcherDisconnect).toHaveBeenCalledOnce();
+  });
+
+  it("disconnects instance and closes db after success", async () => {
+    const { server, getHandler } = createMockServer();
+    registerScrapeMessagingHistory(server);
+
+    mockLauncher();
+    const { disconnect: instanceDisconnect } = mockInstance();
+    const { close: dbClose } = mockDb();
+    mockRepo();
+    vi.mocked(discoverInstancePort).mockResolvedValue(55123);
+    vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+
+    const handler = getHandler("scrape-messaging-history");
+    await handler({ cdpPort: 9222 });
+
+    expect(instanceDisconnect).toHaveBeenCalledOnce();
+    expect(dbClose).toHaveBeenCalledOnce();
+  });
+
+  it("disconnects instance after error", async () => {
+    const { server, getHandler } = createMockServer();
+    registerScrapeMessagingHistory(server);
+
+    mockLauncher();
+    const { disconnect: instanceDisconnect } = mockInstance({
+      executeAction: vi.fn().mockRejectedValue(new Error("test error")),
+    });
+    vi.mocked(discoverInstancePort).mockResolvedValue(55123);
+
+    const handler = getHandler("scrape-messaging-history");
+    await handler({ cdpPort: 9222 });
+
+    expect(instanceDisconnect).toHaveBeenCalledOnce();
+  });
+
+  it("passes cdpPort to LauncherService and discoverInstancePort", async () => {
+    const { server, getHandler } = createMockServer();
+    registerScrapeMessagingHistory(server);
+
+    setupSuccessPath();
+
+    const handler = getHandler("scrape-messaging-history");
+    await handler({ cdpPort: 4567 });
+
+    expect(LauncherService).toHaveBeenCalledWith(4567);
+    expect(discoverInstancePort).toHaveBeenCalledWith(4567);
+  });
+
+  it("passes discovered port and timeout to InstanceService", async () => {
+    const { server, getHandler } = createMockServer();
+    registerScrapeMessagingHistory(server);
+
+    setupSuccessPath();
+
+    const handler = getHandler("scrape-messaging-history");
+    await handler({ cdpPort: 9222 });
+
+    expect(InstanceService).toHaveBeenCalledWith(55123, { timeout: 300_000 });
+  });
+
+  it("discovers database for the account", async () => {
+    const { server, getHandler } = createMockServer();
+    registerScrapeMessagingHistory(server);
+
+    setupSuccessPath();
+
+    const handler = getHandler("scrape-messaging-history");
+    await handler({ cdpPort: 9222 });
+
+    expect(discoverDatabase).toHaveBeenCalledWith(1);
+  });
+});

--- a/packages/mcp/src/tools/scrape-messaging-history.ts
+++ b/packages/mcp/src/tools/scrape-messaging-history.ts
@@ -1,0 +1,177 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  type Account,
+  DatabaseClient,
+  discoverDatabase,
+  discoverInstancePort,
+  InstanceNotRunningError,
+  InstanceService,
+  LauncherService,
+  LinkedHelperNotRunningError,
+  MessageRepository,
+} from "@lhremote/core";
+import { z } from "zod";
+
+export function registerScrapeMessagingHistory(server: McpServer): void {
+  server.tool(
+    "scrape-messaging-history",
+    "Trigger LinkedHelper to scrape all messaging history from LinkedIn into the local database, then return aggregate stats. This is a long-running operation that may take several minutes.",
+    {
+      cdpPort: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .default(9222)
+        .describe("CDP port (default: 9222)"),
+    },
+    async ({ cdpPort }) => {
+      // Connect to launcher to find running instance
+      const launcher = new LauncherService(cdpPort);
+
+      try {
+        await launcher.connect();
+      } catch (error) {
+        if (error instanceof LinkedHelperNotRunningError) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: "LinkedHelper is not running. Use launch-app first.",
+              },
+            ],
+          };
+        }
+        const message =
+          error instanceof Error ? error.message : String(error);
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: `Failed to connect to LinkedHelper: ${message}`,
+            },
+          ],
+        };
+      }
+
+      let accountId: number;
+      try {
+        const accounts = await launcher.listAccounts();
+        if (accounts.length === 0) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: "No accounts found.",
+              },
+            ],
+          };
+        }
+        if (accounts.length > 1) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: "Multiple accounts found. Cannot determine which instance to use.",
+              },
+            ],
+          };
+        }
+        accountId = (accounts[0] as Account).id;
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : String(error);
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: `Failed to list accounts: ${message}`,
+            },
+          ],
+        };
+      } finally {
+        launcher.disconnect();
+      }
+
+      // Discover instance CDP port
+      const instancePort = await discoverInstancePort(cdpPort);
+      if (instancePort === null) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: "No LinkedHelper instance is running. Use start-instance first.",
+            },
+          ],
+        };
+      }
+
+      // Connect to instance, execute action, then query stats
+      // Use a 5-minute timeout — scraping messaging history is long-running
+      const instance = new InstanceService(instancePort, { timeout: 300_000 });
+      let db: DatabaseClient | null = null;
+
+      try {
+        await instance.connect();
+
+        // Execute the scrape action (may take several minutes)
+        await instance.executeAction("ScrapeMessagingHistory");
+
+        // Query stats from the database
+        const dbPath = discoverDatabase(accountId);
+        db = new DatabaseClient(dbPath);
+        const repo = new MessageRepository(db);
+        const stats = repo.getMessageStats();
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                {
+                  success: true,
+                  actionType: "ScrapeMessagingHistory",
+                  stats,
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      } catch (error) {
+        if (error instanceof InstanceNotRunningError) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: "No LinkedHelper instance is running. Use start-instance first.",
+              },
+            ],
+          };
+        }
+        const message =
+          error instanceof Error ? error.message : String(error);
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: `Failed to scrape messaging history: ${message}`,
+            },
+          ],
+        };
+      } finally {
+        instance.disconnect();
+        db?.close();
+      }
+    },
+  );
+}


### PR DESCRIPTION
## Summary

- Add generic `executeAction(actionName, config)` method to `InstanceService`, refactoring `triggerExtraction` to delegate to it
- Implement `scrape-messaging-history` as both MCP tool and CLI command
- Triggers LinkedHelper's `ScrapeMessagingHistory` action to pull full conversation history from LinkedIn into the local database, then returns aggregate stats

Closes #49

## Test plan

- [x] Unit tests for `InstanceService.executeAction` (action name passed correctly, config serialized, not-connected error)
- [x] Unit tests for MCP tool (16 tests covering success, all error paths, resource cleanup)
- [x] Existing `triggerExtraction` tests still pass (delegates to `executeAction`)
- [x] All 450 tests pass across all packages
- [ ] E2E test with running LinkedHelper instance (local only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)