### PR TITLE
(feat) mcp: add campaign-export tool

### DIFF
--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -85,10 +85,11 @@ describe("createServer", () => {
     expect(names).toContain("scrape-messaging-history");
     expect(names).toContain("campaign-create");
     expect(names).toContain("campaign-delete");
+    expect(names).toContain("campaign-export");
     expect(names).toContain("campaign-get");
     expect(names).toContain("check-replies");
     expect(names).toContain("check-status");
     expect(names).toContain("describe-actions");
-    expect(names).toHaveLength(17);
+    expect(names).toHaveLength(18);
   });
 });

--- a/packages/mcp/src/tools/campaign-export.test.ts
+++ b/packages/mcp/src/tools/campaign-export.test.ts
@@ -1,0 +1,296 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return {
+    ...actual,
+    LauncherService: vi.fn(),
+    DatabaseClient: vi.fn(),
+    CampaignRepository: vi.fn(),
+    discoverDatabase: vi.fn(),
+    serializeCampaignYaml: vi.fn(),
+    serializeCampaignJson: vi.fn(),
+  };
+});
+
+import {
+  type Account,
+  type Campaign,
+  type CampaignAction,
+  CampaignNotFoundError,
+  CampaignRepository,
+  DatabaseClient,
+  discoverDatabase,
+  LauncherService,
+  LinkedHelperNotRunningError,
+  serializeCampaignJson,
+  serializeCampaignYaml,
+} from "@lhremote/core";
+
+import { registerCampaignExport } from "./campaign-export.js";
+import { createMockServer } from "./testing/mock-server.js";
+
+const MOCK_CAMPAIGN: Campaign = {
+  id: 15,
+  name: "Outreach Campaign",
+  description: "Connect with engineering leaders",
+  state: "active",
+  liAccountId: 1,
+  isPaused: true,
+  isArchived: false,
+  isValid: true,
+  createdAt: "2026-02-07T10:00:00Z",
+};
+
+const MOCK_ACTIONS: CampaignAction[] = [
+  {
+    id: 86,
+    campaignId: 15,
+    name: "Visit Profile",
+    description: null,
+    config: {
+      id: 100,
+      actionType: "VisitAndExtract",
+      actionSettings: { extractProfile: true },
+      coolDown: 60000,
+      maxActionResultsPerIteration: 10,
+      isDraft: false,
+    },
+    versionId: 1,
+  },
+];
+
+function mockLauncher(overrides: Record<string, unknown> = {}) {
+  const disconnect = vi.fn();
+  vi.mocked(LauncherService).mockImplementation(function () {
+    return {
+      connect: vi.fn().mockResolvedValue(undefined),
+      disconnect,
+      listAccounts: vi
+        .fn()
+        .mockResolvedValue([{ id: 1, liId: 1, name: "Alice" } as Account]),
+      ...overrides,
+    } as unknown as LauncherService;
+  });
+  return { disconnect };
+}
+
+function mockDb() {
+  const close = vi.fn();
+  vi.mocked(DatabaseClient).mockImplementation(function () {
+    return { close, db: {} } as unknown as DatabaseClient;
+  });
+  return { close };
+}
+
+function mockCampaignRepo(
+  campaign: Campaign = MOCK_CAMPAIGN,
+  actions: CampaignAction[] = MOCK_ACTIONS,
+) {
+  vi.mocked(CampaignRepository).mockImplementation(function () {
+    return {
+      getCampaign: vi.fn().mockReturnValue(campaign),
+      getCampaignActions: vi.fn().mockReturnValue(actions),
+    } as unknown as CampaignRepository;
+  });
+}
+
+function setupSuccessPath() {
+  mockLauncher();
+  mockDb();
+  mockCampaignRepo();
+  vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+}
+
+describe("registerCampaignExport", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("registers a tool named campaign-export", () => {
+    const { server } = createMockServer();
+    registerCampaignExport(server);
+
+    expect(server.tool).toHaveBeenCalledOnce();
+    expect(server.tool).toHaveBeenCalledWith(
+      "campaign-export",
+      expect.any(String),
+      expect.any(Object),
+      expect.any(Function),
+    );
+  });
+
+  it("exports campaign as YAML by default", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignExport(server);
+    setupSuccessPath();
+
+    const yamlOutput = 'version: "1"\nname: Outreach Campaign\n';
+    vi.mocked(serializeCampaignYaml).mockReturnValue(yamlOutput);
+
+    const handler = getHandler("campaign-export");
+    const result = await handler({ campaignId: 15, format: "yaml", cdpPort: 9222 });
+
+    expect(serializeCampaignYaml).toHaveBeenCalledWith(MOCK_CAMPAIGN, MOCK_ACTIONS);
+    expect(result).toEqual({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(
+            { campaignId: 15, format: "yaml", config: yamlOutput },
+            null,
+            2,
+          ),
+        },
+      ],
+    });
+  });
+
+  it("exports campaign as JSON when requested", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignExport(server);
+    setupSuccessPath();
+
+    const jsonOutput = '{\n  "version": "1",\n  "name": "Outreach Campaign"\n}\n';
+    vi.mocked(serializeCampaignJson).mockReturnValue(jsonOutput);
+
+    const handler = getHandler("campaign-export");
+    const result = await handler({ campaignId: 15, format: "json", cdpPort: 9222 });
+
+    expect(serializeCampaignJson).toHaveBeenCalledWith(MOCK_CAMPAIGN, MOCK_ACTIONS);
+    expect(result).toEqual({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(
+            { campaignId: 15, format: "json", config: jsonOutput },
+            null,
+            2,
+          ),
+        },
+      ],
+    });
+  });
+
+  it("returns error for non-existent campaign", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignExport(server);
+
+    mockLauncher();
+    mockDb();
+    vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+    vi.mocked(CampaignRepository).mockImplementation(function () {
+      return {
+        getCampaign: vi.fn().mockImplementation(() => {
+          throw new CampaignNotFoundError(999);
+        }),
+        getCampaignActions: vi.fn(),
+      } as unknown as CampaignRepository;
+    });
+
+    const handler = getHandler("campaign-export");
+    const result = await handler({ campaignId: 999, format: "yaml", cdpPort: 9222 });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "Campaign 999 not found.",
+        },
+      ],
+    });
+  });
+
+  it("returns error when connection fails", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignExport(server);
+
+    vi.mocked(LauncherService).mockImplementation(function () {
+      return {
+        connect: vi.fn().mockRejectedValue(new Error("connection refused")),
+        disconnect: vi.fn(),
+      } as unknown as LauncherService;
+    });
+
+    const handler = getHandler("campaign-export");
+    const result = await handler({ campaignId: 15, format: "yaml", cdpPort: 9222 });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "Failed to connect to LinkedHelper: connection refused",
+        },
+      ],
+    });
+  });
+
+  it("returns error when LinkedHelper is not running", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignExport(server);
+
+    vi.mocked(LauncherService).mockImplementation(function () {
+      return {
+        connect: vi.fn().mockRejectedValue(new LinkedHelperNotRunningError(9222)),
+        disconnect: vi.fn(),
+      } as unknown as LauncherService;
+    });
+
+    const handler = getHandler("campaign-export");
+    const result = await handler({ campaignId: 15, format: "yaml", cdpPort: 9222 });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "LinkedHelper is not running. Use launch-app first.",
+        },
+      ],
+    });
+  });
+
+  it("closes database after success", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignExport(server);
+
+    mockLauncher();
+    const { close: dbClose } = mockDb();
+    mockCampaignRepo();
+    vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+    vi.mocked(serializeCampaignYaml).mockReturnValue("version: '1'\n");
+
+    const handler = getHandler("campaign-export");
+    await handler({ campaignId: 15, format: "yaml", cdpPort: 9222 });
+
+    expect(dbClose).toHaveBeenCalledOnce();
+  });
+
+  it("closes database after error", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignExport(server);
+
+    mockLauncher();
+    const { close: dbClose } = mockDb();
+    vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+    vi.mocked(CampaignRepository).mockImplementation(function () {
+      return {
+        getCampaign: vi.fn().mockImplementation(() => {
+          throw new Error("db error");
+        }),
+        getCampaignActions: vi.fn(),
+      } as unknown as CampaignRepository;
+    });
+
+    const handler = getHandler("campaign-export");
+    await handler({ campaignId: 15, format: "yaml", cdpPort: 9222 });
+
+    expect(dbClose).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/mcp/src/tools/campaign-export.ts
+++ b/packages/mcp/src/tools/campaign-export.ts
@@ -1,0 +1,167 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  type Account,
+  CampaignNotFoundError,
+  CampaignRepository,
+  DatabaseClient,
+  discoverDatabase,
+  LauncherService,
+  LinkedHelperNotRunningError,
+  serializeCampaignJson,
+  serializeCampaignYaml,
+} from "@lhremote/core";
+import { z } from "zod";
+
+export function registerCampaignExport(server: McpServer): void {
+  server.tool(
+    "campaign-export",
+    "Export a campaign configuration as YAML or JSON for backup or reuse",
+    {
+      campaignId: z
+        .number()
+        .int()
+        .positive()
+        .describe("Campaign ID"),
+      format: z
+        .enum(["yaml", "json"])
+        .optional()
+        .default("yaml")
+        .describe("Export format"),
+      cdpPort: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .default(9222)
+        .describe("CDP port (default: 9222)"),
+    },
+    async ({ campaignId, format, cdpPort }) => {
+      // Connect to launcher to find account
+      const launcher = new LauncherService(cdpPort);
+
+      try {
+        await launcher.connect();
+      } catch (error) {
+        if (error instanceof LinkedHelperNotRunningError) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: "LinkedHelper is not running. Use launch-app first.",
+              },
+            ],
+          };
+        }
+        const message =
+          error instanceof Error ? error.message : String(error);
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: `Failed to connect to LinkedHelper: ${message}`,
+            },
+          ],
+        };
+      }
+
+      let accountId: number;
+      try {
+        const accounts = await launcher.listAccounts();
+        if (accounts.length === 0) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: "No accounts found.",
+              },
+            ],
+          };
+        }
+        if (accounts.length > 1) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: "Multiple accounts found. Cannot determine which instance to use.",
+              },
+            ],
+          };
+        }
+        accountId = (accounts[0] as Account).id;
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : String(error);
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: `Failed to list accounts: ${message}`,
+            },
+          ],
+        };
+      } finally {
+        launcher.disconnect();
+      }
+
+      // Discover and open database
+      let db: DatabaseClient | null = null;
+
+      try {
+        const dbPath = discoverDatabase(accountId);
+        db = new DatabaseClient(dbPath);
+
+        const campaignRepo = new CampaignRepository(db);
+        const campaign = campaignRepo.getCampaign(campaignId);
+        const actions = campaignRepo.getCampaignActions(campaignId);
+
+        const config =
+          format === "json"
+            ? serializeCampaignJson(campaign, actions)
+            : serializeCampaignYaml(campaign, actions);
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                { campaignId, format, config },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      } catch (error) {
+        if (error instanceof CampaignNotFoundError) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: `Campaign ${String(campaignId)} not found.`,
+              },
+            ],
+          };
+        }
+        const message =
+          error instanceof Error ? error.message : String(error);
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: `Failed to export campaign: ${message}`,
+            },
+          ],
+        };
+      } finally {
+        db?.close();
+      }
+    },
+  );
+}

