### PR TITLE
(feat) mcp,cli: implement check-replies tool

### DIFF
--- a/packages/cli/src/handlers/check-replies.test.ts
+++ b/packages/cli/src/handlers/check-replies.test.ts
@@ -1,0 +1,261 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return {
+    ...actual,
+    LauncherService: vi.fn(),
+    InstanceService: vi.fn(),
+    DatabaseClient: vi.fn(),
+    MessageRepository: vi.fn(),
+    discoverInstancePort: vi.fn(),
+    discoverDatabase: vi.fn(),
+  };
+});
+
+import {
+  type Account,
+  type ConversationMessages,
+  DatabaseClient,
+  discoverDatabase,
+  discoverInstancePort,
+  InstanceService,
+  LauncherService,
+  MessageRepository,
+} from "@lhremote/core";
+
+import { handleCheckReplies } from "./check-replies.js";
+
+const MOCK_CONVERSATIONS: ConversationMessages[] = [
+  {
+    chatId: 123,
+    personId: 456,
+    personName: "Jane Doe",
+    messages: [
+      {
+        id: 789,
+        type: "MEMBER_TO_MEMBER",
+        text: "Thanks for reaching out!",
+        subject: null,
+        sendAt: "2025-01-15T10:30:00Z",
+        attachmentsCount: 0,
+        senderPersonId: 456,
+        senderFirstName: "Jane",
+        senderLastName: "Doe",
+      },
+    ],
+  },
+];
+
+function mockLauncher(overrides: Record<string, unknown> = {}) {
+  vi.mocked(LauncherService).mockImplementation(function () {
+    return {
+      connect: vi.fn().mockResolvedValue(undefined),
+      disconnect: vi.fn(),
+      listAccounts: vi
+        .fn()
+        .mockResolvedValue([{ id: 1, liId: 1, name: "Alice" } as Account]),
+      ...overrides,
+    } as unknown as LauncherService;
+  });
+}
+
+function mockInstance(overrides: Record<string, unknown> = {}) {
+  vi.mocked(InstanceService).mockImplementation(function () {
+    return {
+      connect: vi.fn().mockResolvedValue(undefined),
+      disconnect: vi.fn(),
+      executeAction: vi.fn().mockResolvedValue(undefined),
+      ...overrides,
+    } as unknown as InstanceService;
+  });
+}
+
+function mockDb() {
+  vi.mocked(DatabaseClient).mockImplementation(function () {
+    return { close: vi.fn(), db: {} } as unknown as DatabaseClient;
+  });
+}
+
+function mockRepo(conversations: ConversationMessages[] = MOCK_CONVERSATIONS) {
+  vi.mocked(MessageRepository).mockImplementation(function () {
+    return {
+      getMessagesSince: vi.fn().mockReturnValue(conversations),
+    } as unknown as MessageRepository;
+  });
+}
+
+function setupSuccessPath() {
+  mockLauncher();
+  mockInstance();
+  mockDb();
+  mockRepo();
+  vi.mocked(discoverInstancePort).mockResolvedValue(55123);
+  vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+}
+
+describe("handleCheckReplies", () => {
+  const originalExitCode = process.exitCode;
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    process.exitCode = undefined;
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-01-15T12:00:00Z"));
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    process.exitCode = originalExitCode;
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  function getStdout(): string {
+    return stdoutSpy.mock.calls
+      .map((call: unknown[]) => String(call[0]))
+      .join("");
+  }
+
+  function getStderr(): string {
+    return stderrSpy.mock.calls
+      .map((call: unknown[]) => String(call[0]))
+      .join("");
+  }
+
+  it("prints JSON with --json", async () => {
+    setupSuccessPath();
+
+    await handleCheckReplies({ json: true });
+
+    expect(process.exitCode).toBeUndefined();
+    const output = JSON.parse(getStdout());
+    expect(output.newMessages).toEqual(MOCK_CONVERSATIONS);
+    expect(output.totalNew).toBe(1);
+    expect(output.checkedAt).toBeDefined();
+  });
+
+  it("prints human-readable output by default", async () => {
+    setupSuccessPath();
+
+    await handleCheckReplies({});
+
+    expect(process.exitCode).toBeUndefined();
+    const output = getStdout();
+    expect(output).toContain("1 new message found:");
+    expect(output).toContain("Jane Doe (person #456, chat #123):");
+    expect(output).toContain("Thanks for reaching out!");
+  });
+
+  it("prints progress to stderr", async () => {
+    setupSuccessPath();
+
+    await handleCheckReplies({});
+
+    const stderr = getStderr();
+    expect(stderr).toContain("Checking for new replies...");
+    expect(stderr).toContain("Done.");
+  });
+
+  it("prints 'No new messages' when empty", async () => {
+    mockLauncher();
+    mockInstance();
+    mockDb();
+    mockRepo([]);
+    vi.mocked(discoverInstancePort).mockResolvedValue(55123);
+    vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+
+    await handleCheckReplies({});
+
+    expect(getStdout()).toContain("No new messages found.");
+  });
+
+  it("uses since parameter when provided", async () => {
+    mockLauncher();
+    mockInstance();
+    mockDb();
+    const getMessagesSince = vi.fn().mockReturnValue([]);
+    vi.mocked(MessageRepository).mockImplementation(function () {
+      return { getMessagesSince } as unknown as MessageRepository;
+    });
+    vi.mocked(discoverInstancePort).mockResolvedValue(55123);
+    vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+
+    await handleCheckReplies({ since: "2025-01-14T00:00:00Z" });
+
+    expect(getMessagesSince).toHaveBeenCalledWith("2025-01-14T00:00:00Z");
+  });
+
+  it("defaults to last 24 hours when since is omitted", async () => {
+    mockLauncher();
+    mockInstance();
+    mockDb();
+    const getMessagesSince = vi.fn().mockReturnValue([]);
+    vi.mocked(MessageRepository).mockImplementation(function () {
+      return { getMessagesSince } as unknown as MessageRepository;
+    });
+    vi.mocked(discoverInstancePort).mockResolvedValue(55123);
+    vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+
+    await handleCheckReplies({});
+
+    expect(getMessagesSince).toHaveBeenCalledWith("2025-01-14T12:00:00.000Z");
+  });
+
+  it("sets exitCode on error", async () => {
+    mockLauncher({
+      listAccounts: vi.fn().mockResolvedValue([]),
+    });
+
+    await handleCheckReplies({});
+
+    expect(process.exitCode).toBe(1);
+    expect(getStderr()).toContain("No accounts found.");
+  });
+
+  it("sets exitCode when no instance running", async () => {
+    mockLauncher();
+    vi.mocked(discoverInstancePort).mockResolvedValue(null);
+
+    await handleCheckReplies({});
+
+    expect(process.exitCode).toBe(1);
+    expect(getStderr()).toContain(
+      "No LinkedHelper instance is running. Use start-instance first.",
+    );
+  });
+
+  it("pluralizes message count correctly", async () => {
+    mockLauncher();
+    mockInstance();
+    mockDb();
+    mockRepo([
+      {
+        chatId: 1,
+        personId: 1,
+        personName: "Alice",
+        messages: [
+          {
+            id: 1, type: "DEFAULT", text: "msg1", subject: null,
+            sendAt: "2025-01-15T10:00:00Z", attachmentsCount: 0,
+            senderPersonId: 1, senderFirstName: "Alice", senderLastName: null,
+          },
+          {
+            id: 2, type: "DEFAULT", text: "msg2", subject: null,
+            sendAt: "2025-01-15T10:05:00Z", attachmentsCount: 0,
+            senderPersonId: 1, senderFirstName: "Alice", senderLastName: null,
+          },
+        ],
+      },
+    ]);
+    vi.mocked(discoverInstancePort).mockResolvedValue(55123);
+    vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+
+    await handleCheckReplies({});
+
+    expect(getStdout()).toContain("2 new messages found:");
+  });
+});

