### PR TITLE
(feat) mcp: add campaign-create tool

### DIFF
--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -83,9 +83,10 @@ describe("createServer", () => {
     expect(names).toContain("query-profiles");
     expect(names).toContain("query-messages");
     expect(names).toContain("scrape-messaging-history");
+    expect(names).toContain("campaign-create");
     expect(names).toContain("check-replies");
     expect(names).toContain("check-status");
     expect(names).toContain("describe-actions");
-    expect(names).toHaveLength(14);
+    expect(names).toHaveLength(15);
   });
 });

--- a/packages/mcp/src/tools/campaign-create.test.ts
+++ b/packages/mcp/src/tools/campaign-create.test.ts
@@ -1,0 +1,319 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return {
+    ...actual,
+    LauncherService: vi.fn(),
+    InstanceService: vi.fn(),
+    DatabaseClient: vi.fn(),
+    CampaignService: vi.fn(),
+    discoverInstancePort: vi.fn(),
+    discoverDatabase: vi.fn(),
+    parseCampaignYaml: vi.fn(),
+    parseCampaignJson: vi.fn(),
+  };
+});
+
+import {
+  type Account,
+  type Campaign,
+  CampaignExecutionError,
+  CampaignFormatError,
+  CampaignService,
+  DatabaseClient,
+  discoverDatabase,
+  discoverInstancePort,
+  InstanceService,
+  LauncherService,
+  parseCampaignJson,
+  parseCampaignYaml,
+} from "@lhremote/core";
+
+import { registerCampaignCreate } from "./campaign-create.js";
+import { createMockServer } from "./testing/mock-server.js";
+
+const YAML_CONFIG = `
+version: "1"
+name: Test Campaign
+actions:
+  - type: VisitAndExtract
+`;
+
+const JSON_CONFIG = JSON.stringify({
+  version: "1",
+  name: "Test Campaign",
+  actions: [{ type: "VisitAndExtract" }],
+});
+
+const PARSED_CONFIG = {
+  name: "Test Campaign",
+  actions: [{ name: "VisitAndExtract", actionType: "VisitAndExtract" }],
+};
+
+const MOCK_CAMPAIGN: Campaign = {
+  id: 42,
+  name: "Test Campaign",
+  description: null,
+  state: "active",
+  liAccountId: 1,
+  isPaused: true,
+  isArchived: false,
+  isValid: true,
+  createdAt: "2025-01-01T00:00:00.000Z",
+};
+
+function mockLauncher(overrides: Record<string, unknown> = {}) {
+  const disconnect = vi.fn();
+  vi.mocked(LauncherService).mockImplementation(function () {
+    return {
+      connect: vi.fn().mockResolvedValue(undefined),
+      disconnect,
+      listAccounts: vi
+        .fn()
+        .mockResolvedValue([{ id: 1, liId: 1, name: "Alice" } as Account]),
+      ...overrides,
+    } as unknown as LauncherService;
+  });
+  return { disconnect };
+}
+
+function mockInstance(overrides: Record<string, unknown> = {}) {
+  const disconnect = vi.fn();
+  vi.mocked(InstanceService).mockImplementation(function () {
+    return {
+      connect: vi.fn().mockResolvedValue(undefined),
+      disconnect,
+      ...overrides,
+    } as unknown as InstanceService;
+  });
+  return { disconnect };
+}
+
+function mockDb() {
+  const close = vi.fn();
+  vi.mocked(DatabaseClient).mockImplementation(function () {
+    return { close, db: {} } as unknown as DatabaseClient;
+  });
+  return { close };
+}
+
+function mockCampaignService(campaign: Campaign = MOCK_CAMPAIGN) {
+  vi.mocked(CampaignService).mockImplementation(function () {
+    return {
+      create: vi.fn().mockResolvedValue(campaign),
+    } as unknown as CampaignService;
+  });
+}
+
+function setupSuccessPath() {
+  mockLauncher();
+  mockInstance();
+  mockDb();
+  mockCampaignService();
+  vi.mocked(discoverInstancePort).mockResolvedValue(55123);
+  vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+  vi.mocked(parseCampaignYaml).mockReturnValue(PARSED_CONFIG);
+  vi.mocked(parseCampaignJson).mockReturnValue(PARSED_CONFIG);
+}
+
+describe("registerCampaignCreate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("registers a tool named campaign-create", () => {
+    const { server } = createMockServer();
+    registerCampaignCreate(server);
+
+    expect(server.tool).toHaveBeenCalledOnce();
+    expect(server.tool).toHaveBeenCalledWith(
+      "campaign-create",
+      expect.any(String),
+      expect.any(Object),
+      expect.any(Function),
+    );
+  });
+
+  it("successfully creates campaign from YAML config", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignCreate(server);
+    setupSuccessPath();
+
+    const handler = getHandler("campaign-create");
+    const result = await handler({
+      config: YAML_CONFIG,
+      format: "yaml",
+      cdpPort: 9222,
+    });
+
+    expect(parseCampaignYaml).toHaveBeenCalledWith(YAML_CONFIG);
+    expect(result).toEqual({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(MOCK_CAMPAIGN, null, 2),
+        },
+      ],
+    });
+  });
+
+  it("successfully creates campaign from JSON config", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignCreate(server);
+    setupSuccessPath();
+
+    const handler = getHandler("campaign-create");
+    const result = await handler({
+      config: JSON_CONFIG,
+      format: "json",
+      cdpPort: 9222,
+    });
+
+    expect(parseCampaignJson).toHaveBeenCalledWith(JSON_CONFIG);
+    expect(result).toEqual({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(MOCK_CAMPAIGN, null, 2),
+        },
+      ],
+    });
+  });
+
+  it("returns error for invalid YAML", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignCreate(server);
+
+    vi.mocked(parseCampaignYaml).mockImplementation(() => {
+      throw new CampaignFormatError("Invalid YAML: unexpected token");
+    });
+
+    const handler = getHandler("campaign-create");
+    const result = await handler({
+      config: "%%%invalid",
+      format: "yaml",
+      cdpPort: 9222,
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "Invalid campaign configuration: Invalid YAML: unexpected token",
+        },
+      ],
+    });
+  });
+
+  it("returns error for invalid JSON", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignCreate(server);
+
+    vi.mocked(parseCampaignJson).mockImplementation(() => {
+      throw new CampaignFormatError("Invalid JSON: unexpected token");
+    });
+
+    const handler = getHandler("campaign-create");
+    const result = await handler({
+      config: "{not-json",
+      format: "json",
+      cdpPort: 9222,
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "Invalid campaign configuration: Invalid JSON: unexpected token",
+        },
+      ],
+    });
+  });
+
+  it("returns error when campaign creation fails", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignCreate(server);
+
+    mockLauncher();
+    mockInstance();
+    mockDb();
+    vi.mocked(discoverInstancePort).mockResolvedValue(55123);
+    vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+    vi.mocked(parseCampaignYaml).mockReturnValue(PARSED_CONFIG);
+    vi.mocked(CampaignService).mockImplementation(function () {
+      return {
+        create: vi
+          .fn()
+          .mockRejectedValue(
+            new CampaignExecutionError("Failed to create campaign: UI error"),
+          ),
+      } as unknown as CampaignService;
+    });
+
+    const handler = getHandler("campaign-create");
+    const result = await handler({
+      config: YAML_CONFIG,
+      format: "yaml",
+      cdpPort: 9222,
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "Failed to create campaign: Failed to create campaign: UI error",
+        },
+      ],
+    });
+  });
+
+  it("disconnects instance and closes db after success", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignCreate(server);
+
+    mockLauncher();
+    const { disconnect: instanceDisconnect } = mockInstance();
+    const { close: dbClose } = mockDb();
+    mockCampaignService();
+    vi.mocked(discoverInstancePort).mockResolvedValue(55123);
+    vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+    vi.mocked(parseCampaignYaml).mockReturnValue(PARSED_CONFIG);
+
+    const handler = getHandler("campaign-create");
+    await handler({ config: YAML_CONFIG, format: "yaml", cdpPort: 9222 });
+
+    expect(instanceDisconnect).toHaveBeenCalledOnce();
+    expect(dbClose).toHaveBeenCalledOnce();
+  });
+
+  it("disconnects instance and closes db after error", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignCreate(server);
+
+    mockLauncher();
+    const { disconnect: instanceDisconnect } = mockInstance();
+    const { close: dbClose } = mockDb();
+    vi.mocked(discoverInstancePort).mockResolvedValue(55123);
+    vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+    vi.mocked(parseCampaignYaml).mockReturnValue(PARSED_CONFIG);
+    vi.mocked(CampaignService).mockImplementation(function () {
+      return {
+        create: vi.fn().mockRejectedValue(new Error("test error")),
+      } as unknown as CampaignService;
+    });
+
+    const handler = getHandler("campaign-create");
+    await handler({ config: YAML_CONFIG, format: "yaml", cdpPort: 9222 });
+
+    expect(instanceDisconnect).toHaveBeenCalledOnce();
+    expect(dbClose).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/mcp/src/tools/campaign-create.ts
+++ b/packages/mcp/src/tools/campaign-create.ts
@@ -1,0 +1,220 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  type Account,
+  CampaignExecutionError,
+  CampaignFormatError,
+  CampaignService,
+  DatabaseClient,
+  discoverDatabase,
+  discoverInstancePort,
+  InstanceNotRunningError,
+  InstanceService,
+  LauncherService,
+  LinkedHelperNotRunningError,
+  parseCampaignJson,
+  parseCampaignYaml,
+} from "@lhremote/core";
+import { z } from "zod";
+
+export function registerCampaignCreate(server: McpServer): void {
+  server.tool(
+    "campaign-create",
+    "Create a new LinkedHelper campaign from YAML or JSON configuration",
+    {
+      config: z.string().describe("Campaign configuration in YAML or JSON format"),
+      format: z
+        .enum(["yaml", "json"])
+        .optional()
+        .default("yaml")
+        .describe("Configuration format"),
+      cdpPort: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .default(9222)
+        .describe("CDP port (default: 9222)"),
+    },
+    async ({ config, format, cdpPort }) => {
+      // Parse campaign config
+      let parsedConfig;
+      try {
+        parsedConfig =
+          format === "json"
+            ? parseCampaignJson(config)
+            : parseCampaignYaml(config);
+      } catch (error) {
+        if (error instanceof CampaignFormatError) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: `Invalid campaign configuration: ${error.message}`,
+              },
+            ],
+          };
+        }
+        const message =
+          error instanceof Error ? error.message : String(error);
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: `Failed to parse campaign configuration: ${message}`,
+            },
+          ],
+        };
+      }
+
+      // Connect to launcher to find running instance
+      const launcher = new LauncherService(cdpPort);
+
+      try {
+        await launcher.connect();
+      } catch (error) {
+        if (error instanceof LinkedHelperNotRunningError) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: "LinkedHelper is not running. Use launch-app first.",
+              },
+            ],
+          };
+        }
+        const message =
+          error instanceof Error ? error.message : String(error);
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: `Failed to connect to LinkedHelper: ${message}`,
+            },
+          ],
+        };
+      }
+
+      let accountId: number;
+      try {
+        const accounts = await launcher.listAccounts();
+        if (accounts.length === 0) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: "No accounts found.",
+              },
+            ],
+          };
+        }
+        if (accounts.length > 1) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: "Multiple accounts found. Cannot determine which instance to use.",
+              },
+            ],
+          };
+        }
+        accountId = (accounts[0] as Account).id;
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : String(error);
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: `Failed to list accounts: ${message}`,
+            },
+          ],
+        };
+      } finally {
+        launcher.disconnect();
+      }
+
+      // Discover instance CDP port
+      const instancePort = await discoverInstancePort(cdpPort);
+      if (instancePort === null) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: "No LinkedHelper instance is running. Use start-instance first.",
+            },
+          ],
+        };
+      }
+
+      // Connect to instance and create campaign
+      const instance = new InstanceService(instancePort);
+      let db: DatabaseClient | null = null;
+
+      try {
+        await instance.connect();
+
+        // Discover and open database
+        const dbPath = discoverDatabase(accountId);
+        db = new DatabaseClient(dbPath);
+
+        // Create campaign
+        const campaignService = new CampaignService(instance, db);
+        const campaign = await campaignService.create(parsedConfig);
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(campaign, null, 2),
+            },
+          ],
+        };
+      } catch (error) {
+        if (error instanceof InstanceNotRunningError) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: "No LinkedHelper instance is running. Use start-instance first.",
+              },
+            ],
+          };
+        }
+        if (error instanceof CampaignExecutionError) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: `Failed to create campaign: ${error.message}`,
+              },
+            ],
+          };
+        }
+        const message =
+          error instanceof Error ? error.message : String(error);
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: `Failed to create campaign: ${message}`,
+            },
+          ],
+        };
+      } finally {
+        instance.disconnect();
+        db?.close();
+      }
+    },
+  );
+}

