### PR TITLE
(fix) mcp: remove unused archive parameter from campaign-delete

### DIFF
--- a/packages/mcp/src/tools/campaign-delete.test.ts
+++ b/packages/mcp/src/tools/campaign-delete.test.ts
@@ -112,7 +112,6 @@ describe("registerCampaignDelete", () => {
     const handler = getHandler("campaign-delete");
     const result = await handler({
       campaignId: 15,
-      archive: true,
       cdpPort: 9222,
     });
 
@@ -148,7 +147,6 @@ describe("registerCampaignDelete", () => {
     const handler = getHandler("campaign-delete");
     const result = await handler({
       campaignId: 999,
-      archive: true,
       cdpPort: 9222,
     });
 
@@ -179,7 +177,6 @@ describe("registerCampaignDelete", () => {
     const handler = getHandler("campaign-delete");
     const result = await handler({
       campaignId: 15,
-      archive: true,
       cdpPort: 9222,
     });
 
@@ -208,7 +205,6 @@ describe("registerCampaignDelete", () => {
     const handler = getHandler("campaign-delete");
     const result = await handler({
       campaignId: 15,
-      archive: true,
       cdpPort: 9222,
     });
 
@@ -248,7 +244,6 @@ describe("registerCampaignDelete", () => {
     const handler = getHandler("campaign-delete");
     const result = await handler({
       campaignId: 15,
-      archive: true,
       cdpPort: 9222,
     });
 

--- a/packages/mcp/src/tools/campaign-delete.ts
+++ b/packages/mcp/src/tools/campaign-delete.ts
@@ -17,18 +17,13 @@ import { z } from "zod";
 export function registerCampaignDelete(server: McpServer): void {
   server.tool(
     "campaign-delete",
-    "Delete or archive a campaign. Archived campaigns are hidden but retained in database.",
+    "Delete (archive) a campaign. The campaign is hidden but retained in database.",
     {
       campaignId: z
         .number()
         .int()
         .positive()
         .describe("Campaign ID"),
-      archive: z
-        .boolean()
-        .optional()
-        .default(true)
-        .describe("Archive instead of delete (default: true)"),
       cdpPort: z
         .number()
         .int()


### PR DESCRIPTION
## Summary

- Remove the unused `archive` parameter from the MCP `campaign-delete` tool's Zod schema — the handler never read it and LinkedHelper always archives (hard delete is not supported)
- Update tool description to clarify archive-only behavior
- Remove `archive: true` from test handler calls

Closes #137

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm test` passes (684 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)