--- a/packages/cli/src/handlers/check-replies.ts
+++ b/packages/cli/src/handlers/check-replies.ts
@@ -1,0 +1,132 @@
+import {
+  type Account,
+  type ConversationMessages,
+  DatabaseClient,
+  discoverDatabase,
+  discoverInstancePort,
+  InstanceService,
+  LauncherService,
+  MessageRepository,
+} from "@lhremote/core";
+
+export async function handleCheckReplies(options: {
+  since?: string;
+  cdpPort?: number;
+  json?: boolean;
+}): Promise<void> {
+  const cdpPort = options.cdpPort ?? 9222;
+  const cutoff =
+    options.since ??
+    new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+
+  // Connect to launcher to find the running account
+  const launcher = new LauncherService(cdpPort);
+
+  let accountId: number;
+  try {
+    await launcher.connect();
+    const accounts = await launcher.listAccounts();
+    if (accounts.length === 0) {
+      process.stderr.write("No accounts found.\n");
+      process.exitCode = 1;
+      return;
+    }
+    if (accounts.length > 1) {
+      process.stderr.write(
+        "Multiple accounts found. Cannot determine which instance to use.\n",
+      );
+      process.exitCode = 1;
+      return;
+    }
+    accountId = (accounts[0] as Account).id;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+    return;
+  } finally {
+    launcher.disconnect();
+  }
+
+  // Discover instance CDP port
+  const instancePort = await discoverInstancePort(cdpPort);
+  if (instancePort === null) {
+    process.stderr.write(
+      "No LinkedHelper instance is running. Use start-instance first.\n",
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  // Connect to instance, execute action, then query new messages
+  const instance = new InstanceService(instancePort, { timeout: 120_000 });
+  let db: DatabaseClient | null = null;
+
+  try {
+    await instance.connect();
+
+    process.stderr.write("Checking for new replies...\n");
+
+    await instance.executeAction("CheckForReplies");
+
+    process.stderr.write("Done.\n");
+
+    // Query messages from the database
+    const dbPath = discoverDatabase(accountId);
+    db = new DatabaseClient(dbPath);
+    const repo = new MessageRepository(db);
+    const conversations = repo.getMessagesSince(cutoff);
+
+    const totalNew = conversations.reduce(
+      (sum, c) => sum + c.messages.length,
+      0,
+    );
+
+    if (options.json) {
+      process.stdout.write(
+        JSON.stringify(
+          {
+            newMessages: conversations,
+            totalNew,
+            checkedAt: new Date().toISOString(),
+          },
+          null,
+          2,
+        ) + "\n",
+      );
+    } else {
+      printReplies(conversations, totalNew);
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+  } finally {
+    instance.disconnect();
+    db?.close();
+  }
+}
+
+function printReplies(
+  conversations: ConversationMessages[],
+  totalNew: number,
+): void {
+  if (totalNew === 0) {
+    process.stdout.write("No new messages found.\n");
+    return;
+  }
+
+  process.stdout.write(
+    `\n${String(totalNew)} new message${totalNew === 1 ? "" : "s"} found:\n`,
+  );
+
+  for (const conv of conversations) {
+    process.stdout.write(
+      `\n${conv.personName} (person #${String(conv.personId)}, chat #${String(conv.chatId)}):\n`,
+    );
+    for (const msg of conv.messages) {
+      const ts = msg.sendAt.replace("T", " ").slice(0, 16);
+      process.stdout.write(`  [${ts}] ${msg.text}\n`);
+    }
+  }
+}

--- a/packages/cli/src/handlers/index.ts
+++ b/packages/cli/src/handlers/index.ts
@@ -1,3 +1,4 @@
+export { handleCheckReplies } from "./check-replies.js";
 export { handleCheckStatus } from "./check-status.js";
 export { handleFindApp } from "./find-app.js";
 export { handleQueryMessages } from "./query-messages.js";

--- a/packages/cli/src/program.test.ts
+++ b/packages/cli/src/program.test.ts
@@ -43,8 +43,9 @@ describe("createProgram", () => {
     expect(commandNames).toContain("query-profile");
     expect(commandNames).toContain("query-messages");
     expect(commandNames).toContain("scrape-messaging-history");
+    expect(commandNames).toContain("check-replies");
     expect(commandNames).toContain("check-status");
-    expect(commandNames).toHaveLength(11);
+    expect(commandNames).toHaveLength(12);
   });
 
   describe("launch-app", () => {

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -3,6 +3,7 @@ import { createRequire } from "node:module";
 import { Command, InvalidArgumentError } from "commander";
 
 import {
+  handleCheckReplies,
   handleCheckStatus,
   handleFindApp,
   handleLaunchApp,
@@ -127,6 +128,14 @@ export function createProgram(): Command {
     .option("--cdp-port <port>", "CDP debugging port", parsePositiveInt)
     .option("--json", "Output as JSON")
     .action(handleScrapeMessagingHistory);
+
+  program
+    .command("check-replies")
+    .description("Check for new message replies from LinkedIn")
+    .option("--since <timestamp>", "Only show replies after this ISO timestamp")
+    .option("--cdp-port <port>", "CDP debugging port", parsePositiveInt)
+    .option("--json", "Output as JSON")
+    .action(handleCheckReplies);
 
   program
     .command("check-status")

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,7 @@ export type {
   Account,
   Chat,
   ChatParticipant,
+  ConversationMessages,
   ConversationThread,
   CurrentPosition,
   Education,

--- a/packages/core/src/services/mcp-claude.e2e.test.ts
+++ b/packages/core/src/services/mcp-claude.e2e.test.ts
@@ -210,5 +210,22 @@ describeE2E("MCP tools via Claude CLI", () => {
       },
       360_000,
     );
+
+    it(
+      "check-replies checks for new replies and returns results",
+      () => {
+        const result = runClaude(
+          "Use the check-replies tool to check for new message replies. " +
+          "Report the raw JSON from the tool response, nothing else.",
+          180_000,
+        );
+
+        expect(result.is_error).toBe(false);
+        expect(result.num_turns).toBeGreaterThanOrEqual(2);
+        // The response should contain reply check results
+        expect(result.result).toMatch(/newMessages|totalNew|checkedAt/i);
+      },
+      240_000,
+    );
   });
 });

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -21,6 +21,7 @@ export type { Account } from "./account.js";
 export type {
   Chat,
   ChatParticipant,
+  ConversationMessages,
   ConversationThread,
   Message,
   MessageStats,

--- a/packages/core/src/types/messaging.ts
+++ b/packages/core/src/types/messaging.ts
@@ -48,3 +48,10 @@ export interface MessageStats {
   earliestMessage: string | null;
   latestMessage: string | null;
 }
+
+export interface ConversationMessages {
+  chatId: number;
+  personId: number;
+  personName: string;
+  messages: Message[];
+}

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -82,7 +82,8 @@ describe("createServer", () => {
     expect(names).toContain("query-profile");
     expect(names).toContain("query-messages");
     expect(names).toContain("scrape-messaging-history");
+    expect(names).toContain("check-replies");
     expect(names).toContain("check-status");
-    expect(names).toHaveLength(11);
+    expect(names).toHaveLength(12);
   });
 });

--- a/packages/mcp/src/tools/check-replies.test.ts
+++ b/packages/mcp/src/tools/check-replies.test.ts
@@ -1,0 +1,475 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return {
+    ...actual,
+    LauncherService: vi.fn(),
+    InstanceService: vi.fn(),
+    DatabaseClient: vi.fn(),
+    MessageRepository: vi.fn(),
+    discoverInstancePort: vi.fn(),
+    discoverDatabase: vi.fn(),
+  };
+});
+
+import {
+  type Account,
+  type ConversationMessages,
+  DatabaseClient,
+  discoverDatabase,
+  discoverInstancePort,
+  InstanceNotRunningError,
+  InstanceService,
+  LauncherService,
+  LinkedHelperNotRunningError,
+  MessageRepository,
+} from "@lhremote/core";
+
+import { registerCheckReplies } from "./check-replies.js";
+import { createMockServer } from "./testing/mock-server.js";
+
+const MOCK_CONVERSATIONS: ConversationMessages[] = [
+  {
+    chatId: 123,
+    personId: 456,
+    personName: "Jane Doe",
+    messages: [
+      {
+        id: 789,
+        type: "MEMBER_TO_MEMBER",
+        text: "Thanks for reaching out!",
+        subject: null,
+        sendAt: "2025-01-15T10:30:00Z",
+        attachmentsCount: 0,
+        senderPersonId: 456,
+        senderFirstName: "Jane",
+        senderLastName: "Doe",
+      },
+    ],
+  },
+  {
+    chatId: 124,
+    personId: 790,
+    personName: "John Smith",
+    messages: [
+      {
+        id: 791,
+        type: "MEMBER_TO_MEMBER",
+        text: "Let's schedule a call",
+        subject: null,
+        sendAt: "2025-01-15T11:00:00Z",
+        attachmentsCount: 0,
+        senderPersonId: 790,
+        senderFirstName: "John",
+        senderLastName: "Smith",
+      },
+      {
+        id: 792,
+        type: "MEMBER_TO_MEMBER",
+        text: "How about Thursday?",
+        subject: null,
+        sendAt: "2025-01-15T11:05:00Z",
+        attachmentsCount: 0,
+        senderPersonId: 790,
+        senderFirstName: "John",
+        senderLastName: "Smith",
+      },
+    ],
+  },
+];
+
+function mockLauncher(overrides: Record<string, unknown> = {}) {
+  const disconnect = vi.fn();
+  vi.mocked(LauncherService).mockImplementation(function () {
+    return {
+      connect: vi.fn().mockResolvedValue(undefined),
+      disconnect,
+      listAccounts: vi
+        .fn()
+        .mockResolvedValue([{ id: 1, liId: 1, name: "Alice" } as Account]),
+      ...overrides,
+    } as unknown as LauncherService;
+  });
+  return { disconnect };
+}
+
+function mockInstance(overrides: Record<string, unknown> = {}) {
+  const disconnect = vi.fn();
+  vi.mocked(InstanceService).mockImplementation(function () {
+    return {
+      connect: vi.fn().mockResolvedValue(undefined),
+      disconnect,
+      executeAction: vi.fn().mockResolvedValue(undefined),
+      ...overrides,
+    } as unknown as InstanceService;
+  });
+  return { disconnect };
+}
+
+function mockDb() {
+  const close = vi.fn();
+  vi.mocked(DatabaseClient).mockImplementation(function () {
+    return { close, db: {} } as unknown as DatabaseClient;
+  });
+  return { close };
+}
+
+function mockRepo(conversations: ConversationMessages[] = MOCK_CONVERSATIONS) {
+  vi.mocked(MessageRepository).mockImplementation(function () {
+    return {
+      getMessagesSince: vi.fn().mockReturnValue(conversations),
+    } as unknown as MessageRepository;
+  });
+}
+
+function setupSuccessPath() {
+  mockLauncher();
+  mockInstance();
+  mockDb();
+  mockRepo();
+  vi.mocked(discoverInstancePort).mockResolvedValue(55123);
+  vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+}
+
+describe("registerCheckReplies", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-01-15T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("registers a tool named check-replies", () => {
+    const { server } = createMockServer();
+    registerCheckReplies(server);
+
+    expect(server.tool).toHaveBeenCalledOnce();
+    expect(server.tool).toHaveBeenCalledWith(
+      "check-replies",
+      expect.any(String),
+      expect.any(Object),
+      expect.any(Function),
+    );
+  });
+
+  it("returns new messages on success", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCheckReplies(server);
+    setupSuccessPath();
+
+    const handler = getHandler("check-replies");
+    const result = await handler({ cdpPort: 9222 });
+
+    const content = (result as { content: { text: string }[] }).content;
+    expect(content[0]).toBeDefined();
+    const parsed = JSON.parse(content[0]?.text ?? "");
+    expect(parsed.newMessages).toEqual(MOCK_CONVERSATIONS);
+    expect(parsed.totalNew).toBe(3);
+    expect(parsed.checkedAt).toBeDefined();
+  });
+
+  it("executes CheckForReplies action", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCheckReplies(server);
+
+    mockLauncher();
+    const executeAction = vi.fn().mockResolvedValue(undefined);
+    mockInstance({ executeAction });
+    mockDb();
+    mockRepo();
+    vi.mocked(discoverInstancePort).mockResolvedValue(55123);
+    vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+
+    const handler = getHandler("check-replies");
+    await handler({ cdpPort: 9222 });
+
+    expect(executeAction).toHaveBeenCalledWith("CheckForReplies");
+  });
+
+  it("uses since parameter when provided", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCheckReplies(server);
+
+    mockLauncher();
+    mockInstance();
+    mockDb();
+    const getMessagesSince = vi.fn().mockReturnValue([]);
+    vi.mocked(MessageRepository).mockImplementation(function () {
+      return { getMessagesSince } as unknown as MessageRepository;
+    });
+    vi.mocked(discoverInstancePort).mockResolvedValue(55123);
+    vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+
+    const handler = getHandler("check-replies");
+    await handler({ since: "2025-01-14T00:00:00Z", cdpPort: 9222 });
+
+    expect(getMessagesSince).toHaveBeenCalledWith("2025-01-14T00:00:00Z");
+  });
+
+  it("defaults to last 24 hours when since is omitted", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCheckReplies(server);
+
+    mockLauncher();
+    mockInstance();
+    mockDb();
+    const getMessagesSince = vi.fn().mockReturnValue([]);
+    vi.mocked(MessageRepository).mockImplementation(function () {
+      return { getMessagesSince } as unknown as MessageRepository;
+    });
+    vi.mocked(discoverInstancePort).mockResolvedValue(55123);
+    vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+
+    const handler = getHandler("check-replies");
+    await handler({ cdpPort: 9222 });
+
+    expect(getMessagesSince).toHaveBeenCalledWith("2025-01-14T12:00:00.000Z");
+  });
+
+  it("returns error when LinkedHelper not running", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCheckReplies(server);
+
+    vi.mocked(LauncherService).mockImplementation(function () {
+      return {
+        connect: vi
+          .fn()
+          .mockRejectedValue(new LinkedHelperNotRunningError(9222)),
+        disconnect: vi.fn(),
+      } as unknown as LauncherService;
+    });
+
+    const handler = getHandler("check-replies");
+    const result = await handler({ cdpPort: 9222 });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "LinkedHelper is not running. Use launch-app first.",
+        },
+      ],
+    });
+  });
+
+  it("returns error when no accounts found", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCheckReplies(server);
+
+    mockLauncher({
+      listAccounts: vi.fn().mockResolvedValue([]),
+    });
+
+    const handler = getHandler("check-replies");
+    const result = await handler({ cdpPort: 9222 });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [{ type: "text", text: "No accounts found." }],
+    });
+  });
+
+  it("returns error when multiple accounts found", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCheckReplies(server);
+
+    mockLauncher({
+      listAccounts: vi.fn().mockResolvedValue([
+        { id: 1, liId: 1, name: "Alice" },
+        { id: 2, liId: 2, name: "Bob" },
+      ]),
+    });
+
+    const handler = getHandler("check-replies");
+    const result = await handler({ cdpPort: 9222 });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "Multiple accounts found. Cannot determine which instance to use.",
+        },
+      ],
+    });
+  });
+
+  it("returns error when no instance is running", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCheckReplies(server);
+
+    mockLauncher();
+    vi.mocked(discoverInstancePort).mockResolvedValue(null);
+
+    const handler = getHandler("check-replies");
+    const result = await handler({ cdpPort: 9222 });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "No LinkedHelper instance is running. Use start-instance first.",
+        },
+      ],
+    });
+  });
+
+  it("returns error when instance connect fails", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCheckReplies(server);
+
+    mockLauncher();
+    vi.mocked(discoverInstancePort).mockResolvedValue(55123);
+    vi.mocked(InstanceService).mockImplementation(function () {
+      return {
+        connect: vi
+          .fn()
+          .mockRejectedValue(
+            new InstanceNotRunningError("LinkedIn webview target not found"),
+          ),
+        disconnect: vi.fn(),
+      } as unknown as InstanceService;
+    });
+
+    const handler = getHandler("check-replies");
+    const result = await handler({ cdpPort: 9222 });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "No LinkedHelper instance is running. Use start-instance first.",
+        },
+      ],
+    });
+  });
+
+  it("returns error on action execution failure", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCheckReplies(server);
+
+    mockLauncher();
+    mockInstance({
+      executeAction: vi.fn().mockRejectedValue(new Error("action timed out")),
+    });
+    vi.mocked(discoverInstancePort).mockResolvedValue(55123);
+
+    const handler = getHandler("check-replies");
+    const result = await handler({ cdpPort: 9222 });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "Failed to check replies: action timed out",
+        },
+      ],
+    });
+  });
+
+  it("disconnects launcher after account lookup", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCheckReplies(server);
+
+    const { disconnect: launcherDisconnect } = mockLauncher();
+    mockInstance();
+    mockDb();
+    mockRepo();
+    vi.mocked(discoverInstancePort).mockResolvedValue(55123);
+    vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+
+    const handler = getHandler("check-replies");
+    await handler({ cdpPort: 9222 });
+
+    expect(launcherDisconnect).toHaveBeenCalledOnce();
+  });
+
+  it("disconnects instance and closes db after success", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCheckReplies(server);
+
+    mockLauncher();
+    const { disconnect: instanceDisconnect } = mockInstance();
+    const { close: dbClose } = mockDb();
+    mockRepo();
+    vi.mocked(discoverInstancePort).mockResolvedValue(55123);
+    vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+
+    const handler = getHandler("check-replies");
+    await handler({ cdpPort: 9222 });
+
+    expect(instanceDisconnect).toHaveBeenCalledOnce();
+    expect(dbClose).toHaveBeenCalledOnce();
+  });
+
+  it("disconnects instance after error", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCheckReplies(server);
+
+    mockLauncher();
+    const { disconnect: instanceDisconnect } = mockInstance({
+      executeAction: vi.fn().mockRejectedValue(new Error("test error")),
+    });
+    vi.mocked(discoverInstancePort).mockResolvedValue(55123);
+
+    const handler = getHandler("check-replies");
+    await handler({ cdpPort: 9222 });
+
+    expect(instanceDisconnect).toHaveBeenCalledOnce();
+  });
+
+  it("passes cdpPort to LauncherService and discoverInstancePort", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCheckReplies(server);
+
+    setupSuccessPath();
+
+    const handler = getHandler("check-replies");
+    await handler({ cdpPort: 4567 });
+
+    expect(LauncherService).toHaveBeenCalledWith(4567);
+    expect(discoverInstancePort).toHaveBeenCalledWith(4567);
+  });
+
+  it("passes discovered port and timeout to InstanceService", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCheckReplies(server);
+
+    setupSuccessPath();
+
+    const handler = getHandler("check-replies");
+    await handler({ cdpPort: 9222 });
+
+    expect(InstanceService).toHaveBeenCalledWith(55123, { timeout: 120_000 });
+  });
+
+  it("returns empty results when no new messages", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCheckReplies(server);
+
+    mockLauncher();
+    mockInstance();
+    mockDb();
+    mockRepo([]);
+    vi.mocked(discoverInstancePort).mockResolvedValue(55123);
+    vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+
+    const handler = getHandler("check-replies");
+    const result = await handler({ cdpPort: 9222 });
+
+    const content = (result as { content: { text: string }[] }).content;
+    expect(content[0]).toBeDefined();
+    const parsed = JSON.parse(content[0]?.text ?? "");
+    expect(parsed.newMessages).toEqual([]);
+    expect(parsed.totalNew).toBe(0);
+  });
+});