--- a/packages/mcp/src/tools/index.ts
+++ b/packages/mcp/src/tools/index.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import { registerCampaignCreate } from "./campaign-create.js";
 import { registerCampaignDelete } from "./campaign-delete.js";
+import { registerCampaignExport } from "./campaign-export.js";
 import { registerCampaignGet } from "./campaign-get.js";
 import { registerCheckReplies } from "./check-replies.js";
 import { registerCheckStatus } from "./check-status.js";
@@ -21,6 +22,7 @@ import { registerVisitAndExtract } from "./visit-and-extract.js";
 export function registerAllTools(server: McpServer): void {
   registerCampaignCreate(server);
   registerCampaignDelete(server);
+  registerCampaignExport(server);
   registerCampaignGet(server);
   registerFindApp(server);
   registerLaunchApp(server);


### PR DESCRIPTION
## Summary
- Add `campaign-export` MCP tool to export campaign configuration as YAML or JSON
- Accepts `campaignId`, `format` (yaml/json, default yaml), and `cdpPort` parameters
- Returns serialized campaign config using `serializeCampaignYaml`/`serializeCampaignJson` from core

## Test plan
- [x] Unit tests for YAML export (default)
- [x] Unit tests for JSON export
- [x] Error handling: non-existent campaign, connection failure, LinkedHelper not running
- [x] Database lifecycle: closes after success and error
- [x] Server test updated for tool count (17 → 18)
- [x] All tests pass (`pnpm test`)
- [x] Lint clean (`pnpm lint`)

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)