### PR TITLE
(feat) core: add campaign YAML/JSON format

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,6 +42,7 @@
     "devtools-protocol": "^0.0.1577676",
     "get-port": "catalog:",
     "pid-port": "catalog:",
-    "ps-list": "catalog:"
+    "ps-list": "catalog:",
+    "yaml": "catalog:"
   }
 }

--- a/packages/core/src/formats/campaign-format.test.ts
+++ b/packages/core/src/formats/campaign-format.test.ts
@@ -1,0 +1,518 @@
+import { describe, expect, it } from "vitest";
+
+import type { Campaign, CampaignAction } from "../types/index.js";
+import {
+  CampaignFormatError,
+  parseCampaignJson,
+  parseCampaignYaml,
+  serializeCampaignJson,
+  serializeCampaignYaml,
+} from "./campaign-format.js";
+
+const MINIMAL_YAML = `
+version: "1"
+name: "Test Campaign"
+actions:
+  - type: VisitAndExtract
+`;
+
+const FULL_YAML = `
+version: "1"
+name: "Outreach Campaign"
+description: "A test campaign"
+settings:
+  cooldownMs: 30000
+  maxActionsPerRun: 5
+actions:
+  - type: VisitAndExtract
+    config:
+      extractProfile: true
+  - type: MessageToPerson
+    config:
+      messageTemplate: "Hi {firstName}"
+`;
+
+const MOCK_CAMPAIGN: Campaign = {
+  id: 1,
+  name: "Test Campaign",
+  description: "Test description",
+  state: "paused",
+  liAccountId: 1,
+  isPaused: true,
+  isArchived: false,
+  isValid: true,
+  createdAt: "2025-01-15T00:00:00Z",
+};
+
+const MOCK_ACTIONS: CampaignAction[] = [
+  {
+    id: 10,
+    campaignId: 1,
+    name: "Visit & Extract",
+    description: null,
+    config: {
+      id: 100,
+      actionType: "VisitAndExtract",
+      actionSettings: { extractProfile: true },
+      coolDown: 60000,
+      maxActionResultsPerIteration: 10,
+      isDraft: false,
+    },
+    versionId: 1000,
+  },
+  {
+    id: 11,
+    campaignId: 1,
+    name: "Message",
+    description: null,
+    config: {
+      id: 101,
+      actionType: "MessageToPerson",
+      actionSettings: { messageTemplate: "Hi {firstName}" },
+      coolDown: 60000,
+      maxActionResultsPerIteration: 10,
+      isDraft: false,
+    },
+    versionId: 1001,
+  },
+];
+
+describe("parseCampaignYaml", () => {
+  it("parses minimal valid YAML", () => {
+    const config = parseCampaignYaml(MINIMAL_YAML);
+
+    expect(config.name).toBe("Test Campaign");
+    expect(config.description).toBeUndefined();
+    expect(config.actions).toHaveLength(1);
+    expect(config.actions[0]?.actionType).toBe("VisitAndExtract");
+  });
+
+  it("parses full YAML with settings and description", () => {
+    const config = parseCampaignYaml(FULL_YAML);
+
+    expect(config.name).toBe("Outreach Campaign");
+    expect(config.description).toBe("A test campaign");
+    expect(config.actions).toHaveLength(2);
+    expect(config.actions[0]?.actionType).toBe("VisitAndExtract");
+    expect(config.actions[0]?.actionSettings).toEqual({ extractProfile: true });
+    expect(config.actions[1]?.actionType).toBe("MessageToPerson");
+    expect(config.actions[1]?.actionSettings).toEqual({
+      messageTemplate: "Hi {firstName}",
+    });
+  });
+
+  it("applies campaign-level settings as action defaults", () => {
+    const config = parseCampaignYaml(FULL_YAML);
+
+    expect(config.actions[0]?.coolDown).toBe(30000);
+    expect(config.actions[0]?.maxActionResultsPerIteration).toBe(5);
+    expect(config.actions[1]?.coolDown).toBe(30000);
+    expect(config.actions[1]?.maxActionResultsPerIteration).toBe(5);
+  });
+
+  it("allows per-action overrides of settings", () => {
+    const yaml = `
+version: "1"
+name: "Test"
+settings:
+  cooldownMs: 30000
+  maxActionsPerRun: 5
+actions:
+  - type: VisitAndExtract
+    cooldownMs: 10000
+    maxActionsPerRun: 20
+`;
+    const config = parseCampaignYaml(yaml);
+
+    expect(config.actions[0]?.coolDown).toBe(10000);
+    expect(config.actions[0]?.maxActionResultsPerIteration).toBe(20);
+  });
+
+  it("derives action name from type", () => {
+    const config = parseCampaignYaml(MINIMAL_YAML);
+
+    expect(config.actions[0]?.name).toBe("VisitAndExtract");
+  });
+
+  it("does not set coolDown/maxActionResultsPerIteration when no settings", () => {
+    const config = parseCampaignYaml(MINIMAL_YAML);
+
+    expect(config.actions[0]?.coolDown).toBeUndefined();
+    expect(config.actions[0]?.maxActionResultsPerIteration).toBeUndefined();
+  });
+
+  it("throws CampaignFormatError for missing version", () => {
+    const yaml = `
+name: "Test"
+actions:
+  - type: VisitAndExtract
+`;
+    expect(() => parseCampaignYaml(yaml)).toThrow(CampaignFormatError);
+    expect(() => parseCampaignYaml(yaml)).toThrow("Missing required field: version");
+  });
+
+  it("throws CampaignFormatError for wrong version", () => {
+    const yaml = `
+version: "2"
+name: "Test"
+actions:
+  - type: VisitAndExtract
+`;
+    expect(() => parseCampaignYaml(yaml)).toThrow(CampaignFormatError);
+    expect(() => parseCampaignYaml(yaml)).toThrow("Unsupported version: 2");
+  });
+
+  it("throws CampaignFormatError for missing name", () => {
+    const yaml = `
+version: "1"
+actions:
+  - type: VisitAndExtract
+`;
+    expect(() => parseCampaignYaml(yaml)).toThrow(CampaignFormatError);
+    expect(() => parseCampaignYaml(yaml)).toThrow("Missing or empty required field: name");
+  });
+
+  it("throws CampaignFormatError for empty name", () => {
+    const yaml = `
+version: "1"
+name: ""
+actions:
+  - type: VisitAndExtract
+`;
+    expect(() => parseCampaignYaml(yaml)).toThrow(CampaignFormatError);
+    expect(() => parseCampaignYaml(yaml)).toThrow("Missing or empty required field: name");
+  });
+
+  it("throws CampaignFormatError for missing actions", () => {
+    const yaml = `
+version: "1"
+name: "Test"
+`;
+    expect(() => parseCampaignYaml(yaml)).toThrow(CampaignFormatError);
+    expect(() => parseCampaignYaml(yaml)).toThrow("Missing required field: actions");
+  });
+
+  it("throws CampaignFormatError for non-array actions", () => {
+    const yaml = `
+version: "1"
+name: "Test"
+actions: "visit"
+`;
+    expect(() => parseCampaignYaml(yaml)).toThrow(CampaignFormatError);
+    expect(() => parseCampaignYaml(yaml)).toThrow("Invalid field: actions must be an array");
+  });
+
+  it("throws CampaignFormatError for non-object settings", () => {
+    const yaml = `
+version: "1"
+name: "Test"
+settings: "fast"
+actions:
+  - type: VisitAndExtract
+`;
+    expect(() => parseCampaignYaml(yaml)).toThrow(CampaignFormatError);
+    expect(() => parseCampaignYaml(yaml)).toThrow(
+      "Invalid field: settings must be an object",
+    );
+  });
+
+  it("throws CampaignFormatError for array settings", () => {
+    const json = JSON.stringify({
+      version: "1",
+      name: "Test",
+      settings: [1, 2, 3],
+      actions: [{ type: "VisitAndExtract" }],
+    });
+    expect(() => parseCampaignJson(json)).toThrow(CampaignFormatError);
+    expect(() => parseCampaignJson(json)).toThrow(
+      "Invalid field: settings must be an object",
+    );
+  });
+
+  it("ignores non-numeric cooldownMs in settings", () => {
+    const json = JSON.stringify({
+      version: "1",
+      name: "Test",
+      settings: { cooldownMs: null, maxActionsPerRun: 5 },
+      actions: [{ type: "VisitAndExtract" }],
+    });
+    const config = parseCampaignJson(json);
+    expect(config.actions[0]?.coolDown).toBeUndefined();
+    expect(config.actions[0]?.maxActionResultsPerIteration).toBe(5);
+  });
+
+  it("ignores NaN and Infinity in settings via YAML", () => {
+    const yaml = `
+version: "1"
+name: "Test"
+settings:
+  cooldownMs: .nan
+  maxActionsPerRun: .inf
+actions:
+  - type: VisitAndExtract
+`;
+    const config = parseCampaignYaml(yaml);
+    expect(config.actions[0]?.coolDown).toBeUndefined();
+    expect(config.actions[0]?.maxActionResultsPerIteration).toBeUndefined();
+  });
+
+  it("ignores array config in actions", () => {
+    const json = JSON.stringify({
+      version: "1",
+      name: "Test",
+      actions: [{ type: "VisitAndExtract", config: [1, 2, 3] }],
+    });
+    const config = parseCampaignJson(json);
+    expect(config.actions[0]?.actionSettings).toBeUndefined();
+  });
+
+  it("throws CampaignFormatError for empty actions array", () => {
+    const yaml = `
+version: "1"
+name: "Test"
+actions: []
+`;
+    expect(() => parseCampaignYaml(yaml)).toThrow(CampaignFormatError);
+    expect(() => parseCampaignYaml(yaml)).toThrow("Actions array must not be empty");
+  });
+
+  it("throws CampaignFormatError for action without type", () => {
+    const yaml = `
+version: "1"
+name: "Test"
+actions:
+  - config:
+      extractProfile: true
+`;
+    expect(() => parseCampaignYaml(yaml)).toThrow(CampaignFormatError);
+    expect(() => parseCampaignYaml(yaml)).toThrow(
+      "Action at index 0 is missing required field: type",
+    );
+  });
+
+  it("throws CampaignFormatError for invalid YAML syntax", () => {
+    expect(() => parseCampaignYaml("{{invalid")).toThrow(CampaignFormatError);
+    expect(() => parseCampaignYaml("{{invalid")).toThrow("Invalid YAML");
+  });
+
+  it("throws CampaignFormatError for non-object document", () => {
+    expect(() => parseCampaignYaml("just a string")).toThrow(CampaignFormatError);
+    expect(() => parseCampaignYaml("just a string")).toThrow(
+      "Campaign document must be an object",
+    );
+  });
+});
+
+describe("parseCampaignJson", () => {
+  it("parses valid JSON", () => {
+    const json = JSON.stringify({
+      version: "1",
+      name: "Test Campaign",
+      actions: [{ type: "VisitAndExtract" }],
+    });
+    const config = parseCampaignJson(json);
+
+    expect(config.name).toBe("Test Campaign");
+    expect(config.actions).toHaveLength(1);
+    expect(config.actions[0]?.actionType).toBe("VisitAndExtract");
+  });
+
+  it("throws CampaignFormatError for invalid JSON syntax", () => {
+    expect(() => parseCampaignJson("{invalid}")).toThrow(CampaignFormatError);
+    expect(() => parseCampaignJson("{invalid}")).toThrow("Invalid JSON");
+  });
+
+  it("throws CampaignFormatError for invalid document structure", () => {
+    expect(() => parseCampaignJson('"just a string"')).toThrow(CampaignFormatError);
+  });
+});
+
+describe("serializeCampaignYaml", () => {
+  it("serializes campaign with uniform settings to campaign-level", () => {
+    const yaml = serializeCampaignYaml(MOCK_CAMPAIGN, MOCK_ACTIONS);
+
+    expect(yaml).toContain("version:");
+    expect(yaml).toContain('name: Test Campaign');
+    expect(yaml).toContain("description: Test description");
+    expect(yaml).toContain("cooldownMs: 60000");
+    expect(yaml).toContain("maxActionsPerRun: 10");
+    expect(yaml).toContain("type: VisitAndExtract");
+    expect(yaml).toContain("type: MessageToPerson");
+  });
+
+  it("serializes campaign with varied settings as per-action overrides", () => {
+    const action0 = MOCK_ACTIONS[0] as CampaignAction;
+    const action1 = MOCK_ACTIONS[1] as CampaignAction;
+    const variedActions: CampaignAction[] = [
+      {
+        ...action0,
+        config: { ...action0.config, coolDown: 30000 },
+      },
+      {
+        ...action1,
+        config: { ...action1.config, coolDown: 60000 },
+      },
+    ];
+    const yaml = serializeCampaignYaml(MOCK_CAMPAIGN, variedActions);
+
+    // cooldownMs should NOT be at campaign-level settings since they differ
+    // but maxActionsPerRun is still uniform so should be in settings
+    expect(yaml).toContain("maxActionsPerRun: 10");
+    // per-action cooldownMs should be present
+    expect(yaml).toContain("cooldownMs: 30000");
+    expect(yaml).toContain("cooldownMs: 60000");
+  });
+
+  it("includes description when non-null", () => {
+    const yaml = serializeCampaignYaml(MOCK_CAMPAIGN, MOCK_ACTIONS);
+
+    expect(yaml).toContain("description: Test description");
+  });
+
+  it("omits description when null", () => {
+    const campaign = { ...MOCK_CAMPAIGN, description: null };
+    const yaml = serializeCampaignYaml(campaign, MOCK_ACTIONS);
+
+    expect(yaml).not.toContain("description:");
+  });
+
+  it("omits empty actionSettings from config", () => {
+    const action0 = MOCK_ACTIONS[0] as CampaignAction;
+    const actions: CampaignAction[] = [
+      {
+        ...action0,
+        config: { ...action0.config, actionSettings: {} },
+      },
+    ];
+    const yaml = serializeCampaignYaml(MOCK_CAMPAIGN, actions);
+
+    expect(yaml).not.toContain("config:");
+  });
+
+  it("includes non-empty actionSettings as config", () => {
+    const yaml = serializeCampaignYaml(MOCK_CAMPAIGN, MOCK_ACTIONS);
+
+    expect(yaml).toContain("extractProfile: true");
+    expect(yaml).toContain("messageTemplate:");
+  });
+});
+
+describe("serializeCampaignJson", () => {
+  it("serializes to pretty-printed JSON", () => {
+    const json = serializeCampaignJson(MOCK_CAMPAIGN, MOCK_ACTIONS);
+
+    expect(() => JSON.parse(json)).not.toThrow();
+    const doc = JSON.parse(json) as Record<string, unknown>;
+    expect(doc["version"]).toBe("1");
+    expect(doc["name"]).toBe("Test Campaign");
+  });
+
+  it("produces valid JSON that round-trips through parseCampaignJson", () => {
+    const json = serializeCampaignJson(MOCK_CAMPAIGN, MOCK_ACTIONS);
+    const config = parseCampaignJson(json);
+
+    expect(config.name).toBe("Test Campaign");
+    expect(config.description).toBe("Test description");
+    expect(config.actions).toHaveLength(2);
+    expect(config.actions[0]?.actionType).toBe("VisitAndExtract");
+    expect(config.actions[1]?.actionType).toBe("MessageToPerson");
+  });
+});
+
+describe("round-trip", () => {
+  it("YAML: serialize → parse preserves campaign data", () => {
+    const yaml = serializeCampaignYaml(MOCK_CAMPAIGN, MOCK_ACTIONS);
+    const config = parseCampaignYaml(yaml);
+
+    expect(config.name).toBe("Test Campaign");
+    expect(config.description).toBe("Test description");
+    expect(config.actions).toHaveLength(2);
+    expect(config.actions[0]?.actionType).toBe("VisitAndExtract");
+    expect(config.actions[0]?.actionSettings).toEqual({ extractProfile: true });
+    expect(config.actions[0]?.coolDown).toBe(60000);
+    expect(config.actions[0]?.maxActionResultsPerIteration).toBe(10);
+    expect(config.actions[1]?.actionType).toBe("MessageToPerson");
+    expect(config.actions[1]?.actionSettings).toEqual({
+      messageTemplate: "Hi {firstName}",
+    });
+  });
+
+  it("JSON: serialize → parse preserves campaign data", () => {
+    const json = serializeCampaignJson(MOCK_CAMPAIGN, MOCK_ACTIONS);
+    const config = parseCampaignJson(json);
+
+    expect(config.name).toBe("Test Campaign");
+    expect(config.description).toBe("Test description");
+    expect(config.actions).toHaveLength(2);
+    expect(config.actions[0]?.actionType).toBe("VisitAndExtract");
+    expect(config.actions[0]?.actionSettings).toEqual({ extractProfile: true });
+    expect(config.actions[1]?.actionType).toBe("MessageToPerson");
+  });
+
+  it("YAML: serialize → parse preserves varied per-action settings", () => {
+    const action0 = MOCK_ACTIONS[0] as CampaignAction;
+    const action1 = MOCK_ACTIONS[1] as CampaignAction;
+    const variedActions: CampaignAction[] = [
+      {
+        ...action0,
+        config: { ...action0.config, coolDown: 30000, maxActionResultsPerIteration: 5 },
+      },
+      {
+        ...action1,
+        config: { ...action1.config, coolDown: 60000, maxActionResultsPerIteration: 20 },
+      },
+    ];
+    const yaml = serializeCampaignYaml(MOCK_CAMPAIGN, variedActions);
+    const config = parseCampaignYaml(yaml);
+
+    expect(config.actions[0]?.coolDown).toBe(30000);
+    expect(config.actions[0]?.maxActionResultsPerIteration).toBe(5);
+    expect(config.actions[1]?.coolDown).toBe(60000);
+    expect(config.actions[1]?.maxActionResultsPerIteration).toBe(20);
+  });
+
+  it("parse → serialize → parse produces identical config", () => {
+    const config1 = parseCampaignYaml(FULL_YAML);
+
+    // Create a mock campaign and actions from parsed config to simulate DB state
+    const campaign: Campaign = {
+      id: 1,
+      name: config1.name,
+      description: config1.description ?? null,
+      state: "active",
+      liAccountId: 1,
+      isPaused: false,
+      isArchived: false,
+      isValid: true,
+      createdAt: "2025-01-15T00:00:00Z",
+    };
+    const actions: CampaignAction[] = config1.actions.map((a, i) => ({
+      id: i + 1,
+      campaignId: 1,
+      name: a.name,
+      description: null,
+      config: {
+        id: i + 100,
+        actionType: a.actionType,
+        actionSettings: a.actionSettings ?? {},
+        coolDown: a.coolDown ?? 60000,
+        maxActionResultsPerIteration: a.maxActionResultsPerIteration ?? 10,
+        isDraft: false,
+      },
+      versionId: i + 1000,
+    }));
+
+    const yaml = serializeCampaignYaml(campaign, actions);
+    const config2 = parseCampaignYaml(yaml);
+
+    expect(config2.name).toBe(config1.name);
+    expect(config2.description).toBe(config1.description);
+    expect(config2.actions).toHaveLength(config1.actions.length);
+    for (let i = 0; i < config1.actions.length; i++) {
+      expect(config2.actions[i]?.actionType).toBe(config1.actions[i]?.actionType);
+      expect(config2.actions[i]?.actionSettings).toEqual(
+        config1.actions[i]?.actionSettings,
+      );
+    }
+  });
+});