--- a/packages/mcp/src/tools/check-replies.ts
+++ b/packages/mcp/src/tools/check-replies.ts
@@ -1,0 +1,190 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  type Account,
+  DatabaseClient,
+  discoverDatabase,
+  discoverInstancePort,
+  InstanceNotRunningError,
+  InstanceService,
+  LauncherService,
+  LinkedHelperNotRunningError,
+  MessageRepository,
+} from "@lhremote/core";
+import { z } from "zod";
+
+export function registerCheckReplies(server: McpServer): void {
+  server.tool(
+    "check-replies",
+    "Trigger LinkedHelper to check for new message replies on LinkedIn, then return any new messages found. If `since` is omitted, returns messages from the last 24 hours.",
+    {
+      since: z
+        .string()
+        .optional()
+        .describe(
+          "ISO timestamp; only return messages after this time. If omitted, returns messages from the last 24 hours",
+        ),
+      cdpPort: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .default(9222)
+        .describe("CDP port (default: 9222)"),
+    },
+    async ({ since, cdpPort }) => {
+      const cutoff =
+        since ?? new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+
+      // Connect to launcher to find running instance
+      const launcher = new LauncherService(cdpPort);
+
+      try {
+        await launcher.connect();
+      } catch (error) {
+        if (error instanceof LinkedHelperNotRunningError) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: "LinkedHelper is not running. Use launch-app first.",
+              },
+            ],
+          };
+        }
+        const message =
+          error instanceof Error ? error.message : String(error);
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: `Failed to connect to LinkedHelper: ${message}`,
+            },
+          ],
+        };
+      }
+
+      let accountId: number;
+      try {
+        const accounts = await launcher.listAccounts();
+        if (accounts.length === 0) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: "No accounts found.",
+              },
+            ],
+          };
+        }
+        if (accounts.length > 1) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: "Multiple accounts found. Cannot determine which instance to use.",
+              },
+            ],
+          };
+        }
+        accountId = (accounts[0] as Account).id;
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : String(error);
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: `Failed to list accounts: ${message}`,
+            },
+          ],
+        };
+      } finally {
+        launcher.disconnect();
+      }
+
+      // Discover instance CDP port
+      const instancePort = await discoverInstancePort(cdpPort);
+      if (instancePort === null) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: "No LinkedHelper instance is running. Use start-instance first.",
+            },
+          ],
+        };
+      }
+
+      // Connect to instance, execute action, then query new messages
+      const instance = new InstanceService(instancePort, { timeout: 120_000 });
+      let db: DatabaseClient | null = null;
+
+      try {
+        await instance.connect();
+
+        // Execute the CheckForReplies action
+        await instance.executeAction("CheckForReplies");
+
+        // Query messages from the database
+        const dbPath = discoverDatabase(accountId);
+        db = new DatabaseClient(dbPath);
+        const repo = new MessageRepository(db);
+        const conversations = repo.getMessagesSince(cutoff);
+
+        const totalNew = conversations.reduce(
+          (sum, c) => sum + c.messages.length,
+          0,
+        );
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                {
+                  newMessages: conversations,
+                  totalNew,
+                  checkedAt: new Date().toISOString(),
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      } catch (error) {
+        if (error instanceof InstanceNotRunningError) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: "No LinkedHelper instance is running. Use start-instance first.",
+              },
+            ],
+          };
+        }
+        const message =
+          error instanceof Error ? error.message : String(error);
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: `Failed to check replies: ${message}`,
+            },
+          ],
+        };
+      } finally {
+        instance.disconnect();
+        db?.close();
+      }
+    },
+  );
+}

