### PR TITLE
(feat) core: add action execution service

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,6 +23,8 @@ export type {
 
 // Services
 export {
+  ActionExecutionError,
+  type ActionResult,
   AppLaunchError,
   AppNotFoundError,
   AppService,

--- a/packages/core/src/services/errors.test.ts
+++ b/packages/core/src/services/errors.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  ActionExecutionError,
   AppLaunchError,
   AppNotFoundError,
   ExtractionTimeoutError,
@@ -78,6 +79,26 @@ describe("Service errors", () => {
   it("should allow custom message for InstanceNotRunningError", () => {
     const error = new InstanceNotRunningError("LinkedIn target not found");
     expect(error.message).toBe("LinkedIn target not found");
+  });
+
+  it("should set correct name for ActionExecutionError", () => {
+    const error = new ActionExecutionError("MessageToPerson");
+    expect(error.name).toBe("ActionExecutionError");
+    expect(error.actionType).toBe("MessageToPerson");
+    expect(error.message).toContain("MessageToPerson");
+    expect(error).toBeInstanceOf(ServiceError);
+  });
+
+  it("should allow custom message for ActionExecutionError", () => {
+    const error = new ActionExecutionError("InMail", "rate limited");
+    expect(error.message).toBe("rate limited");
+    expect(error.actionType).toBe("InMail");
+  });
+
+  it("should support cause via ErrorOptions for ActionExecutionError", () => {
+    const cause = new TypeError("CDP failed");
+    const error = new ActionExecutionError("InMail", "action failed", { cause });
+    expect(error.cause).toBe(cause);
   });
 
   it("should set correct name for ExtractionTimeoutError", () => {

--- a/packages/core/src/services/errors.ts
+++ b/packages/core/src/services/errors.ts
@@ -80,6 +80,23 @@ export class WrongPortError extends ServiceError {
 }
 
 /**
+ * Thrown when a LinkedHelper action execution fails.
+ */
+export class ActionExecutionError extends ServiceError {
+  /** The action type that was attempted (e.g., 'MessageToPerson'). */
+  readonly actionType: string;
+
+  constructor(actionType: string, message?: string, options?: ErrorOptions) {
+    super(
+      message ?? `Action '${actionType}' failed`,
+      options,
+    );
+    this.name = "ActionExecutionError";
+    this.actionType = actionType;
+  }
+}
+
+/**
  * Thrown when profile extraction times out waiting for data
  * to appear in the database.
  */

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -1,5 +1,5 @@
 export { AppService, type AppServiceOptions } from "./app.js";
-export { InstanceService } from "./instance.js";
+export { InstanceService, type ActionResult } from "./instance.js";
 export {
   startInstanceWithRecovery,
   waitForInstancePort,
@@ -16,6 +16,7 @@ export {
 } from "./status.js";
 export { ProfileService, extractSlug, type VisitAndExtractOptions } from "./profile.js";
 export {
+  ActionExecutionError,
   AppLaunchError,
   AppNotFoundError,
   ExtractionTimeoutError,


### PR DESCRIPTION
## Summary

- Add generic `executeAction(actionName, config)` method to `InstanceService` that calls `executeSingleAction` via CDP on the instance UI target
- Return structured `ActionResult` with `success`, `actionType`, and optional `error` fields
- Add `ActionExecutionError` with `actionType` property and error cause chain preservation
- Refactor `triggerExtraction()` to delegate to `executeAction("SaveCurrentProfile")`
- Export `ActionResult` type and `ActionExecutionError` from core package

## Test plan

- [x] Unit tests verify correct CDP expression is built for action name and config
- [x] Unit tests verify `ActionResult` is returned on success
- [x] Unit tests verify `ActionExecutionError` is thrown on CDP evaluation failure with action type and cause preserved
- [x] Unit tests verify `ServiceError` thrown when not connected
- [x] Error class tests for `ActionExecutionError` name, message, `actionType`, and cause support
- [x] `triggerExtraction` delegation test updated
- [x] All 257 core tests pass, all CI green (macOS, Ubuntu, Windows)

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)