### PR TITLE
(fix) deps: add @eslint/js as explicit dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "dev": "turbo run dev"
   },
   "devDependencies": {
+    "@eslint/js": "catalog:",
     "@vitest/coverage-v8": "^4.0.18",
     "eslint": "^9.39.2",
     "eslint-config-prettier": "^10.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,9 @@ settings:
 
 catalogs:
   default:
+    '@eslint/js':
+      specifier: ^9.39.2
+      version: 9.39.2
     '@modelcontextprotocol/sdk':
       specifier: ^1.26.0
       version: 1.26.0
@@ -47,6 +50,9 @@ importers:
 
   .:
     devDependencies:
+      '@eslint/js':
+        specifier: 'catalog:'
+        version: 9.39.2
       '@vitest/coverage-v8':
         specifier: ^4.0.18
         version: 4.0.18(vitest@4.0.18(@types/node@22.19.11)(yaml@2.8.2))

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,7 @@ catalog:
   typescript: "^5.7.3"
   "@types/node": "^22"
   vitest: "^4.0.18"
+  "@eslint/js": "^9.39.2"
   eslint: "^9.39.2"
   prettier: "^3.8.1"
   typescript-eslint: "^8.54.0"


### PR DESCRIPTION
## Summary
- Add `@eslint/js` to pnpm workspace catalog and root `package.json` devDependencies
- `eslint.config.js` imports `@eslint/js` directly, but it was only resolved as a transitive dependency of `eslint` — a phantom dependency under strict pnpm resolution

## Test plan
- [x] `pnpm install` resolves without changes (already available transitively)
- [x] `pnpm lint` passes across all packages
- [x] `pnpm test` passes (684 tests)

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)