### PR TITLE
(refactor) core: extract shared utilities (isCdpPort, delay, errorMessage)

### DIFF
--- a/packages/cli/src/handlers/campaign-create.ts
+++ b/packages/cli/src/handlers/campaign-create.ts
@@ -9,6 +9,7 @@ import {
   DatabaseClient,
   discoverDatabase,
   discoverInstancePort,
+  errorMessage,
   InstanceService,
   LauncherService,
   parseCampaignJson,
@@ -65,7 +66,7 @@ export async function handleCampaignCreate(options: {
         `Invalid campaign configuration: ${error.message}\n`,
       );
     } else {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = errorMessage(error);
       process.stderr.write(
         `Failed to parse campaign configuration: ${message}\n`,
       );
@@ -95,7 +96,7 @@ export async function handleCampaignCreate(options: {
     }
     accountId = (accounts[0] as Account).id;
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = errorMessage(error);
     process.stderr.write(`${message}\n`);
     process.exitCode = 1;
     return;
@@ -136,7 +137,7 @@ export async function handleCampaignCreate(options: {
     if (error instanceof CampaignExecutionError) {
       process.stderr.write(`Failed to create campaign: ${error.message}\n`);
     } else {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = errorMessage(error);
       process.stderr.write(`${message}\n`);
     }
     process.exitCode = 1;

--- a/packages/cli/src/handlers/campaign-delete.ts
+++ b/packages/cli/src/handlers/campaign-delete.ts
@@ -6,6 +6,7 @@ import {
   DatabaseClient,
   discoverDatabase,
   discoverInstancePort,
+  errorMessage,
   InstanceService,
   LauncherService,
 } from "@lhremote/core";
@@ -40,7 +41,7 @@ export async function handleCampaignDelete(
     }
     accountId = (accounts[0] as Account).id;
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = errorMessage(error);
     process.stderr.write(`${message}\n`);
     process.exitCode = 1;
     return;
@@ -88,7 +89,7 @@ export async function handleCampaignDelete(
     } else if (error instanceof CampaignExecutionError) {
       process.stderr.write(`Failed to delete campaign: ${error.message}\n`);
     } else {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = errorMessage(error);
       process.stderr.write(`${message}\n`);
     }
     process.exitCode = 1;

--- a/packages/cli/src/handlers/campaign-export.ts
+++ b/packages/cli/src/handlers/campaign-export.ts
@@ -6,6 +6,7 @@ import {
   CampaignRepository,
   DatabaseClient,
   discoverDatabase,
+  errorMessage,
   LauncherService,
   serializeCampaignJson,
   serializeCampaignYaml,
@@ -51,7 +52,7 @@ export async function handleCampaignExport(
     }
     accountId = (accounts[0] as Account).id;
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = errorMessage(error);
     process.stderr.write(`${message}\n`);
     process.exitCode = 1;
     return;
@@ -87,7 +88,7 @@ export async function handleCampaignExport(
     if (error instanceof CampaignNotFoundError) {
       process.stderr.write(`Campaign ${String(campaignId)} not found.\n`);
     } else {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = errorMessage(error);
       process.stderr.write(`${message}\n`);
     }
     process.exitCode = 1;

--- a/packages/cli/src/handlers/campaign-get.ts
+++ b/packages/cli/src/handlers/campaign-get.ts
@@ -4,6 +4,7 @@ import {
   CampaignRepository,
   DatabaseClient,
   discoverDatabase,
+  errorMessage,
   LauncherService,
 } from "@lhremote/core";
 
@@ -37,7 +38,7 @@ export async function handleCampaignGet(
     }
     accountId = (accounts[0] as Account).id;
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = errorMessage(error);
     process.stderr.write(`${message}\n`);
     process.exitCode = 1;
     return;
@@ -85,7 +86,7 @@ export async function handleCampaignGet(
     if (error instanceof CampaignNotFoundError) {
       process.stderr.write(`Campaign ${String(campaignId)} not found.\n`);
     } else {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = errorMessage(error);
       process.stderr.write(`${message}\n`);
     }
     process.exitCode = 1;

--- a/packages/cli/src/handlers/campaign-list.ts
+++ b/packages/cli/src/handlers/campaign-list.ts
@@ -3,6 +3,7 @@ import {
   type CampaignSummary,
   DatabaseClient,
   discoverAllDatabases,
+  errorMessage,
 } from "@lhremote/core";
 
 export async function handleCampaignList(options: {
@@ -27,7 +28,7 @@ export async function handleCampaignList(options: {
       const campaigns = repo.listCampaigns({ includeArchived });
       allCampaigns.push(...campaigns);
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = errorMessage(error);
       process.stderr.write(`Error in database at ${dbPath}: ${message}\n`);
       process.exitCode = 1;
       return;

--- a/packages/cli/src/handlers/campaign-start.ts
+++ b/packages/cli/src/handlers/campaign-start.ts
@@ -9,6 +9,7 @@ import {
   DatabaseClient,
   discoverDatabase,
   discoverInstancePort,
+  errorMessage,
   InstanceService,
   LauncherService,
 } from "@lhremote/core";
@@ -68,7 +69,7 @@ export async function handleCampaignStart(
     try {
       personIds = parsePersonIds(options.personIds);
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = errorMessage(error);
       process.stderr.write(`${message}\n`);
       process.exitCode = 1;
       return;
@@ -77,7 +78,7 @@ export async function handleCampaignStart(
     try {
       personIds = readPersonIdsFile(options.personIdsFile);
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = errorMessage(error);
       process.stderr.write(`${message}\n`);
       process.exitCode = 1;
       return;
@@ -117,7 +118,7 @@ export async function handleCampaignStart(
     }
     accountId = (accounts[0] as Account).id;
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = errorMessage(error);
     process.stderr.write(`${message}\n`);
     process.exitCode = 1;
     return;
@@ -168,7 +169,7 @@ export async function handleCampaignStart(
     } else if (error instanceof CampaignExecutionError) {
       process.stderr.write(`Failed to start campaign: ${error.message}\n`);
     } else {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = errorMessage(error);
       process.stderr.write(`${message}\n`);
     }
     process.exitCode = 1;

--- a/packages/cli/src/handlers/campaign-status.ts
+++ b/packages/cli/src/handlers/campaign-status.ts
@@ -6,6 +6,7 @@ import {
   DatabaseClient,
   discoverDatabase,
   discoverInstancePort,
+  errorMessage,
   InstanceService,
   LauncherService,
 } from "@lhremote/core";
@@ -42,7 +43,7 @@ export async function handleCampaignStatus(
     }
     accountId = (accounts[0] as Account).id;
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = errorMessage(error);
     process.stderr.write(`${message}\n`);
     process.exitCode = 1;
     return;
@@ -119,7 +120,7 @@ export async function handleCampaignStatus(
         `Failed to get campaign status: ${error.message}\n`,
       );
     } else {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = errorMessage(error);
       process.stderr.write(`${message}\n`);
     }
     process.exitCode = 1;

--- a/packages/cli/src/handlers/campaign-stop.ts
+++ b/packages/cli/src/handlers/campaign-stop.ts
@@ -6,6 +6,7 @@ import {
   DatabaseClient,
   discoverDatabase,
   discoverInstancePort,
+  errorMessage,
   InstanceService,
   LauncherService,
 } from "@lhremote/core";
@@ -40,7 +41,7 @@ export async function handleCampaignStop(
     }
     accountId = (accounts[0] as Account).id;
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = errorMessage(error);
     process.stderr.write(`${message}\n`);
     process.exitCode = 1;
     return;
@@ -86,7 +87,7 @@ export async function handleCampaignStop(
     } else if (error instanceof CampaignExecutionError) {
       process.stderr.write(`Failed to stop campaign: ${error.message}\n`);
     } else {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = errorMessage(error);
       process.stderr.write(`${message}\n`);
     }
     process.exitCode = 1;

--- a/packages/cli/src/handlers/check-replies.ts
+++ b/packages/cli/src/handlers/check-replies.ts
@@ -4,6 +4,7 @@ import {
   DatabaseClient,
   discoverDatabase,
   discoverInstancePort,
+  errorMessage,
   InstanceService,
   LauncherService,
   MessageRepository,
@@ -40,7 +41,7 @@ export async function handleCheckReplies(options: {
     }
     accountId = (accounts[0] as Account).id;
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = errorMessage(error);
     process.stderr.write(`${message}\n`);
     process.exitCode = 1;
     return;
@@ -98,7 +99,7 @@ export async function handleCheckReplies(options: {
       printReplies(conversations, totalNew);
     }
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = errorMessage(error);
     process.stderr.write(`${message}\n`);
     process.exitCode = 1;
   } finally {

--- a/packages/cli/src/handlers/check-status.ts
+++ b/packages/cli/src/handlers/check-status.ts
@@ -1,4 +1,4 @@
-import { checkStatus } from "@lhremote/core";
+import { checkStatus, errorMessage } from "@lhremote/core";
 
 export async function handleCheckStatus(options: {
   cdpPort?: number;
@@ -49,7 +49,7 @@ export async function handleCheckStatus(options: {
       }
     }
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = errorMessage(error);
     process.stderr.write(`${message}\n`);
     process.exitCode = 1;
   }

--- a/packages/cli/src/handlers/find-app.ts
+++ b/packages/cli/src/handlers/find-app.ts
@@ -1,4 +1,4 @@
-import { findApp } from "@lhremote/core";
+import { errorMessage, findApp } from "@lhremote/core";
 
 export async function handleFindApp(options: {
   json?: boolean;
@@ -25,7 +25,7 @@ export async function handleFindApp(options: {
       );
     }
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = errorMessage(error);
     process.stderr.write(`${message}\n`);
     process.exitCode = 1;
   }

--- a/packages/cli/src/handlers/launch-app.ts
+++ b/packages/cli/src/handlers/launch-app.ts
@@ -1,4 +1,4 @@
-import { AppService } from "@lhremote/core";
+import { AppService, errorMessage } from "@lhremote/core";
 
 export async function handleLaunchApp(options: {
   cdpPort?: number;
@@ -8,7 +8,7 @@ export async function handleLaunchApp(options: {
   try {
     await app.launch();
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = errorMessage(error);
     process.stderr.write(`${message}\n`);
     process.exitCode = 1;
     return;

--- a/packages/cli/src/handlers/list-accounts.ts
+++ b/packages/cli/src/handlers/list-accounts.ts
@@ -1,4 +1,4 @@
-import { LauncherService } from "@lhremote/core";
+import { errorMessage, LauncherService } from "@lhremote/core";
 
 export async function handleListAccounts(options: {
   cdpPort?: number;
@@ -9,7 +9,7 @@ export async function handleListAccounts(options: {
   try {
     await launcher.connect();
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = errorMessage(error);
     process.stderr.write(`${message}\n`);
     process.exitCode = 1;
     return;
@@ -31,7 +31,7 @@ export async function handleListAccounts(options: {
       }
     }
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = errorMessage(error);
     process.stderr.write(`${message}\n`);
     process.exitCode = 1;
   } finally {

--- a/packages/cli/src/handlers/query-messages.ts
+++ b/packages/cli/src/handlers/query-messages.ts
@@ -5,6 +5,7 @@ import {
   ChatNotFoundError,
   DatabaseClient,
   discoverAllDatabases,
+  errorMessage,
   MessageRepository,
 } from "@lhremote/core";
 
@@ -77,7 +78,7 @@ export async function handleQueryMessages(options: {
       if (error instanceof ChatNotFoundError) {
         continue;
       }
-      const message = error instanceof Error ? error.message : String(error);
+      const message = errorMessage(error);
       process.stderr.write(`${message}\n`);
       process.exitCode = 1;
       return;

--- a/packages/cli/src/handlers/query-profile.ts
+++ b/packages/cli/src/handlers/query-profile.ts
@@ -2,6 +2,7 @@ import {
   type Profile,
   DatabaseClient,
   discoverAllDatabases,
+  errorMessage,
   ProfileNotFoundError,
   ProfileRepository,
 } from "@lhremote/core";
@@ -43,7 +44,7 @@ export async function handleQueryProfile(options: {
       if (error instanceof ProfileNotFoundError) {
         continue;
       }
-      const message = error instanceof Error ? error.message : String(error);
+      const message = errorMessage(error);
       process.stderr.write(`${message}\n`);
       process.exitCode = 1;
       return;

--- a/packages/cli/src/handlers/query-profiles.ts
+++ b/packages/cli/src/handlers/query-profiles.ts
@@ -1,6 +1,7 @@
 import {
   DatabaseClient,
   discoverAllDatabases,
+  errorMessage,
   ProfileRepository,
   type ProfileSearchResult,
 } from "@lhremote/core";
@@ -38,7 +39,7 @@ export async function handleQueryProfiles(options: {
       allProfiles.push(...result.profiles);
       totalCount += result.total;
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = errorMessage(error);
       process.stderr.write(`${message}\n`);
       process.exitCode = 1;
       return;

--- a/packages/cli/src/handlers/quit-app.ts
+++ b/packages/cli/src/handlers/quit-app.ts
@@ -1,4 +1,4 @@
-import { AppService } from "@lhremote/core";
+import { AppService, errorMessage } from "@lhremote/core";
 
 export async function handleQuitApp(options: {
   cdpPort?: number;
@@ -8,7 +8,7 @@ export async function handleQuitApp(options: {
   try {
     await app.quit();
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = errorMessage(error);
     process.stderr.write(`${message}\n`);
     process.exitCode = 1;
     return;

--- a/packages/cli/src/handlers/scrape-messaging-history.ts
+++ b/packages/cli/src/handlers/scrape-messaging-history.ts
@@ -4,6 +4,7 @@ import {
   DatabaseClient,
   discoverDatabase,
   discoverInstancePort,
+  errorMessage,
   InstanceService,
   LauncherService,
   MessageRepository,
@@ -36,7 +37,7 @@ export async function handleScrapeMessagingHistory(options: {
     }
     accountId = (accounts[0] as Account).id;
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = errorMessage(error);
     process.stderr.write(`${message}\n`);
     process.exitCode = 1;
     return;
@@ -87,7 +88,7 @@ export async function handleScrapeMessagingHistory(options: {
       printStats(stats);
     }
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = errorMessage(error);
     process.stderr.write(`${message}\n`);
     process.exitCode = 1;
   } finally {

--- a/packages/cli/src/handlers/start-instance.ts
+++ b/packages/cli/src/handlers/start-instance.ts
@@ -1,4 +1,5 @@
 import {
+  errorMessage,
   LauncherService,
   startInstanceWithRecovery,
 } from "@lhremote/core";
@@ -14,7 +15,7 @@ export async function handleStartInstance(
   try {
     await launcher.connect();
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = errorMessage(error);
     process.stderr.write(`${message}\n`);
     process.exitCode = 1;
     return;
@@ -44,7 +45,7 @@ export async function handleStartInstance(
       `Instance ${verb} for account ${String(accountId)} on CDP port ${String(outcome.port)}\n`,
     );
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = errorMessage(error);
     process.stderr.write(`${message}\n`);
     process.exitCode = 1;
   } finally {

--- a/packages/cli/src/handlers/stop-instance.ts
+++ b/packages/cli/src/handlers/stop-instance.ts
@@ -1,4 +1,4 @@
-import { LauncherService } from "@lhremote/core";
+import { errorMessage, LauncherService } from "@lhremote/core";
 
 export async function handleStopInstance(
   accountIdArg: string,
@@ -11,7 +11,7 @@ export async function handleStopInstance(
   try {
     await launcher.connect();
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = errorMessage(error);
     process.stderr.write(`${message}\n`);
     process.exitCode = 1;
     return;
@@ -23,7 +23,7 @@ export async function handleStopInstance(
       `Instance stopped for account ${String(accountId)}\n`,
     );
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = errorMessage(error);
     process.stderr.write(`${message}\n`);
     process.exitCode = 1;
   } finally {

--- a/packages/core/src/cdp/app-discovery.ts
+++ b/packages/core/src/cdp/app-discovery.ts
@@ -1,5 +1,6 @@
 import { pidToPorts } from "pid-port";
 import psList from "ps-list";
+import { isCdpPort } from "../utils/cdp-port.js";
 
 /**
  * Known LinkedHelper binary names across platforms.
@@ -72,18 +73,4 @@ async function probeProcess(pid: number): Promise<DiscoveredApp> {
   // Process is running but no CDP port detected (or none responding)
   const firstPort = [...ports][0] ?? null;
   return { pid, cdpPort: firstPort, connectable: false };
-}
-
-/**
- * Check whether a port exposes a CDP `/json/list` endpoint.
- */
-async function isCdpPort(port: number): Promise<boolean> {
-  try {
-    const response = await fetch(
-      `http://127.0.0.1:${String(port)}/json/list`,
-    );
-    return response.ok;
-  } catch {
-    return false;
-  }
 }

--- a/packages/core/src/cdp/instance-discovery.ts
+++ b/packages/core/src/cdp/instance-discovery.ts
@@ -1,5 +1,6 @@
 import { pidToPorts, portToPid } from "pid-port";
 import psList from "ps-list";
+import { isCdpPort } from "../utils/cdp-port.js";
 
 /**
  * Default CDP port used by the LinkedHelper launcher process.
@@ -130,19 +131,5 @@ export async function killInstanceProcesses(
     } catch {
       // Process may already be dead
     }
-  }
-}
-
-/**
- * Check whether a port exposes a CDP `/json/list` endpoint.
- */
-async function isCdpPort(port: number): Promise<boolean> {
-  try {
-    const response = await fetch(
-      `http://127.0.0.1:${String(port)}/json/list`,
-    );
-    return response.ok;
-  } catch {
-    return false;
   }
 }

--- a/packages/core/src/formats/campaign-format.ts
+++ b/packages/core/src/formats/campaign-format.ts
@@ -1,5 +1,6 @@
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 
+import { errorMessage } from "../utils/error-message.js";
 import type {
   Campaign,
   CampaignAction,
@@ -62,7 +63,7 @@ export function parseCampaignYaml(yamlString: string): CampaignConfig {
   try {
     doc = parseYaml(yamlString);
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = errorMessage(error);
     throw new CampaignFormatError(`Invalid YAML: ${message}`);
   }
   return parseCampaignDocument(doc);
@@ -79,7 +80,7 @@ export function parseCampaignJson(jsonString: string): CampaignConfig {
   try {
     doc = JSON.parse(jsonString) as unknown;
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = errorMessage(error);
     throw new CampaignFormatError(`Invalid JSON: ${message}`);
   }
   return parseCampaignDocument(doc);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -118,3 +118,6 @@ export {
   findApp,
   type DiscoveredApp,
 } from "./cdp/index.js";
+
+// Utilities
+export { delay, errorMessage, isCdpPort } from "./utils/index.js";

--- a/packages/core/src/services/campaign.ts
+++ b/packages/core/src/services/campaign.ts
@@ -9,6 +9,8 @@ import type {
 } from "../types/index.js";
 import type { DatabaseClient } from "../db/index.js";
 import { CampaignRepository } from "../db/index.js";
+import { delay } from "../utils/delay.js";
+import { errorMessage } from "../utils/error-message.js";
 import type { InstanceService } from "./instance.js";
 import { CampaignExecutionError, CampaignTimeoutError } from "./errors.js";
 
@@ -82,7 +84,7 @@ export class CampaignService {
       return this.campaignRepo.getCampaign(result.id);
     } catch (error) {
       if (error instanceof CampaignExecutionError) throw error;
-      const message = error instanceof Error ? error.message : String(error);
+      const message = errorMessage(error);
       throw new CampaignExecutionError(
         `Failed to create campaign: ${message}`,
         undefined,
@@ -127,7 +129,7 @@ export class CampaignService {
       );
     } catch (error) {
       if (error instanceof CampaignExecutionError) throw error;
-      const message = error instanceof Error ? error.message : String(error);
+      const message = errorMessage(error);
       throw new CampaignExecutionError(
         `Failed to delete campaign ${String(campaignId)}: ${message}`,
         campaignId,
@@ -169,7 +171,7 @@ export class CampaignService {
         })()`,
       );
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = errorMessage(error);
       throw new CampaignExecutionError(
         `Failed to unpause campaign ${String(campaignId)}: ${message}`,
         campaignId,
@@ -194,7 +196,7 @@ export class CampaignService {
       }
     } catch (error) {
       if (error instanceof CampaignExecutionError) throw error;
-      const message = error instanceof Error ? error.message : String(error);
+      const message = errorMessage(error);
       throw new CampaignExecutionError(
         `Failed to start campaign runner: ${message}`,
         campaignId,
@@ -231,7 +233,7 @@ export class CampaignService {
       );
     } catch (error) {
       if (error instanceof CampaignExecutionError) throw error;
-      const message = error instanceof Error ? error.message : String(error);
+      const message = errorMessage(error);
       throw new CampaignExecutionError(
         `Failed to stop campaign ${String(campaignId)}: ${message}`,
         campaignId,
@@ -357,8 +359,4 @@ export class CampaignService {
       }),
     );
   }
-}
-
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/packages/core/src/services/instance-lifecycle.ts
+++ b/packages/core/src/services/instance-lifecycle.ts
@@ -1,4 +1,5 @@
 import { discoverInstancePort } from "../cdp/index.js";
+import { delay } from "../utils/delay.js";
 import type { LauncherService } from "./launcher.js";
 import { StartInstanceError } from "./errors.js";
 
@@ -54,7 +55,7 @@ export async function startInstanceWithRecovery(
 
       // Stale state — crash recovery
       await launcher.stopInstance(accountId);
-      await sleep(CRASH_RECOVERY_DELAY);
+      await delay(CRASH_RECOVERY_DELAY);
       await launcher.startInstance(accountId);
     } else {
       throw error;
@@ -86,7 +87,7 @@ export async function waitForInstancePort(
     if (port !== null) {
       return port;
     }
-    await sleep(PORT_DISCOVERY_INTERVAL);
+    await delay(PORT_DISCOVERY_INTERVAL);
   }
 
   return null;
@@ -108,10 +109,6 @@ export async function waitForInstanceShutdown(
     if (port === null) {
       return;
     }
-    await sleep(PORT_DISCOVERY_INTERVAL);
+    await delay(PORT_DISCOVERY_INTERVAL);
   }
-}
-
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/packages/core/src/services/instance.ts
+++ b/packages/core/src/services/instance.ts
@@ -1,5 +1,7 @@
 import { CDPClient, discoverTargets } from "../cdp/index.js";
 import type { CdpTarget } from "../types/cdp.js";
+import { delay } from "../utils/delay.js";
+import { errorMessage } from "../utils/error-message.js";
 import { ActionExecutionError, InstanceNotRunningError, ServiceError } from "./errors.js";
 
 /**
@@ -68,7 +70,7 @@ export class InstanceService {
         break;
       }
 
-      await new Promise<void>((resolve) => setTimeout(resolve, CONNECT_POLL_INTERVAL));
+      await delay(CONNECT_POLL_INTERVAL);
     }
 
     if (!linkedInTarget) {
@@ -146,7 +148,7 @@ export class InstanceService {
         true,
       );
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      const message = errorMessage(error);
       throw new ActionExecutionError(actionName, `Action '${actionName}' failed: ${message}`, { cause: error });
     }
 

--- a/packages/core/src/utils/cdp-port.test.ts
+++ b/packages/core/src/utils/cdp-port.test.ts
@@ -1,0 +1,36 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { isCdpPort } from "./cdp-port.js";
+
+describe("isCdpPort", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should return true when the port responds with ok", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: true }),
+    );
+
+    expect(await isCdpPort(9222)).toBe(true);
+    expect(fetch).toHaveBeenCalledWith("http://127.0.0.1:9222/json/list");
+  });
+
+  it("should return false when the port responds with non-ok", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({ ok: false }),
+    );
+
+    expect(await isCdpPort(9222)).toBe(false);
+  });
+
+  it("should return false when fetch throws", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new Error("ECONNREFUSED")),
+    );
+
+    expect(await isCdpPort(9222)).toBe(false);
+  });
+});

--- a/packages/core/src/utils/cdp-port.ts
+++ b/packages/core/src/utils/cdp-port.ts
@@ -1,0 +1,13 @@
+/**
+ * Check whether a port exposes a CDP `/json/list` endpoint.
+ */
+export async function isCdpPort(port: number): Promise<boolean> {
+  try {
+    const response = await fetch(
+      `http://127.0.0.1:${String(port)}/json/list`,
+    );
+    return response.ok;
+  } catch {
+    return false;
+  }
+}

--- a/packages/core/src/utils/delay.test.ts
+++ b/packages/core/src/utils/delay.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { delay } from "./delay.js";
+
+describe("delay", () => {
+  it("should resolve after the given time", async () => {
+    const start = Date.now();
+    await delay(50);
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeGreaterThanOrEqual(40);
+  });
+
+  it("should return a promise that resolves to undefined", async () => {
+    const result = await delay(0);
+    expect(result).toBeUndefined();
+  });
+});

--- a/packages/core/src/utils/delay.ts
+++ b/packages/core/src/utils/delay.ts
@@ -1,0 +1,6 @@
+/**
+ * Return a promise that resolves after the given number of milliseconds.
+ */
+export function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/core/src/utils/error-message.test.ts
+++ b/packages/core/src/utils/error-message.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { errorMessage } from "./error-message.js";
+
+describe("errorMessage", () => {
+  it("should extract message from Error instances", () => {
+    expect(errorMessage(new Error("something failed"))).toBe(
+      "something failed",
+    );
+  });
+
+  it("should extract message from Error subclasses", () => {
+    expect(errorMessage(new TypeError("bad type"))).toBe("bad type");
+  });
+
+  it("should convert strings via String()", () => {
+    expect(errorMessage("plain string")).toBe("plain string");
+  });
+
+  it("should convert numbers via String()", () => {
+    expect(errorMessage(42)).toBe("42");
+  });
+
+  it("should convert null via String()", () => {
+    expect(errorMessage(null)).toBe("null");
+  });
+
+  it("should convert undefined via String()", () => {
+    expect(errorMessage(undefined)).toBe("undefined");
+  });
+
+  it("should convert objects via String()", () => {
+    expect(errorMessage({ toString: () => "custom" })).toBe("custom");
+  });
+});

--- a/packages/core/src/utils/error-message.ts
+++ b/packages/core/src/utils/error-message.ts
@@ -1,0 +1,6 @@
+/**
+ * Extract a human-readable message from an unknown caught value.
+ */
+export function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,0 +1,3 @@
+export { isCdpPort } from "./cdp-port.js";
+export { delay } from "./delay.js";
+export { errorMessage } from "./error-message.js";

--- a/packages/mcp/src/stdio.ts
+++ b/packages/mcp/src/stdio.ts
@@ -1,4 +1,5 @@
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { errorMessage } from "@lhremote/core";
 
 import { createServer } from "./server.js";
 
@@ -14,7 +15,7 @@ export async function runStdioServer(): Promise<void> {
   try {
     await server.connect(transport);
   } catch (error: unknown) {
-    const message = error instanceof Error ? error.message : String(error);
+    const message = errorMessage(error);
     process.stderr.write(`Failed to start MCP server: ${message}\n`);
     process.exit(1);
   }
@@ -25,7 +26,7 @@ export async function runStdioServer(): Promise<void> {
     server
       .close()
       .catch((error: unknown) => {
-        const message = error instanceof Error ? error.message : String(error);
+        const message = errorMessage(error);
         process.stderr.write(`Error during shutdown: ${message}\n`);
       })
       .finally(() => {

--- a/packages/mcp/src/tools/campaign-create.ts
+++ b/packages/mcp/src/tools/campaign-create.ts
@@ -7,6 +7,7 @@ import {
   DatabaseClient,
   discoverDatabase,
   discoverInstancePort,
+  errorMessage,
   InstanceNotRunningError,
   InstanceService,
   LauncherService,
@@ -55,8 +56,7 @@ export function registerCampaignCreate(server: McpServer): void {
             ],
           };
         }
-        const message =
-          error instanceof Error ? error.message : String(error);
+        const message = errorMessage(error);
         return {
           isError: true,
           content: [
@@ -85,8 +85,7 @@ export function registerCampaignCreate(server: McpServer): void {
             ],
           };
         }
-        const message =
-          error instanceof Error ? error.message : String(error);
+        const message = errorMessage(error);
         return {
           isError: true,
           content: [
@@ -125,8 +124,7 @@ export function registerCampaignCreate(server: McpServer): void {
         }
         accountId = (accounts[0] as Account).id;
       } catch (error) {
-        const message =
-          error instanceof Error ? error.message : String(error);
+        const message = errorMessage(error);
         return {
           isError: true,
           content: [
@@ -200,8 +198,7 @@ export function registerCampaignCreate(server: McpServer): void {
             ],
           };
         }
-        const message =
-          error instanceof Error ? error.message : String(error);
+        const message = errorMessage(error);
         return {
           isError: true,
           content: [

--- a/packages/mcp/src/tools/campaign-delete.ts
+++ b/packages/mcp/src/tools/campaign-delete.ts
@@ -7,6 +7,7 @@ import {
   DatabaseClient,
   discoverDatabase,
   discoverInstancePort,
+  errorMessage,
   InstanceNotRunningError,
   InstanceService,
   LauncherService,
@@ -50,8 +51,7 @@ export function registerCampaignDelete(server: McpServer): void {
             ],
           };
         }
-        const message =
-          error instanceof Error ? error.message : String(error);
+        const message = errorMessage(error);
         return {
           isError: true,
           content: [
@@ -90,8 +90,7 @@ export function registerCampaignDelete(server: McpServer): void {
         }
         accountId = (accounts[0] as Account).id;
       } catch (error) {
-        const message =
-          error instanceof Error ? error.message : String(error);
+        const message = errorMessage(error);
         return {
           isError: true,
           content: [
@@ -180,8 +179,7 @@ export function registerCampaignDelete(server: McpServer): void {
             ],
           };
         }
-        const message =
-          error instanceof Error ? error.message : String(error);
+        const message = errorMessage(error);
         return {
           isError: true,
           content: [

--- a/packages/mcp/src/tools/campaign-export.ts
+++ b/packages/mcp/src/tools/campaign-export.ts
@@ -5,6 +5,7 @@ import {
   CampaignRepository,
   DatabaseClient,
   discoverDatabase,
+  errorMessage,
   LauncherService,
   LinkedHelperNotRunningError,
   serializeCampaignJson,
@@ -53,8 +54,7 @@ export function registerCampaignExport(server: McpServer): void {
             ],
           };
         }
-        const message =
-          error instanceof Error ? error.message : String(error);
+        const message = errorMessage(error);
         return {
           isError: true,
           content: [
@@ -93,8 +93,7 @@ export function registerCampaignExport(server: McpServer): void {
         }
         accountId = (accounts[0] as Account).id;
       } catch (error) {
-        const message =
-          error instanceof Error ? error.message : String(error);
+        const message = errorMessage(error);
         return {
           isError: true,
           content: [
@@ -148,8 +147,7 @@ export function registerCampaignExport(server: McpServer): void {
             ],
           };
         }
-        const message =
-          error instanceof Error ? error.message : String(error);
+        const message = errorMessage(error);
         return {
           isError: true,
           content: [

--- a/packages/mcp/src/tools/campaign-get.ts
+++ b/packages/mcp/src/tools/campaign-get.ts
@@ -5,6 +5,7 @@ import {
   CampaignRepository,
   DatabaseClient,
   discoverDatabase,
+  errorMessage,
   LauncherService,
   LinkedHelperNotRunningError,
 } from "@lhremote/core";
@@ -46,8 +47,7 @@ export function registerCampaignGet(server: McpServer): void {
             ],
           };
         }
-        const message =
-          error instanceof Error ? error.message : String(error);
+        const message = errorMessage(error);
         return {
           isError: true,
           content: [
@@ -86,8 +86,7 @@ export function registerCampaignGet(server: McpServer): void {
         }
         accountId = (accounts[0] as Account).id;
       } catch (error) {
-        const message =
-          error instanceof Error ? error.message : String(error);
+        const message = errorMessage(error);
         return {
           isError: true,
           content: [
@@ -132,8 +131,7 @@ export function registerCampaignGet(server: McpServer): void {
             ],
           };
         }
-        const message =
-          error instanceof Error ? error.message : String(error);
+        const message = errorMessage(error);
         return {
           isError: true,
           content: [

--- a/packages/mcp/src/tools/campaign-list.ts
+++ b/packages/mcp/src/tools/campaign-list.ts
@@ -4,6 +4,7 @@ import {
   CampaignRepository,
   DatabaseClient,
   discoverDatabase,
+  errorMessage,
   LauncherService,
   LinkedHelperNotRunningError,
 } from "@lhremote/core";
@@ -45,8 +46,7 @@ export function registerCampaignList(server: McpServer): void {
             ],
           };
         }
-        const message =
-          error instanceof Error ? error.message : String(error);
+        const message = errorMessage(error);
         return {
           isError: true,
           content: [
@@ -85,8 +85,7 @@ export function registerCampaignList(server: McpServer): void {
         }
         accountId = (accounts[0] as Account).id;
       } catch (error) {
-        const message =
-          error instanceof Error ? error.message : String(error);
+        const message = errorMessage(error);
         return {
           isError: true,
           content: [
@@ -123,8 +122,7 @@ export function registerCampaignList(server: McpServer): void {
           ],
         };
       } catch (error) {
-        const message =
-          error instanceof Error ? error.message : String(error);
+        const message = errorMessage(error);
         return {
           isError: true,
           content: [

--- a/packages/mcp/src/tools/campaign-start.ts
+++ b/packages/mcp/src/tools/campaign-start.ts
@@ -8,6 +8,7 @@ import {
   DatabaseClient,
   discoverDatabase,
   discoverInstancePort,
+  errorMessage,
   InstanceNotRunningError,
   InstanceService,
   LauncherService,
@@ -55,8 +56,7 @@ export function registerCampaignStart(server: McpServer): void {
             ],
           };
         }
-        const message =
-          error instanceof Error ? error.message : String(error);
+        const message = errorMessage(error);
         return {
           isError: true,
           content: [
@@ -95,8 +95,7 @@ export function registerCampaignStart(server: McpServer): void {
         }
         accountId = (accounts[0] as Account).id;
       } catch (error) {
-        const message =
-          error instanceof Error ? error.message : String(error);
+        const message = errorMessage(error);
         return {
           isError: true,
           content: [
@@ -202,8 +201,7 @@ export function registerCampaignStart(server: McpServer): void {
             ],
           };
         }
-        const message =
-          error instanceof Error ? error.message : String(error);
+        const message = errorMessage(error);
         return {
           isError: true,
           content: [

--- a/packages/mcp/src/tools/campaign-status.ts
+++ b/packages/mcp/src/tools/campaign-status.ts
@@ -7,6 +7,7 @@ import {
   DatabaseClient,
   discoverDatabase,
   discoverInstancePort,
+  errorMessage,
   InstanceNotRunningError,
   InstanceService,
   LauncherService,
@@ -62,8 +63,7 @@ export function registerCampaignStatus(server: McpServer): void {
             ],
           };
         }
-        const message =
-          error instanceof Error ? error.message : String(error);
+        const message = errorMessage(error);
         return {
           isError: true,
           content: [
@@ -102,8 +102,7 @@ export function registerCampaignStatus(server: McpServer): void {
         }
         accountId = (accounts[0] as Account).id;
       } catch (error) {
-        const message =
-          error instanceof Error ? error.message : String(error);
+        const message = errorMessage(error);
         return {
           isError: true,
           content: [
@@ -194,8 +193,7 @@ export function registerCampaignStatus(server: McpServer): void {
             ],
           };
         }
-        const message =
-          error instanceof Error ? error.message : String(error);
+        const message = errorMessage(error);
         return {
           isError: true,
           content: [

--- a/packages/mcp/src/tools/campaign-stop.ts
+++ b/packages/mcp/src/tools/campaign-stop.ts
@@ -7,6 +7,7 @@ import {
   DatabaseClient,
   discoverDatabase,
   discoverInstancePort,
+  errorMessage,
   InstanceNotRunningError,
   InstanceService,
   LauncherService,
@@ -50,8 +51,7 @@ export function registerCampaignStop(server: McpServer): void {
             ],
           };
         }
-        const message =
-          error instanceof Error ? error.message : String(error);
+        const message = errorMessage(error);
         return {
           isError: true,
           content: [
@@ -90,8 +90,7 @@ export function registerCampaignStop(server: McpServer): void {
         }
         accountId = (accounts[0] as Account).id;
       } catch (error) {
-        const message =
-          error instanceof Error ? error.message : String(error);
+        const message = errorMessage(error);
         return {
           isError: true,
           content: [
@@ -184,8 +183,7 @@ export function registerCampaignStop(server: McpServer): void {
             ],
           };
         }
-        const message =
-          error instanceof Error ? error.message : String(error);
+        const message = errorMessage(error);
         return {
           isError: true,
           content: [

--- a/packages/mcp/src/tools/check-replies.ts
+++ b/packages/mcp/src/tools/check-replies.ts
@@ -4,6 +4,7 @@ import {
   DatabaseClient,
   discoverDatabase,
   discoverInstancePort,
+  errorMessage,
   InstanceNotRunningError,
   InstanceService,
   LauncherService,
@@ -52,8 +53,7 @@ export function registerCheckReplies(server: McpServer): void {
             ],
           };
         }
-        const message =
-          error instanceof Error ? error.message : String(error);
+        const message = errorMessage(error);
         return {
           isError: true,
           content: [
@@ -92,8 +92,7 @@ export function registerCheckReplies(server: McpServer): void {
         }
         accountId = (accounts[0] as Account).id;
       } catch (error) {
-        const message =
-          error instanceof Error ? error.message : String(error);
+        const message = errorMessage(error);
         return {
           isError: true,
           content: [
@@ -170,8 +169,7 @@ export function registerCheckReplies(server: McpServer): void {
             ],
           };
         }
-        const message =
-          error instanceof Error ? error.message : String(error);
+        const message = errorMessage(error);
         return {
           isError: true,
           content: [

--- a/packages/mcp/src/tools/check-status.ts
+++ b/packages/mcp/src/tools/check-status.ts
@@ -1,5 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { checkStatus } from "@lhremote/core";
+import { checkStatus, errorMessage } from "@lhremote/core";
 import { z } from "zod";
 
 export function registerCheckStatus(server: McpServer): void {
@@ -25,8 +25,7 @@ export function registerCheckStatus(server: McpServer): void {
           ],
         };
       } catch (error) {
-        const message =
-          error instanceof Error ? error.message : String(error);
+        const message = errorMessage(error);
         return {
           isError: true,
           content: [

--- a/packages/mcp/src/tools/find-app.ts
+++ b/packages/mcp/src/tools/find-app.ts
@@ -1,5 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { findApp } from "@lhremote/core";
+import { errorMessage, findApp } from "@lhremote/core";
 
 export function registerFindApp(server: McpServer): void {
   server.tool(
@@ -27,8 +27,7 @@ export function registerFindApp(server: McpServer): void {
           ],
         };
       } catch (error) {
-        const message =
-          error instanceof Error ? error.message : String(error);
+        const message = errorMessage(error);
         return {
           isError: true,
           content: [

--- a/packages/mcp/src/tools/launch-app.ts
+++ b/packages/mcp/src/tools/launch-app.ts
@@ -1,5 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { AppLaunchError, AppNotFoundError, AppService } from "@lhremote/core";
+import { AppLaunchError, AppNotFoundError, AppService, errorMessage } from "@lhremote/core";
 import { z } from "zod";
 
 export function registerLaunchApp(server: McpServer): void {
@@ -29,8 +29,7 @@ export function registerLaunchApp(server: McpServer): void {
             content: [{ type: "text", text: error.message }],
           };
         }
-        const message =
-          error instanceof Error ? error.message : String(error);
+        const message = errorMessage(error);
         return {
           isError: true,
           content: [

--- a/packages/mcp/src/tools/list-accounts.ts
+++ b/packages/mcp/src/tools/list-accounts.ts
@@ -1,5 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { LauncherService, LinkedHelperNotRunningError } from "@lhremote/core";
+import { errorMessage, LauncherService, LinkedHelperNotRunningError } from "@lhremote/core";
 import { z } from "zod";
 
 export function registerListAccounts(server: McpServer): void {
@@ -32,8 +32,7 @@ export function registerListAccounts(server: McpServer): void {
             ],
           };
         }
-        const message =
-          error instanceof Error ? error.message : String(error);
+        const message = errorMessage(error);
         return {
           isError: true,
           content: [
@@ -53,8 +52,7 @@ export function registerListAccounts(server: McpServer): void {
           ],
         };
       } catch (error) {
-        const message =
-          error instanceof Error ? error.message : String(error);
+        const message = errorMessage(error);
         return {
           isError: true,
           content: [

--- a/packages/mcp/src/tools/query-messages.ts
+++ b/packages/mcp/src/tools/query-messages.ts
@@ -3,6 +3,7 @@ import {
   ChatNotFoundError,
   DatabaseClient,
   discoverAllDatabases,
+  errorMessage,
   MessageRepository,
 } from "@lhremote/core";
 import { z } from "zod";
@@ -112,8 +113,7 @@ export function registerQueryMessages(server: McpServer): void {
           if (error instanceof ChatNotFoundError) {
             continue;
           }
-          const message =
-            error instanceof Error ? error.message : String(error);
+          const message = errorMessage(error);
           return {
             isError: true,
             content: [

--- a/packages/mcp/src/tools/query-profile.ts
+++ b/packages/mcp/src/tools/query-profile.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   DatabaseClient,
   discoverAllDatabases,
+  errorMessage,
   ProfileNotFoundError,
   ProfileRepository,
 } from "@lhremote/core";
@@ -72,8 +73,7 @@ export function registerQueryProfile(server: McpServer): void {
           if (error instanceof ProfileNotFoundError) {
             continue;
           }
-          const message =
-            error instanceof Error ? error.message : String(error);
+          const message = errorMessage(error);
           return {
             isError: true,
             content: [

--- a/packages/mcp/src/tools/query-profiles.ts
+++ b/packages/mcp/src/tools/query-profiles.ts
@@ -2,6 +2,7 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   DatabaseClient,
   discoverAllDatabases,
+  errorMessage,
   ProfileRepository,
   type ProfileSearchResult,
 } from "@lhremote/core";
@@ -64,8 +65,7 @@ export function registerQueryProfiles(server: McpServer): void {
           allProfiles.push(...result.profiles);
           totalCount += result.total;
         } catch (error) {
-          const message =
-            error instanceof Error ? error.message : String(error);
+          const message = errorMessage(error);
           return {
             isError: true,
             content: [

--- a/packages/mcp/src/tools/quit-app.ts
+++ b/packages/mcp/src/tools/quit-app.ts
@@ -1,5 +1,5 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { AppService } from "@lhremote/core";
+import { AppService, errorMessage } from "@lhremote/core";
 import { z } from "zod";
 
 export function registerQuitApp(server: McpServer): void {
@@ -21,8 +21,7 @@ export function registerQuitApp(server: McpServer): void {
       try {
         await app.quit();
       } catch (error) {
-        const message =
-          error instanceof Error ? error.message : String(error);
+        const message = errorMessage(error);
         return {
           isError: true,
           content: [

--- a/packages/mcp/src/tools/scrape-messaging-history.ts
+++ b/packages/mcp/src/tools/scrape-messaging-history.ts
@@ -4,6 +4,7 @@ import {
   DatabaseClient,
   discoverDatabase,
   discoverInstancePort,
+  errorMessage,
   InstanceNotRunningError,
   InstanceService,
   LauncherService,
@@ -43,8 +44,7 @@ export function registerScrapeMessagingHistory(server: McpServer): void {
             ],
           };
         }
-        const message =
-          error instanceof Error ? error.message : String(error);
+        const message = errorMessage(error);
         return {
           isError: true,
           content: [
@@ -83,8 +83,7 @@ export function registerScrapeMessagingHistory(server: McpServer): void {
         }
         accountId = (accounts[0] as Account).id;
       } catch (error) {
-        const message =
-          error instanceof Error ? error.message : String(error);
+        const message = errorMessage(error);
         return {
           isError: true,
           content: [
@@ -157,8 +156,7 @@ export function registerScrapeMessagingHistory(server: McpServer): void {
             ],
           };
         }
-        const message =
-          error instanceof Error ? error.message : String(error);
+        const message = errorMessage(error);
         return {
           isError: true,
           content: [

--- a/packages/mcp/src/tools/start-instance.ts
+++ b/packages/mcp/src/tools/start-instance.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   type Account,
+  errorMessage,
   LauncherService,
   LinkedHelperNotRunningError,
   startInstanceWithRecovery,
@@ -45,8 +46,7 @@ export function registerStartInstance(server: McpServer): void {
             ],
           };
         }
-        const message =
-          error instanceof Error ? error.message : String(error);
+        const message = errorMessage(error);
         return {
           isError: true,
           content: [
@@ -120,8 +120,7 @@ export function registerStartInstance(server: McpServer): void {
           ],
         };
       } catch (error) {
-        const message =
-          error instanceof Error ? error.message : String(error);
+        const message = errorMessage(error);
         return {
           isError: true,
           content: [

--- a/packages/mcp/src/tools/stop-instance.ts
+++ b/packages/mcp/src/tools/stop-instance.ts
@@ -1,6 +1,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   type Account,
+  errorMessage,
   LauncherService,
   LinkedHelperNotRunningError,
 } from "@lhremote/core";
@@ -44,8 +45,7 @@ export function registerStopInstance(server: McpServer): void {
             ],
           };
         }
-        const message =
-          error instanceof Error ? error.message : String(error);
+        const message = errorMessage(error);
         return {
           isError: true,
           content: [
@@ -98,8 +98,7 @@ export function registerStopInstance(server: McpServer): void {
           ],
         };
       } catch (error) {
-        const message =
-          error instanceof Error ? error.message : String(error);
+        const message = errorMessage(error);
         return {
           isError: true,
           content: [


### PR DESCRIPTION
## Summary

- Create `packages/core/src/utils/` module with three shared utilities: `isCdpPort`, `delay`, and `errorMessage`
- Replace duplicate `isCdpPort` implementations in `instance-discovery.ts` and `app-discovery.ts`
- Replace duplicate `sleep`/`delay` implementations in `instance-lifecycle.ts`, `campaign.ts`, and inline in `instance.ts`
- Replace 89 occurrences of `error instanceof Error ? error.message : String(error)` across 47 files in core, cli, and mcp packages
- Add unit tests for all three utilities
- Export all utilities from `@lhremote/core`

Closes #147

## Test plan

- [x] All existing tests pass (696 tests across 4 packages)
- [x] New unit tests for `isCdpPort`, `delay`, and `errorMessage`
- [x] Full monorepo build passes
- [x] Lint passes across all packages
- [x] Zero remaining occurrences of the old pattern (only the implementation itself)

🤖 Generated with [Claude Code](https://claude.com/claude-code)