--- a/packages/mcp/src/tools/index.ts
+++ b/packages/mcp/src/tools/index.ts
@@ -1,5 +1,6 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
+import { registerCampaignCreate } from "./campaign-create.js";
 import { registerCheckReplies } from "./check-replies.js";
 import { registerCheckStatus } from "./check-status.js";
 import { registerDescribeActions } from "./describe-actions.js";
@@ -16,6 +17,7 @@ import { registerScrapeMessagingHistory } from "./scrape-messaging-history.js";
 import { registerVisitAndExtract } from "./visit-and-extract.js";
 
 export function registerAllTools(server: McpServer): void {
+  registerCampaignCreate(server);
   registerFindApp(server);
   registerLaunchApp(server);
   registerQuitApp(server);


### PR DESCRIPTION
## Summary
- Add `campaign-create` MCP tool that creates LinkedHelper campaigns from YAML or JSON configuration
- Parses config via `parseCampaignYaml`/`parseCampaignJson`, connects to CDP, creates campaign via `CampaignService.create()`
- Includes 8 unit tests covering YAML/JSON success, parse errors, creation errors, and cleanup

## Test plan
- [x] Unit tests for YAML config parsing and campaign creation
- [x] Unit tests for JSON config parsing and campaign creation
- [x] Unit tests for invalid YAML/JSON error handling
- [x] Unit tests for campaign creation failure error handling
- [x] Unit tests for resource cleanup (instance disconnect, db close)
- [x] Server integration test updated for new tool count (14)
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (all 656 tests)

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)