### PR TITLE
(feat) core: add action types catalog

### DIFF
--- a/packages/core/src/data/action-types.test.ts
+++ b/packages/core/src/data/action-types.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  getActionTypeCatalog,
+  getActionTypeInfo,
+  type ActionType,
+  type ActionCategory,
+} from "./action-types.js";
+
+describe("getActionTypeCatalog", () => {
+  it("returns all action types when no category is specified", () => {
+    const catalog = getActionTypeCatalog();
+
+    expect(catalog.actionTypes).toHaveLength(13);
+
+    const names = catalog.actionTypes.map((t) => t.name);
+    expect(names).toContain("VisitAndExtract");
+    expect(names).toContain("MessageToPerson");
+    expect(names).toContain("InMail");
+    expect(names).toContain("InvitePerson");
+    expect(names).toContain("Follow");
+    expect(names).toContain("EndorseSkills");
+    expect(names).toContain("CheckForReplies");
+    expect(names).toContain("ScrapeMessagingHistory");
+    expect(names).toContain("Waiter");
+    expect(names).toContain("DataEnrichment");
+    expect(names).toContain("PersonPostsLiker");
+    expect(names).toContain("RemoveFromFirstConnection");
+    expect(names).toContain("FilterContactsOutOfMyNetwork");
+  });
+
+  it("filters by category", () => {
+    const messaging = getActionTypeCatalog("messaging");
+
+    expect(messaging.actionTypes.length).toBeGreaterThan(0);
+    for (const info of messaging.actionTypes) {
+      expect(info.category).toBe("messaging");
+    }
+
+    const names = messaging.actionTypes.map((t) => t.name);
+    expect(names).toContain("MessageToPerson");
+    expect(names).toContain("InMail");
+    expect(names).toContain("CheckForReplies");
+    expect(names).toContain("ScrapeMessagingHistory");
+  });
+
+  it("returns people category types", () => {
+    const people = getActionTypeCatalog("people");
+    const names = people.actionTypes.map((t) => t.name);
+    expect(names).toContain("VisitAndExtract");
+    expect(names).toContain("InvitePerson");
+    expect(names).toContain("RemoveFromFirstConnection");
+  });
+
+  it("returns engagement category types", () => {
+    const engagement = getActionTypeCatalog("engagement");
+    const names = engagement.actionTypes.map((t) => t.name);
+    expect(names).toContain("Follow");
+    expect(names).toContain("EndorseSkills");
+    expect(names).toContain("PersonPostsLiker");
+  });
+
+  it("returns crm category types", () => {
+    const crm = getActionTypeCatalog("crm");
+    const names = crm.actionTypes.map((t) => t.name);
+    expect(names).toContain("DataEnrichment");
+    expect(names).toContain("FilterContactsOutOfMyNetwork");
+  });
+
+  it("returns workflow category types", () => {
+    const workflow = getActionTypeCatalog("workflow");
+    const names = workflow.actionTypes.map((t) => t.name);
+    expect(names).toContain("Waiter");
+  });
+
+  it("returns a new array on each call", () => {
+    const catalog1 = getActionTypeCatalog();
+    const catalog2 = getActionTypeCatalog();
+    expect(catalog1.actionTypes).not.toBe(catalog2.actionTypes);
+  });
+
+  it("returns frozen action type objects", () => {
+    const catalog = getActionTypeCatalog();
+    for (const info of catalog.actionTypes) {
+      expect(Object.isFrozen(info)).toBe(true);
+      expect(Object.isFrozen(info.configSchema)).toBe(true);
+    }
+  });
+
+  it("every action type has required fields", () => {
+    const catalog = getActionTypeCatalog();
+    for (const info of catalog.actionTypes) {
+      expect(info.name).toBeTruthy();
+      expect(info.description).toBeTruthy();
+      expect(info.category).toBeTruthy();
+      expect(info.configSchema).toBeDefined();
+    }
+  });
+
+  it("every action type has a valid category", () => {
+    const validCategories: ActionCategory[] = [
+      "people",
+      "messaging",
+      "engagement",
+      "crm",
+      "workflow",
+    ];
+    const catalog = getActionTypeCatalog();
+    for (const info of catalog.actionTypes) {
+      expect(validCategories).toContain(info.category);
+    }
+  });
+
+  it("categories are exhaustive (every category has at least one type)", () => {
+    const categories: ActionCategory[] = [
+      "people",
+      "messaging",
+      "engagement",
+      "crm",
+      "workflow",
+    ];
+    for (const category of categories) {
+      const catalog = getActionTypeCatalog(category);
+      expect(catalog.actionTypes.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("getActionTypeInfo", () => {
+  it("returns info for known action types", () => {
+    const knownTypes: ActionType[] = [
+      "VisitAndExtract",
+      "MessageToPerson",
+      "InMail",
+      "InvitePerson",
+      "Follow",
+      "EndorseSkills",
+      "CheckForReplies",
+      "ScrapeMessagingHistory",
+      "Waiter",
+      "DataEnrichment",
+      "PersonPostsLiker",
+      "RemoveFromFirstConnection",
+      "FilterContactsOutOfMyNetwork",
+    ];
+
+    for (const typeName of knownTypes) {
+      const info = getActionTypeInfo(typeName);
+      expect(info).toBeDefined();
+      if (info === undefined) throw new Error(`Expected info for ${typeName}`);
+      expect(info.name).toBe(typeName);
+    }
+  });
+
+  it("returns undefined for unknown action type", () => {
+    expect(getActionTypeInfo("NonExistentAction")).toBeUndefined();
+  });
+
+  it("returns correct fields for VisitAndExtract", () => {
+    const info = getActionTypeInfo("VisitAndExtract");
+    expect(info).toBeDefined();
+    if (info === undefined) throw new Error("Expected info");
+    expect(info.category).toBe("people");
+    expect(info.configSchema).toHaveProperty("extractProfile");
+    const field = info.configSchema["extractProfile"];
+    expect(field).toBeDefined();
+    if (field === undefined) throw new Error("Expected field");
+    expect(field.type).toBe("boolean");
+  });
+
+  it("returns correct fields for MessageToPerson", () => {
+    const info = getActionTypeInfo("MessageToPerson");
+    expect(info).toBeDefined();
+    if (info === undefined) throw new Error("Expected info");
+    expect(info.category).toBe("messaging");
+    expect(info.configSchema).toHaveProperty("messageTemplate");
+    const field = info.configSchema["messageTemplate"];
+    expect(field).toBeDefined();
+    if (field === undefined) throw new Error("Expected field");
+    expect(field.required).toBe(true);
+    expect(info.configSchema).toHaveProperty("rejectIfReplied");
+  });
+
+  it("returns correct fields for Waiter", () => {
+    const info = getActionTypeInfo("Waiter");
+    expect(info).toBeDefined();
+    if (info === undefined) throw new Error("Expected info");
+    expect(info.category).toBe("workflow");
+    expect(info.configSchema).toHaveProperty("delay");
+    const field = info.configSchema["delay"];
+    expect(field).toBeDefined();
+    if (field === undefined) throw new Error("Expected field");
+    expect(field.required).toBe(true);
+    expect(field.type).toBe("number");
+  });
+
+  it("returns example when available", () => {
+    const info = getActionTypeInfo("VisitAndExtract");
+    expect(info).toBeDefined();
+    if (info === undefined) throw new Error("Expected info");
+    expect(info.example).toEqual({ extractProfile: true });
+  });
+
+  it("returns no example when not available", () => {
+    const info = getActionTypeInfo("CheckForReplies");
+    expect(info).toBeDefined();
+    if (info === undefined) throw new Error("Expected info");
+    expect(info.example).toBeUndefined();
+  });
+
+  it("returns frozen objects", () => {
+    const info = getActionTypeInfo("VisitAndExtract");
+    expect(info).toBeDefined();
+    if (info === undefined) throw new Error("Expected info");
+    expect(Object.isFrozen(info)).toBe(true);
+    expect(Object.isFrozen(info.configSchema)).toBe(true);
+  });
+});

--- a/packages/core/src/data/action-types.ts
+++ b/packages/core/src/data/action-types.ts
@@ -1,0 +1,327 @@
+/**
+ * LinkedHelper action type identifiers.
+ *
+ * These correspond to the `actionType` column in the `action_configs` table.
+ */
+export type ActionType =
+  | "CheckForReplies"
+  | "DataEnrichment"
+  | "EndorseSkills"
+  | "FilterContactsOutOfMyNetwork"
+  | "Follow"
+  | "InMail"
+  | "InvitePerson"
+  | "MessageToPerson"
+  | "PersonPostsLiker"
+  | "RemoveFromFirstConnection"
+  | "ScrapeMessagingHistory"
+  | "VisitAndExtract"
+  | "Waiter";
+
+/** Action category grouping. */
+export type ActionCategory = "people" | "messaging" | "engagement" | "crm" | "workflow";
+
+/** Schema for a single configuration field. */
+export interface ConfigFieldSchema {
+  type: "string" | "number" | "boolean" | "array" | "object";
+  required: boolean;
+  description: string;
+  default?: unknown;
+}
+
+/** Metadata about a single action type. */
+export interface ActionTypeInfo {
+  name: ActionType;
+  description: string;
+  category: ActionCategory;
+  configSchema: Record<string, ConfigFieldSchema>;
+  example?: Record<string, unknown>;
+}
+
+/** Return type for catalog queries. */
+export interface ActionTypeCatalog {
+  actionTypes: ActionTypeInfo[];
+}
+
+const ACTION_TYPE_INFOS: ActionTypeInfo[] = [
+  {
+    name: "VisitAndExtract",
+    description: "Visit a LinkedIn profile and extract data (name, positions, education, skills).",
+    category: "people",
+    configSchema: {
+      extractProfile: {
+        type: "boolean",
+        required: false,
+        description: "Whether to extract full profile data after visiting.",
+        default: true,
+      },
+    },
+    example: { extractProfile: true },
+  },
+  {
+    name: "MessageToPerson",
+    description: "Send a direct message to a 1st-degree connection.",
+    category: "messaging",
+    configSchema: {
+      messageTemplate: {
+        type: "object",
+        required: true,
+        description:
+          "Message template with variable substitution support (e.g., {firstName}).",
+      },
+      subjectTemplate: {
+        type: "object",
+        required: false,
+        description: "Optional subject line template for the message.",
+      },
+      rejectIfReplied: {
+        type: "boolean",
+        required: false,
+        description: "Skip person if they already replied in this campaign.",
+        default: false,
+      },
+      rejectIfMessaged: {
+        type: "boolean",
+        required: false,
+        description: "Skip person if a message was already sent to them.",
+        default: false,
+      },
+      rejectIfRepliedWithinCampaign: {
+        type: "boolean",
+        required: false,
+        description:
+          "Skip person if they replied within the current campaign.",
+        default: false,
+      },
+      rejectIfMessagedAfterPreviousCampaignMessage: {
+        type: "boolean",
+        required: false,
+        description:
+          "Skip person if they were messaged after a previous campaign message.",
+        default: false,
+      },
+    },
+    example: {
+      messageTemplate: {
+        type: "variants",
+        variants: [
+          {
+            type: "variant",
+            child: {
+              type: "group",
+              children: [
+                { type: "text", value: "Hello " },
+                { type: "var", name: "firstName" },
+              ],
+            },
+          },
+        ],
+      },
+      rejectIfReplied: false,
+    },
+  },
+  {
+    name: "InMail",
+    description:
+      "Send an InMail message to a LinkedIn member (does not require a connection).",
+    category: "messaging",
+    configSchema: {
+      messageTemplate: {
+        type: "object",
+        required: true,
+        description:
+          "InMail body template with variable substitution support.",
+      },
+      subjectTemplate: {
+        type: "object",
+        required: false,
+        description: "InMail subject line template.",
+      },
+      rejectIfReplied: {
+        type: "boolean",
+        required: false,
+        description: "Skip person if they already replied.",
+        default: false,
+      },
+    },
+    example: {
+      messageTemplate: {
+        type: "variants",
+        variants: [
+          {
+            type: "variant",
+            child: { type: "text", value: "I would like to connect." },
+          },
+        ],
+      },
+    },
+  },
+  {
+    name: "InvitePerson",
+    description: "Send a connection request to a LinkedIn member.",
+    category: "people",
+    configSchema: {
+      messageTemplate: {
+        type: "object",
+        required: false,
+        description:
+          "Optional invitation note template (max 300 characters).",
+      },
+    },
+    example: {
+      messageTemplate: {
+        type: "variants",
+        variants: [
+          {
+            type: "variant",
+            child: {
+              type: "group",
+              children: [
+                { type: "text", value: "Hi " },
+                { type: "var", name: "firstName" },
+                {
+                  type: "text",
+                  value: ", I'd like to add you to my network.",
+                },
+              ],
+            },
+          },
+        ],
+      },
+    },
+  },
+  {
+    name: "Follow",
+    description: "Follow or unfollow a LinkedIn profile.",
+    category: "engagement",
+    configSchema: {
+      unfollow: {
+        type: "boolean",
+        required: false,
+        description: "If true, unfollow instead of follow.",
+        default: false,
+      },
+    },
+    example: { unfollow: false },
+  },
+  {
+    name: "EndorseSkills",
+    description: "Endorse skills listed on a LinkedIn profile.",
+    category: "engagement",
+    configSchema: {
+      maxSkills: {
+        type: "number",
+        required: false,
+        description: "Maximum number of skills to endorse.",
+      },
+    },
+  },
+  {
+    name: "CheckForReplies",
+    description: "Check for new message replies from contacts in the campaign.",
+    category: "messaging",
+    configSchema: {},
+  },
+  {
+    name: "ScrapeMessagingHistory",
+    description: "Scrape all messaging history for the LinkedIn account.",
+    category: "messaging",
+    configSchema: {},
+  },
+  {
+    name: "Waiter",
+    description:
+      "Pause the campaign pipeline for a configured delay before proceeding to the next action.",
+    category: "workflow",
+    configSchema: {
+      delay: {
+        type: "number",
+        required: true,
+        description: "Delay in hours before proceeding to the next action.",
+      },
+    },
+    example: { delay: 24 },
+  },
+  {
+    name: "DataEnrichment",
+    description:
+      "Enrich profile data by extracting additional information from LinkedIn.",
+    category: "crm",
+    configSchema: {},
+  },
+  {
+    name: "PersonPostsLiker",
+    description: "Like recent posts published by a LinkedIn profile.",
+    category: "engagement",
+    configSchema: {
+      maxPosts: {
+        type: "number",
+        required: false,
+        description: "Maximum number of recent posts to like.",
+      },
+    },
+  },
+  {
+    name: "RemoveFromFirstConnection",
+    description: "Remove a person from 1st-degree connections (unfriend).",
+    category: "people",
+    configSchema: {},
+  },
+  {
+    name: "FilterContactsOutOfMyNetwork",
+    description:
+      "Filter out contacts who are no longer in your network (e.g., withdrawn invitations, removed connections).",
+    category: "crm",
+    configSchema: {},
+  },
+];
+
+/** Deep-freeze an object and all nested objects. */
+function deepFreeze<T extends object>(obj: T): Readonly<T> {
+  for (const value of Object.values(obj)) {
+    if (value !== null && typeof value === "object" && !Object.isFrozen(value)) {
+      deepFreeze(value as object);
+    }
+  }
+  return Object.freeze(obj);
+}
+
+// Freeze all catalog entries so consumers cannot mutate the shared static data.
+for (const info of ACTION_TYPE_INFOS) {
+  deepFreeze(info);
+}
+
+/** Map for O(1) lookup by action type name. */
+const ACTION_TYPE_MAP = new Map<ActionType, Readonly<ActionTypeInfo>>(
+  ACTION_TYPE_INFOS.map((info) => [info.name, info]),
+);
+
+/**
+ * Get the action types catalog, optionally filtered by category.
+ */
+export function getActionTypeCatalog(category?: ActionCategory): ActionTypeCatalog {
+  if (category === undefined) {
+    return { actionTypes: [...ACTION_TYPE_INFOS] };
+  }
+
+  return {
+    actionTypes: ACTION_TYPE_INFOS.filter((info) => info.category === category),
+  };
+}
+
+/**
+ * Get metadata for a single action type.
+ *
+ * @returns The action type info, or `undefined` if the type is unknown.
+ */
+export function getActionTypeInfo(
+  actionType: ActionType,
+): Readonly<ActionTypeInfo>;
+export function getActionTypeInfo(
+  actionType: string,
+): Readonly<ActionTypeInfo> | undefined;
+export function getActionTypeInfo(
+  actionType: string,
+): Readonly<ActionTypeInfo> | undefined {
+  return ACTION_TYPE_MAP.get(actionType as ActionType);
+}

--- a/packages/core/src/data/index.ts
+++ b/packages/core/src/data/index.ts
@@ -1,0 +1,9 @@
+export type {
+  ActionCategory,
+  ActionType,
+  ActionTypeCatalog,
+  ActionTypeInfo,
+  ConfigFieldSchema,
+} from "./action-types.js";
+
+export { getActionTypeCatalog, getActionTypeInfo } from "./action-types.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -92,6 +92,17 @@ export {
   serializeCampaignYaml,
 } from "./formats/index.js";
 
+// Data (action types catalog)
+export {
+  type ActionCategory,
+  type ActionType,
+  type ActionTypeCatalog,
+  type ActionTypeInfo,
+  type ConfigFieldSchema,
+  getActionTypeCatalog,
+  getActionTypeInfo,
+} from "./data/index.js";
+
 // Errors (DB + CDP errors can propagate through the service layer)
 export {
   CampaignNotFoundError,


### PR DESCRIPTION
## Summary
- Add static catalog of 13 LinkedHelper action types with descriptions, categories, and config schemas
- Expose `getActionTypeCatalog(category?)` and `getActionTypeInfo(actionType)` functions
- Categories: people, messaging, engagement, crm, workflow
- 18 unit tests covering all catalog queries, filtering, and field validation

Closes #88

## Test plan
- [x] All 18 new unit tests pass (`vitest run src/data/action-types.test.ts`)
- [x] Full test suite passes (403 tests across 32 files)
- [ ] Verify `describe-actions` MCP tool can consume the catalog (future #89)

🤖 Generated with [Claude Code](https://claude.com/claude-code)