### PR TITLE
Add @vitest/coverage-v8 to pnpm workspace catalog

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@eslint/js": "catalog:",
-    "@vitest/coverage-v8": "^4.0.18",
+    "@vitest/coverage-v8": "catalog:",
     "eslint": "^9.39.2",
     "eslint-config-prettier": "^10.1.8",
     "prettier": "^3.8.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,9 @@ catalogs:
     '@types/node':
       specifier: ^22
       version: 22.19.11
+    '@vitest/coverage-v8':
+      specifier: ^4.0.18
+      version: 4.0.18
     commander:
       specifier: ^14.0.3
       version: 14.0.3
@@ -54,7 +57,7 @@ importers:
         specifier: 'catalog:'
         version: 9.39.2
       '@vitest/coverage-v8':
-        specifier: ^4.0.18
+        specifier: 'catalog:'
         version: 4.0.18(vitest@4.0.18(@types/node@22.19.11)(yaml@2.8.2))
       eslint:
         specifier: ^9.39.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,7 @@ catalog:
   typescript: "^5.7.3"
   "@types/node": "^22"
   vitest: "^4.0.18"
+  "@vitest/coverage-v8": "^4.0.18"
   "@eslint/js": "^9.39.2"
   eslint: "^9.39.2"
   prettier: "^3.8.1"


### PR DESCRIPTION
## Summary
- Add `@vitest/coverage-v8` to the pnpm workspace catalog in `pnpm-workspace.yaml` (version `^4.0.18`, matching `vitest`)
- Change root `package.json` entry from inline version specifier to `catalog:`

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)