--- a/packages/core/src/formats/campaign-format.ts
+++ b/packages/core/src/formats/campaign-format.ts
@@ -1,0 +1,332 @@
+import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
+
+import type {
+  Campaign,
+  CampaignAction,
+  CampaignActionConfig,
+  CampaignConfig,
+} from "../types/index.js";
+
+/** Current version of the campaign document format. */
+const CURRENT_VERSION = "1";
+
+/**
+ * Campaign document as it appears in YAML/JSON.
+ *
+ * This is the portable serialization format — not used at runtime.
+ * It maps to/from `CampaignConfig` for import and
+ * `Campaign` + `CampaignAction[]` for export.
+ */
+interface CampaignDocument {
+  version: string;
+  name: string;
+  description?: string;
+  settings?: CampaignDocumentSettings;
+  actions: CampaignDocumentAction[];
+}
+
+interface CampaignDocumentSettings {
+  cooldownMs?: number;
+  maxActionsPerRun?: number;
+}
+
+interface CampaignDocumentAction {
+  type: string;
+  cooldownMs?: number;
+  maxActionsPerRun?: number;
+  config?: Record<string, unknown>;
+}
+
+/**
+ * Thrown when a campaign document fails structural validation.
+ */
+export class CampaignFormatError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "CampaignFormatError";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Parse
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a YAML string into a CampaignConfig.
+ *
+ * @throws {CampaignFormatError} if the YAML is malformed or the document
+ *   fails structural validation.
+ */
+export function parseCampaignYaml(yamlString: string): CampaignConfig {
+  let doc: unknown;
+  try {
+    doc = parseYaml(yamlString);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new CampaignFormatError(`Invalid YAML: ${message}`);
+  }
+  return parseCampaignDocument(doc);
+}
+
+/**
+ * Parse a JSON string into a CampaignConfig.
+ *
+ * @throws {CampaignFormatError} if the JSON is malformed or the document
+ *   fails structural validation.
+ */
+export function parseCampaignJson(jsonString: string): CampaignConfig {
+  let doc: unknown;
+  try {
+    doc = JSON.parse(jsonString) as unknown;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new CampaignFormatError(`Invalid JSON: ${message}`);
+  }
+  return parseCampaignDocument(doc);
+}
+
+// ---------------------------------------------------------------------------
+// Serialize
+// ---------------------------------------------------------------------------
+
+/**
+ * Serialize a campaign and its actions to a YAML string.
+ */
+export function serializeCampaignYaml(
+  campaign: Campaign,
+  actions: CampaignAction[],
+): string {
+  const doc = toCampaignDocument(campaign, actions);
+  return stringifyYaml(doc);
+}
+
+/**
+ * Serialize a campaign and its actions to a JSON string.
+ */
+export function serializeCampaignJson(
+  campaign: Campaign,
+  actions: CampaignAction[],
+): string {
+  const doc = toCampaignDocument(campaign, actions);
+  return JSON.stringify(doc, null, 2) + "\n";
+}
+
+// ---------------------------------------------------------------------------
+// Internal: parse
+// ---------------------------------------------------------------------------
+
+function parseCampaignDocument(doc: unknown): CampaignConfig {
+  if (doc === null || typeof doc !== "object") {
+    throw new CampaignFormatError("Campaign document must be an object");
+  }
+
+  const obj = doc as Record<string, unknown>;
+
+  // Version
+  if (!("version" in obj) || obj["version"] === undefined) {
+    throw new CampaignFormatError("Missing required field: version");
+  }
+  if (String(obj["version"]) !== CURRENT_VERSION) {
+    throw new CampaignFormatError(
+      `Unsupported version: ${String(obj["version"])} (expected ${CURRENT_VERSION})`,
+    );
+  }
+
+  // Name
+  if (!("name" in obj) || typeof obj["name"] !== "string" || obj["name"].trim() === "") {
+    throw new CampaignFormatError("Missing or empty required field: name");
+  }
+  const name = obj["name"].trim();
+
+  // Description
+  const description =
+    "description" in obj && typeof obj["description"] === "string"
+      ? obj["description"]
+      : undefined;
+
+  // Settings (campaign-level defaults)
+  const settings = parseDocumentSettings(obj["settings"]);
+
+  // Actions
+  if (!("actions" in obj) || obj["actions"] === undefined) {
+    throw new CampaignFormatError("Missing required field: actions");
+  }
+  if (!Array.isArray(obj["actions"])) {
+    throw new CampaignFormatError("Invalid field: actions must be an array");
+  }
+  if (obj["actions"].length === 0) {
+    throw new CampaignFormatError("Actions array must not be empty");
+  }
+
+  const actions: CampaignActionConfig[] = (obj["actions"] as unknown[]).map(
+    (raw, index) => parseDocumentAction(raw, index, settings),
+  );
+
+  const config: CampaignConfig = { name, actions };
+  if (description !== undefined) {
+    config.description = description;
+  }
+  return config;
+}
+
+function parseDocumentSettings(
+  raw: unknown,
+): CampaignDocumentSettings {
+  if (raw === null || raw === undefined) {
+    return {};
+  }
+
+  if (Array.isArray(raw) || typeof raw !== "object") {
+    throw new CampaignFormatError("Invalid field: settings must be an object");
+  }
+
+  const obj = raw as Record<string, unknown>;
+  const settings: CampaignDocumentSettings = {};
+
+  if ("cooldownMs" in obj && typeof obj["cooldownMs"] === "number" && Number.isFinite(obj["cooldownMs"])) {
+    settings.cooldownMs = obj["cooldownMs"];
+  }
+  if ("maxActionsPerRun" in obj && typeof obj["maxActionsPerRun"] === "number" && Number.isFinite(obj["maxActionsPerRun"])) {
+    settings.maxActionsPerRun = obj["maxActionsPerRun"];
+  }
+
+  return settings;
+}
+
+function parseDocumentAction(
+  raw: unknown,
+  index: number,
+  defaults: CampaignDocumentSettings,
+): CampaignActionConfig {
+  if (raw === null || typeof raw !== "object") {
+    throw new CampaignFormatError(
+      `Action at index ${String(index)} must be an object`,
+    );
+  }
+
+  const obj = raw as Record<string, unknown>;
+
+  if (!("type" in obj) || typeof obj["type"] !== "string" || obj["type"].trim() === "") {
+    throw new CampaignFormatError(
+      `Action at index ${String(index)} is missing required field: type`,
+    );
+  }
+
+  const actionType = obj["type"].trim();
+  const actionSettings =
+    "config" in obj && obj["config"] !== null && typeof obj["config"] === "object" && !Array.isArray(obj["config"])
+      ? (obj["config"] as Record<string, unknown>)
+      : undefined;
+
+  const action: CampaignActionConfig = {
+    name: actionType,
+    actionType,
+  };
+
+  if (actionSettings !== undefined) {
+    action.actionSettings = actionSettings;
+  }
+
+  // Apply coolDown: per-action override > campaign-level default
+  const coolDown = getFiniteNumberField(obj, "cooldownMs") ?? defaults.cooldownMs;
+  if (coolDown !== undefined) {
+    action.coolDown = coolDown;
+  }
+
+  // Apply maxActionResultsPerIteration: per-action > campaign-level
+  const maxActions =
+    getFiniteNumberField(obj, "maxActionsPerRun") ?? defaults.maxActionsPerRun;
+  if (maxActions !== undefined) {
+    action.maxActionResultsPerIteration = maxActions;
+  }
+
+  return action;
+}
+
+function getFiniteNumberField(
+  obj: Record<string, unknown>,
+  key: string,
+): number | undefined {
+  if (key in obj && typeof obj[key] === "number" && Number.isFinite(obj[key])) {
+    return obj[key];
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Internal: serialize
+// ---------------------------------------------------------------------------
+
+function toCampaignDocument(
+  campaign: Campaign,
+  actions: CampaignAction[],
+): CampaignDocument {
+  // Extract common settings first so we know what goes at campaign-level
+  const commonSettings = extractCommonSettings(actions);
+
+  const docActions: CampaignDocumentAction[] = actions.map((a) => {
+    const docAction: CampaignDocumentAction = { type: a.config.actionType };
+    const settings = a.config.actionSettings;
+
+    if (settings !== undefined && Object.keys(settings).length > 0) {
+      docAction.config = settings;
+    }
+
+    // Emit per-action settings when they differ from campaign-level defaults
+    const coolDown = a.config.coolDown;
+    if (commonSettings?.cooldownMs === undefined && Number.isFinite(coolDown)) {
+      docAction.cooldownMs = coolDown;
+    }
+    const maxResults = a.config.maxActionResultsPerIteration;
+    if (commonSettings?.maxActionsPerRun === undefined && Number.isFinite(maxResults)) {
+      docAction.maxActionsPerRun = maxResults;
+    }
+
+    return docAction;
+  });
+
+  const doc: CampaignDocument = {
+    version: CURRENT_VERSION,
+    name: campaign.name,
+    actions: docActions,
+  };
+
+  if (campaign.description !== null) {
+    doc.description = campaign.description;
+  }
+
+  if (commonSettings !== undefined) {
+    doc.settings = commonSettings;
+  }
+
+  return doc;
+}
+
+function extractCommonSettings(
+  actions: CampaignAction[],
+): CampaignDocumentSettings | undefined {
+  if (actions.length === 0) return undefined;
+
+  const first = actions[0];
+  if (first === undefined) return undefined;
+
+  const coolDown = first.config.coolDown;
+  const maxResults = first.config.maxActionResultsPerIteration;
+
+  const allSameCoolDown = actions.every((a) => a.config.coolDown === coolDown);
+  const allSameMaxResults = actions.every(
+    (a) => a.config.maxActionResultsPerIteration === maxResults,
+  );
+
+  if (!allSameCoolDown && !allSameMaxResults) return undefined;
+
+  const settings: CampaignDocumentSettings = {};
+  if (allSameCoolDown) {
+    settings.cooldownMs = coolDown;
+  }
+  if (allSameMaxResults) {
+    settings.maxActionsPerRun = maxResults;
+  }
+
+  return settings;
+}

--- a/packages/core/src/formats/index.ts
+++ b/packages/core/src/formats/index.ts
@@ -1,0 +1,7 @@
+export {
+  CampaignFormatError,
+  parseCampaignJson,
+  parseCampaignYaml,
+  serializeCampaignJson,
+  serializeCampaignYaml,
+} from "./campaign-format.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -83,6 +83,15 @@ export {
   ProfileRepository,
 } from "./db/index.js";
 
+// Formats
+export {
+  CampaignFormatError,
+  parseCampaignJson,
+  parseCampaignYaml,
+  serializeCampaignJson,
+  serializeCampaignYaml,
+} from "./formats/index.js";
+
 // Errors (DB + CDP errors can propagate through the service layer)
 export {
   CampaignNotFoundError,

--- a/packages/core/src/types/campaign.ts
+++ b/packages/core/src/types/campaign.ts
@@ -109,6 +109,8 @@ export interface GetResultsOptions {
 export interface CampaignConfig {
   /** Campaign name. */
   name: string;
+  /** Optional description. */
+  description?: string;
   /** LinkedIn account ID (default: 1). */
   liAccountId?: number;
   /** Actions to include in the campaign. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,6 +36,9 @@ catalogs:
     vitest:
       specifier: ^4.0.18
       version: 4.0.18
+    yaml:
+      specifier: ^2.7.1
+      version: 2.8.2
     zod:
       specifier: ^4.3.6
       version: 4.3.6
@@ -64,7 +67,7 @@ importers:
         version: 8.54.0(eslint@9.39.2)(typescript@5.9.3)
       vitest:
         specifier: ^4.0.18
-        version: 4.0.18(@types/node@22.19.7)
+        version: 4.0.18(@types/node@22.19.7)(yaml@2.8.2)
 
   packages/cli:
     dependencies:
@@ -86,7 +89,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@types/node@22.19.7)
+        version: 4.0.18(@types/node@22.19.7)(yaml@2.8.2)
 
   packages/core:
     dependencies:
@@ -102,6 +105,9 @@ importers:
       ps-list:
         specifier: 'catalog:'
         version: 9.0.0
+      yaml:
+        specifier: 'catalog:'
+        version: 2.8.2
     devDependencies:
       '@types/node':
         specifier: 'catalog:'
@@ -117,7 +123,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@types/node@22.19.7)
+        version: 4.0.18(@types/node@22.19.7)(yaml@2.8.2)
 
   packages/lhremote:
     dependencies:
@@ -139,7 +145,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@types/node@22.19.7)
+        version: 4.0.18(@types/node@22.19.7)(yaml@2.8.2)
 
   packages/mcp:
     dependencies:
@@ -164,7 +170,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: 'catalog:'
-        version: 4.0.18(@types/node@22.19.7)
+        version: 4.0.18(@types/node@22.19.7)(yaml@2.8.2)
 
 packages:
 
@@ -1539,6 +1545,11 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  yaml@2.8.2:
+    resolution: {integrity: sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -1916,13 +1927,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@22.19.7))':
+  '@vitest/mocker@4.0.18(vite@7.3.1(@types/node@22.19.7)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 4.0.18
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@22.19.7)
+      vite: 7.3.1(@types/node@22.19.7)(yaml@2.8.2)
 
   '@vitest/pretty-format@4.0.18':
     dependencies:
@@ -2771,7 +2782,7 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite@7.3.1(@types/node@22.19.7):
+  vite@7.3.1(@types/node@22.19.7)(yaml@2.8.2):
     dependencies:
       esbuild: 0.27.2
       fdir: 6.5.0(picomatch@4.0.3)
@@ -2782,11 +2793,12 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.19.7
       fsevents: 2.3.3
+      yaml: 2.8.2
 
-  vitest@4.0.18(@types/node@22.19.7):
+  vitest@4.0.18(@types/node@22.19.7)(yaml@2.8.2):
     dependencies:
       '@vitest/expect': 4.0.18
-      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@22.19.7))
+      '@vitest/mocker': 4.0.18(vite@7.3.1(@types/node@22.19.7)(yaml@2.8.2))
       '@vitest/pretty-format': 4.0.18
       '@vitest/runner': 4.0.18
       '@vitest/snapshot': 4.0.18
@@ -2803,7 +2815,7 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.0.3
-      vite: 7.3.1(@types/node@22.19.7)
+      vite: 7.3.1(@types/node@22.19.7)(yaml@2.8.2)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.7
@@ -2832,6 +2844,8 @@ snapshots:
   word-wrap@1.2.5: {}
 
   wrappy@1.0.2: {}
+
+  yaml@2.8.2: {}
 
   yocto-queue@0.1.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,3 +16,4 @@ catalog:
   "@modelcontextprotocol/sdk": "^1.25.3"
   zod: "^4.3.6"
   commander: "^14.0.3"
+  yaml: "^2.7.1"


### PR DESCRIPTION
## Summary
- Add portable YAML/JSON serialization format for campaigns (`src/formats/`)
- Parse functions (`parseCampaignYaml`, `parseCampaignJson`) convert document format to `CampaignConfig` with structural validation
- Serialize functions (`serializeCampaignYaml`, `serializeCampaignJson`) convert `Campaign` + `CampaignAction[]` back to document format, extracting common settings to campaign-level
- Add `yaml` v2 dependency (ESM-native, TypeScript types)
- Add optional `description` field to `CampaignConfig` type

## Test plan
- [x] 29 new unit tests covering parse, serialize, validation errors, and round-trips
- [x] All 378 tests pass (`pnpm test`)
- [x] Lint clean (`pnpm lint`)
- [x] Build clean (`pnpm build`)

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)