### PR TITLE
Fix EditorConfig indent_size for TS/JS files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,3 +15,6 @@ indent_size = 2
 
 [*.json]
 indent_size = 2
+
+[*.{ts,js,mjs,cjs}]
+indent_size = 2


### PR DESCRIPTION
## Summary
- Add `[*.{ts,js,mjs,cjs}]` section to `.editorconfig` with `indent_size = 2`
- Aligns EditorConfig with the Prettier default used across the codebase, preventing 4-space indents that get reformatted to 2-space on save

Closes #136

## Test plan
- [ ] Verify `.editorconfig` has the new section
- [ ] Confirm editors pick up 2-space indent for TS/JS files

🤖 Generated with [Claude Code](https://claude.com/claude-code)