### PR TITLE
(fix) docs: correct test helper path in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ Do **not** add issue numbers (e.g. `(#12)`) to commit messages. GitHub links PRs
 
 - Tier 1 and 2 run together via `pnpm test` — no separate commands needed.
 - Integration tests use `*.integration.test.ts` suffix.
-- Test helper `src/cdp/testing/launch-chromium.ts` manages Chromium lifecycle.
+- Test helper `packages/core/src/cdp/testing/launch-chromium.ts` manages Chromium lifecycle.
 - Chromium is installed in CI via `npx playwright-core install chromium --with-deps`.
 
 ## Infrastructure


### PR DESCRIPTION
## Summary
- Fix stale path `src/cdp/testing/launch-chromium.ts` → `packages/core/src/cdp/testing/launch-chromium.ts` in CLAUDE.md Testing section

Closes #141

## Test plan
- [x] Verified the actual file exists at `packages/core/src/cdp/testing/launch-chromium.ts`
- [x] Confirmed no other stale paths remain in CLAUDE.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)