### PR TITLE
(fix) ci: re-add secrets guard to Codecov upload condition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,10 @@ jobs:
       - run: pnpm lint
       - run: pnpm test ${{ matrix.os == 'ubuntu-latest' && '-- -- --coverage' || '' }}
       - name: Upload coverage to Codecov
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-latest' && env.CODECOV_TOKEN != ''
         uses: codecov/codecov-action@v5
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
## Summary
- Re-adds `secrets.CODECOV_TOKEN != ''` guard to the Codecov upload step condition
- This guard was introduced in 81b6492 and accidentally reverted in d4dc650
- Without it, fork PRs attempt Codecov upload with an empty token (GitHub does not expose secrets to fork workflows)

## Test plan
- [ ] CI passes on all matrix OSes
- [ ] Codecov upload step correctly skipped when token is empty (fork PRs)

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)