--- a/packages/mcp/src/tools/index.ts
+++ b/packages/mcp/src/tools/index.ts
@@ -1,5 +1,6 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
+import { registerCheckReplies } from "./check-replies.js";
 import { registerCheckStatus } from "./check-status.js";
 import { registerFindApp } from "./find-app.js";
 import { registerLaunchApp } from "./launch-app.js";
@@ -23,5 +24,6 @@ export function registerAllTools(server: McpServer): void {
   registerQueryMessages(server);
   registerQueryProfile(server);
   registerScrapeMessagingHistory(server);
+  registerCheckReplies(server);
   registerCheckStatus(server);
 }


### PR DESCRIPTION
## Summary

- Add `ConversationMessages` type and `getMessagesSince()` method to `MessageRepository` for querying messages after a given timestamp, grouped by chat and sender
- Implement `check-replies` MCP tool and CLI command that triggers LinkedHelper's `CheckForReplies` action and returns new messages
- Support optional `--since` ISO timestamp filter (defaults to last 24 hours)

Closes #41

## Test plan

- [x] Unit tests for MCP tool (mock ActionService + MessageRepository)
- [x] Unit tests for CLI handler (mock services, verify stdout/stderr output)
- [x] Integration tests for `getMessagesSince` against fixture database
- [x] Existing test suites updated (tool/command count assertions)
- [x] E2E test with LinkedHelper (local only, requires active license)

🤖 Generated with [Claude Code](https://claude.com/claude-code)