### PR TITLE
(fix) deps: update TypeScript catalog specifier to ^5.9.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "eslint-config-prettier": "^10.1.8",
     "prettier": "^3.8.1",
     "turbo": "^2.3.4",
-    "typescript": "^5.7.3",
+    "typescript": "^5.9.3",
     "typescript-eslint": "^8.54.0",
     "vitest": "^4.0.18"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,7 +37,7 @@ catalogs:
       specifier: ^9.0.0
       version: 9.0.0
     typescript:
-      specifier: ^5.7.3
+      specifier: ^5.9.3
       version: 5.9.3
     vitest:
       specifier: ^4.0.18
@@ -72,7 +72,7 @@ importers:
         specifier: ^2.3.4
         version: 2.8.4
       typescript:
-        specifier: ^5.7.3
+        specifier: ^5.9.3
         version: 5.9.3
       typescript-eslint:
         specifier: ^8.54.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,7 +2,7 @@ packages:
   - "packages/*"
 
 catalog:
-  typescript: "^5.7.3"
+  typescript: "^5.9.3"
   "@types/node": "^22"
   vitest: "^4.0.18"
   "@vitest/coverage-v8": "^4.0.18"


### PR DESCRIPTION
## Summary
- Update TypeScript version specifier from `^5.7.3` to `^5.9.3` in `pnpm-workspace.yaml` catalog and `package.json`
- Lockfile updated to reflect the new specifier (resolved version unchanged at 5.9.3)

Closes #140

## Test plan
- [x] `pnpm install` resolves without changes (already on 5.9.3)
- [x] `pnpm build` succeeds
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (684 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)