### PR TITLE
(feat) mcp: add campaign-get tool

### DIFF
--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -84,9 +84,10 @@ describe("createServer", () => {
     expect(names).toContain("query-messages");
     expect(names).toContain("scrape-messaging-history");
     expect(names).toContain("campaign-create");
+    expect(names).toContain("campaign-get");
     expect(names).toContain("check-replies");
     expect(names).toContain("check-status");
     expect(names).toContain("describe-actions");
-    expect(names).toHaveLength(15);
+    expect(names).toHaveLength(16);
   });
 });

--- a/packages/mcp/src/tools/campaign-get.test.ts
+++ b/packages/mcp/src/tools/campaign-get.test.ts
@@ -1,0 +1,261 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return {
+    ...actual,
+    LauncherService: vi.fn(),
+    DatabaseClient: vi.fn(),
+    CampaignRepository: vi.fn(),
+    discoverDatabase: vi.fn(),
+  };
+});
+
+import {
+  type Account,
+  type Campaign,
+  type CampaignAction,
+  CampaignNotFoundError,
+  CampaignRepository,
+  DatabaseClient,
+  discoverDatabase,
+  LauncherService,
+  LinkedHelperNotRunningError,
+} from "@lhremote/core";
+
+import { registerCampaignGet } from "./campaign-get.js";
+import { createMockServer } from "./testing/mock-server.js";
+
+const MOCK_CAMPAIGN: Campaign = {
+  id: 15,
+  name: "Outreach Campaign",
+  description: "Connect with engineering leaders",
+  state: "active",
+  liAccountId: 1,
+  isPaused: true,
+  isArchived: false,
+  isValid: true,
+  createdAt: "2026-02-07T10:00:00Z",
+};
+
+const MOCK_ACTIONS: CampaignAction[] = [
+  {
+    id: 86,
+    campaignId: 15,
+    name: "Visit Profile",
+    description: null,
+    config: {
+      id: 100,
+      actionType: "VisitAndExtract",
+      actionSettings: { extractProfile: true },
+      coolDown: 60000,
+      maxActionResultsPerIteration: 10,
+      isDraft: false,
+    },
+    versionId: 1,
+  },
+];
+
+function mockLauncher(overrides: Record<string, unknown> = {}) {
+  const disconnect = vi.fn();
+  vi.mocked(LauncherService).mockImplementation(function () {
+    return {
+      connect: vi.fn().mockResolvedValue(undefined),
+      disconnect,
+      listAccounts: vi
+        .fn()
+        .mockResolvedValue([{ id: 1, liId: 1, name: "Alice" } as Account]),
+      ...overrides,
+    } as unknown as LauncherService;
+  });
+  return { disconnect };
+}
+
+function mockDb() {
+  const close = vi.fn();
+  vi.mocked(DatabaseClient).mockImplementation(function () {
+    return { close, db: {} } as unknown as DatabaseClient;
+  });
+  return { close };
+}
+
+function mockCampaignRepo(
+  campaign: Campaign = MOCK_CAMPAIGN,
+  actions: CampaignAction[] = MOCK_ACTIONS,
+) {
+  vi.mocked(CampaignRepository).mockImplementation(function () {
+    return {
+      getCampaign: vi.fn().mockReturnValue(campaign),
+      getCampaignActions: vi.fn().mockReturnValue(actions),
+    } as unknown as CampaignRepository;
+  });
+}
+
+function setupSuccessPath() {
+  mockLauncher();
+  mockDb();
+  mockCampaignRepo();
+  vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+}
+
+describe("registerCampaignGet", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("registers a tool named campaign-get", () => {
+    const { server } = createMockServer();
+    registerCampaignGet(server);
+
+    expect(server.tool).toHaveBeenCalledOnce();
+    expect(server.tool).toHaveBeenCalledWith(
+      "campaign-get",
+      expect.any(String),
+      expect.any(Object),
+      expect.any(Function),
+    );
+  });
+
+  it("returns campaign details with actions", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignGet(server);
+    setupSuccessPath();
+
+    const handler = getHandler("campaign-get");
+    const result = await handler({ campaignId: 15, cdpPort: 9222 });
+
+    expect(result).toEqual({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(
+            { ...MOCK_CAMPAIGN, actions: MOCK_ACTIONS },
+            null,
+            2,
+          ),
+        },
+      ],
+    });
+  });
+
+  it("returns error for non-existent campaign", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignGet(server);
+
+    mockLauncher();
+    mockDb();
+    vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+    vi.mocked(CampaignRepository).mockImplementation(function () {
+      return {
+        getCampaign: vi.fn().mockImplementation(() => {
+          throw new CampaignNotFoundError(999);
+        }),
+        getCampaignActions: vi.fn(),
+      } as unknown as CampaignRepository;
+    });
+
+    const handler = getHandler("campaign-get");
+    const result = await handler({ campaignId: 999, cdpPort: 9222 });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "Campaign 999 not found.",
+        },
+      ],
+    });
+  });
+
+  it("returns error when LinkedHelper is not running", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignGet(server);
+
+    vi.mocked(LauncherService).mockImplementation(function () {
+      return {
+        connect: vi.fn().mockRejectedValue(new LinkedHelperNotRunningError(9222)),
+        disconnect: vi.fn(),
+      } as unknown as LauncherService;
+    });
+
+    const handler = getHandler("campaign-get");
+    const result = await handler({ campaignId: 15, cdpPort: 9222 });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "LinkedHelper is not running. Use launch-app first.",
+        },
+      ],
+    });
+  });
+
+  it("returns error when connection fails", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignGet(server);
+
+    vi.mocked(LauncherService).mockImplementation(function () {
+      return {
+        connect: vi.fn().mockRejectedValue(new Error("connection refused")),
+        disconnect: vi.fn(),
+      } as unknown as LauncherService;
+    });
+
+    const handler = getHandler("campaign-get");
+    const result = await handler({ campaignId: 15, cdpPort: 9222 });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "Failed to connect to LinkedHelper: connection refused",
+        },
+      ],
+    });
+  });
+
+  it("closes database after success", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignGet(server);
+
+    mockLauncher();
+    const { close: dbClose } = mockDb();
+    mockCampaignRepo();
+    vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+
+    const handler = getHandler("campaign-get");
+    await handler({ campaignId: 15, cdpPort: 9222 });
+
+    expect(dbClose).toHaveBeenCalledOnce();
+  });
+
+  it("closes database after error", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignGet(server);
+
+    mockLauncher();
+    const { close: dbClose } = mockDb();
+    vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+    vi.mocked(CampaignRepository).mockImplementation(function () {
+      return {
+        getCampaign: vi.fn().mockImplementation(() => {
+          throw new Error("db error");
+        }),
+        getCampaignActions: vi.fn(),
+      } as unknown as CampaignRepository;
+    });
+
+    const handler = getHandler("campaign-get");
+    await handler({ campaignId: 15, cdpPort: 9222 });
+
+    expect(dbClose).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/mcp/src/tools/campaign-get.ts
+++ b/packages/mcp/src/tools/campaign-get.ts
@@ -1,0 +1,151 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  type Account,
+  CampaignNotFoundError,
+  CampaignRepository,
+  DatabaseClient,
+  discoverDatabase,
+  LauncherService,
+  LinkedHelperNotRunningError,
+} from "@lhremote/core";
+import { z } from "zod";
+
+export function registerCampaignGet(server: McpServer): void {
+  server.tool(
+    "campaign-get",
+    "Get detailed information about a campaign including its actions and configuration",
+    {
+      campaignId: z
+        .number()
+        .int()
+        .positive()
+        .describe("Campaign ID"),
+      cdpPort: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .default(9222)
+        .describe("CDP port (default: 9222)"),
+    },
+    async ({ campaignId, cdpPort }) => {
+      // Connect to launcher to find account
+      const launcher = new LauncherService(cdpPort);
+
+      try {
+        await launcher.connect();
+      } catch (error) {
+        if (error instanceof LinkedHelperNotRunningError) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: "LinkedHelper is not running. Use launch-app first.",
+              },
+            ],
+          };
+        }
+        const message =
+          error instanceof Error ? error.message : String(error);
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: `Failed to connect to LinkedHelper: ${message}`,
+            },
+          ],
+        };
+      }
+
+      let accountId: number;
+      try {
+        const accounts = await launcher.listAccounts();
+        if (accounts.length === 0) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: "No accounts found.",
+              },
+            ],
+          };
+        }
+        if (accounts.length > 1) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: "Multiple accounts found. Cannot determine which instance to use.",
+              },
+            ],
+          };
+        }
+        accountId = (accounts[0] as Account).id;
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : String(error);
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: `Failed to list accounts: ${message}`,
+            },
+          ],
+        };
+      } finally {
+        launcher.disconnect();
+      }
+
+      // Discover and open database
+      let db: DatabaseClient | null = null;
+
+      try {
+        const dbPath = discoverDatabase(accountId);
+        db = new DatabaseClient(dbPath);
+
+        const campaignRepo = new CampaignRepository(db);
+        const campaign = campaignRepo.getCampaign(campaignId);
+        const actions = campaignRepo.getCampaignActions(campaignId);
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({ ...campaign, actions }, null, 2),
+            },
+          ],
+        };
+      } catch (error) {
+        if (error instanceof CampaignNotFoundError) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: `Campaign ${String(campaignId)} not found.`,
+              },
+            ],
+          };
+        }
+        const message =
+          error instanceof Error ? error.message : String(error);
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: `Failed to get campaign: ${message}`,
+            },
+          ],
+        };
+      } finally {
+        db?.close();
+      }
+    },
+  );
+}

--- a/packages/mcp/src/tools/index.ts
+++ b/packages/mcp/src/tools/index.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import { registerCampaignCreate } from "./campaign-create.js";
+import { registerCampaignGet } from "./campaign-get.js";
 import { registerCheckReplies } from "./check-replies.js";
 import { registerCheckStatus } from "./check-status.js";
 import { registerDescribeActions } from "./describe-actions.js";
@@ -18,6 +19,7 @@ import { registerVisitAndExtract } from "./visit-and-extract.js";
 
 export function registerAllTools(server: McpServer): void {
   registerCampaignCreate(server);
+  registerCampaignGet(server);
   registerFindApp(server);
   registerLaunchApp(server);
   registerQuitApp(server);


### PR DESCRIPTION
## Summary
- Add `campaign-get` MCP tool to retrieve campaign details including actions and configuration
- Uses `CampaignRepository` directly for database reads (no CDP instance connection needed)
- Includes 7 unit tests covering success path, error cases, and resource cleanup

Closes #91

## Test plan
- [x] Unit tests pass (`pnpm test` — 7 new tests in `campaign-get.test.ts`)
- [x] Lint passes (`pnpm lint`)
- [x] Server test updated for new tool count (15 → 16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)