### PR TITLE
Add timeout-minutes to CI/CD workflow jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   ci:
     name: Build, Lint & Test (${{ matrix.os }})
+    timeout-minutes: 15
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -35,6 +36,7 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
 
   package:
+    timeout-minutes: 10
     runs-on: ubuntu-latest
 
     permissions:
@@ -64,6 +66,7 @@ jobs:
           path: build/gh-pages
 
   publish-github-pages:
+    timeout-minutes: 10
     if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
 
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
   # moving version stamping before validation.
   validate:
     name: Validate
+    timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -28,6 +29,7 @@ jobs:
 
   publish-npm:
     name: Publish to npm
+    timeout-minutes: 10
     needs: validate
     runs-on: ubuntu-latest
     environment: npm-publish


### PR DESCRIPTION
## Summary

- Add `timeout-minutes: 15` to `ci` and `validate` jobs (build + lint + test)
- Add `timeout-minutes: 10` to `package`, `publish-github-pages`, and `publish-npm` jobs
- Prevents hung jobs from consuming runner minutes for hours (GitHub Actions defaults to 6h)

Closes #143

## Test plan

- [ ] CI workflow passes on all 3 OS matrix entries within timeout
- [ ] Release workflow YAML is valid (no syntax errors in CI)