### PR TITLE
(fix) core: apply is_valid fix after campaign creation

### DIFF
--- a/packages/core/src/db/repositories/campaign.test.ts
+++ b/packages/core/src/db/repositories/campaign.test.ts
@@ -212,6 +212,36 @@ describe("CampaignRepository", () => {
     });
   });
 
+  describe("fixIsValid", () => {
+    it("sets is_valid to 1 for a campaign with NULL is_valid", () => {
+      // Insert a campaign with is_valid = NULL (as created by the API)
+      db.exec(
+        `INSERT INTO campaigns (id, name, type, is_valid, li_account_id)
+         VALUES (99, 'API-Created Campaign', 1, NULL, 1)`,
+      );
+
+      const before = repo.getCampaign(99);
+      expect(before.isValid).toBeNull();
+      expect(before.state).toBe("active");
+
+      repo.fixIsValid(99);
+
+      const after = repo.getCampaign(99);
+      expect(after.isValid).toBe(true);
+      expect(after.state).toBe("active");
+    });
+
+    it("sets is_valid to 1 for a campaign with is_valid = 0", () => {
+      const before = repo.getCampaign(4);
+      expect(before.isValid).toBe(false);
+
+      repo.fixIsValid(4);
+
+      const after = repo.getCampaign(4);
+      expect(after.isValid).toBe(true);
+    });
+  });
+
   describe("resetForRerun", () => {
     it("resets person state for re-run", () => {
       // Initial state: person 1 has state=2 (processed), person 3 has state=1 (queued)

--- a/packages/core/src/services/campaign.ts
+++ b/packages/core/src/services/campaign.ts
@@ -81,6 +81,7 @@ export class CampaignService {
         })()`,
       );
 
+      this.campaignRepo.fixIsValid(result.id);
       return this.campaignRepo.getCampaign(result.id);
     } catch (error) {
       if (error instanceof CampaignExecutionError) throw error;


### PR DESCRIPTION
## Summary

- Add `CampaignRepository.fixIsValid()` to set `is_valid = 1` after programmatic campaign creation
- Call `fixIsValid()` in `CampaignService.create()` between CDP creation and DB read-back
- Campaigns created via `createCampaign()` CDP API have `is_valid = NULL`, making them invisible in the LinkedHelper UI; this fix matches the LH UI editor finalization behavior

Closes #115

## Test plan

- [x] Unit test: `CampaignRepository.fixIsValid()` sets `is_valid = 1` for NULL campaigns
- [x] Unit test: `CampaignRepository.fixIsValid()` sets `is_valid = 1` for `is_valid = 0` campaigns
- [x] Unit test: `CampaignService.create()` calls `fixIsValid` before reading campaign back
- [x] All 699 tests pass across all packages
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)