### PR TITLE
(feat) core,mcp,cli: add import-people-from-urls tool

### DIFF
--- a/packages/cli/src/handlers/import-people-from-urls.ts
+++ b/packages/cli/src/handlers/import-people-from-urls.ts
@@ -1,0 +1,170 @@
+import { readFileSync } from "node:fs";
+
+import {
+  type Account,
+  CampaignExecutionError,
+  CampaignNotFoundError,
+  CampaignService,
+  DatabaseClient,
+  discoverDatabase,
+  discoverInstancePort,
+  errorMessage,
+  InstanceService,
+  LauncherService,
+} from "@lhremote/core";
+
+function parseUrls(raw: string): string[] {
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+function readUrlsFile(filePath: string): string[] {
+  const content = readFileSync(filePath, "utf-8");
+  return content
+    .split(/[\n,]/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+export async function handleImportPeopleFromUrls(
+  campaignId: number,
+  options: {
+    urls?: string;
+    urlsFile?: string;
+    cdpPort?: number;
+    json?: boolean;
+  },
+): Promise<void> {
+  const cdpPort = options.cdpPort ?? 9222;
+
+  // Reject conflicting options
+  if (options.urls && options.urlsFile) {
+    process.stderr.write("Use only one of --urls or --urls-file.\n");
+    process.exitCode = 1;
+    return;
+  }
+
+  // Parse URLs from options
+  let linkedInUrls: string[];
+  if (options.urls) {
+    linkedInUrls = parseUrls(options.urls);
+  } else if (options.urlsFile) {
+    try {
+      linkedInUrls = readUrlsFile(options.urlsFile);
+    } catch (error) {
+      const message = errorMessage(error);
+      process.stderr.write(`${message}\n`);
+      process.exitCode = 1;
+      return;
+    }
+  } else {
+    process.stderr.write("Either --urls or --urls-file is required.\n");
+    process.exitCode = 1;
+    return;
+  }
+
+  if (linkedInUrls.length === 0) {
+    process.stderr.write("No URLs provided.\n");
+    process.exitCode = 1;
+    return;
+  }
+
+  // Connect to launcher
+  const launcher = new LauncherService(cdpPort);
+  let accountId: number;
+
+  try {
+    await launcher.connect();
+    const accounts = await launcher.listAccounts();
+    if (accounts.length === 0) {
+      process.stderr.write("No accounts found.\n");
+      process.exitCode = 1;
+      return;
+    }
+    if (accounts.length > 1) {
+      process.stderr.write(
+        "Multiple accounts found. Cannot determine which instance to use.\n",
+      );
+      process.exitCode = 1;
+      return;
+    }
+    accountId = (accounts[0] as Account).id;
+  } catch (error) {
+    const message = errorMessage(error);
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+    return;
+  } finally {
+    launcher.disconnect();
+  }
+
+  // Discover instance
+  const instancePort = await discoverInstancePort(cdpPort);
+  if (instancePort === null) {
+    process.stderr.write(
+      "No LinkedHelper instance is running. Use start-instance first.\n",
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  // Connect and import people
+  const instance = new InstanceService(instancePort);
+  let db: DatabaseClient | null = null;
+
+  try {
+    await instance.connect();
+    const dbPath = discoverDatabase(accountId);
+    db = new DatabaseClient(dbPath);
+
+    const campaignService = new CampaignService(instance, db);
+    const result = await campaignService.importPeopleFromUrls(
+      campaignId,
+      linkedInUrls,
+    );
+
+    if (options.json) {
+      const response = {
+        success: true,
+        campaignId,
+        actionId: result.actionId,
+        imported: result.successful,
+        alreadyInQueue: result.alreadyInQueue,
+        alreadyProcessed: result.alreadyProcessed,
+        failed: result.failed,
+      };
+      process.stdout.write(JSON.stringify(response, null, 2) + "\n");
+    } else {
+      process.stdout.write(
+        `Imported ${String(result.successful)} people into campaign ${String(campaignId)} action ${String(result.actionId)}.` +
+          (result.alreadyInQueue > 0
+            ? ` ${String(result.alreadyInQueue)} already in queue.`
+            : "") +
+          (result.alreadyProcessed > 0
+            ? ` ${String(result.alreadyProcessed)} already processed.`
+            : "") +
+          (result.failed > 0
+            ? ` ${String(result.failed)} failed.`
+            : "") +
+          "\n",
+      );
+    }
+  } catch (error) {
+    if (error instanceof CampaignNotFoundError) {
+      process.stderr.write(`Campaign ${String(campaignId)} not found.\n`);
+    } else if (error instanceof CampaignExecutionError) {
+      process.stderr.write(
+        `Failed to import people: ${error.message}\n`,
+      );
+    } else {
+      const message = errorMessage(error);
+      process.stderr.write(`${message}\n`);
+    }
+    process.exitCode = 1;
+  } finally {
+    instance.disconnect();
+    db?.close();
+  }
+}

--- a/packages/cli/src/handlers/index.ts
+++ b/packages/cli/src/handlers/index.ts
@@ -5,6 +5,7 @@ export { handleCampaignGet } from "./campaign-get.js";
 export { handleCampaignList } from "./campaign-list.js";
 export { handleCampaignStart } from "./campaign-start.js";
 export { handleCampaignStatus } from "./campaign-status.js";
+export { handleImportPeopleFromUrls } from "./import-people-from-urls.js";
 export { handleCampaignStop } from "./campaign-stop.js";
 export { handleCheckReplies } from "./check-replies.js";
 export { handleDescribeActions } from "./describe-actions.js";

--- a/packages/cli/src/program.test.ts
+++ b/packages/cli/src/program.test.ts
@@ -54,7 +54,8 @@ describe("createProgram", () => {
     expect(commandNames).toContain("check-replies");
     expect(commandNames).toContain("check-status");
     expect(commandNames).toContain("describe-actions");
-    expect(commandNames).toHaveLength(21);
+    expect(commandNames).toContain("import-people-from-urls");
+    expect(commandNames).toHaveLength(22);
   });
 
   describe("launch-app", () => {

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -11,6 +11,7 @@ import {
   handleCampaignStart,
   handleCampaignStatus,
   handleCampaignStop,
+  handleImportPeopleFromUrls,
   handleCheckReplies,
   handleCheckStatus,
   handleDescribeActions,
@@ -170,6 +171,16 @@ export function createProgram(): Command {
     .option("--cdp-port <port>", "CDP debugging port", parsePositiveInt)
     .option("--json", "Output as JSON")
     .action(handleCampaignStop);
+
+  program
+    .command("import-people-from-urls")
+    .description("Import LinkedIn profile URLs into a campaign action target list")
+    .argument("<campaignId>", "Campaign ID to import into", parsePositiveInt)
+    .option("--urls <urls>", "Comma-separated LinkedIn profile URLs")
+    .option("--urls-file <path>", "File containing LinkedIn profile URLs")
+    .option("--cdp-port <port>", "CDP debugging port", parsePositiveInt)
+    .option("--json", "Output as JSON")
+    .action(handleImportPeopleFromUrls);
 
   program
     .command("describe-actions")

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -23,6 +23,7 @@ export type {
   ExternalId,
   ExternalIdTypeGroup,
   GetResultsOptions,
+  ImportPeopleResult,
   InstanceInfo,
   InstanceStatus,
   ListCampaignsOptions,

--- a/packages/core/src/types/campaign.ts
+++ b/packages/core/src/types/campaign.ts
@@ -171,6 +171,22 @@ export interface CampaignStatus {
 }
 
 /**
+ * Result of importing people into a campaign action from LinkedIn URLs.
+ */
+export interface ImportPeopleResult {
+  /** Action ID the people were imported into. */
+  actionId: number;
+  /** Number of people successfully added. */
+  successful: number;
+  /** Number of people already in the target queue. */
+  alreadyInQueue: number;
+  /** Number of people already processed. */
+  alreadyProcessed: number;
+  /** Number of URLs that failed to import. */
+  failed: number;
+}
+
+/**
  * Aggregated results from a campaign run.
  */
 export interface CampaignRunResult {

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -43,6 +43,7 @@ export type {
   CampaignConfig,
   CampaignRunResult,
   CampaignState,
+  ImportPeopleResult,
   CampaignStatus,
   CampaignSummary,
   GetResultsOptions,

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -93,6 +93,7 @@ describe("createServer", () => {
     expect(names).toContain("check-replies");
     expect(names).toContain("check-status");
     expect(names).toContain("describe-actions");
-    expect(names).toHaveLength(21);
+    expect(names).toContain("import-people-from-urls");
+    expect(names).toHaveLength(22);
   });
 });

--- a/packages/mcp/src/tools/import-people-from-urls.test.ts
+++ b/packages/mcp/src/tools/import-people-from-urls.test.ts
@@ -1,0 +1,305 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return {
+    ...actual,
+    LauncherService: vi.fn(),
+    InstanceService: vi.fn(),
+    DatabaseClient: vi.fn(),
+    CampaignService: vi.fn(),
+    discoverInstancePort: vi.fn(),
+    discoverDatabase: vi.fn(),
+  };
+});
+
+import {
+  type Account,
+  CampaignExecutionError,
+  CampaignNotFoundError,
+  CampaignService,
+  DatabaseClient,
+  discoverDatabase,
+  discoverInstancePort,
+  InstanceService,
+  LauncherService,
+  LinkedHelperNotRunningError,
+} from "@lhremote/core";
+
+import { registerImportPeopleFromUrls } from "./import-people-from-urls.js";
+import { createMockServer } from "./testing/mock-server.js";
+
+function mockLauncher(overrides: Record<string, unknown> = {}) {
+  const disconnect = vi.fn();
+  vi.mocked(LauncherService).mockImplementation(function () {
+    return {
+      connect: vi.fn().mockResolvedValue(undefined),
+      disconnect,
+      listAccounts: vi
+        .fn()
+        .mockResolvedValue([{ id: 1, liId: 1, name: "Alice" } as Account]),
+      ...overrides,
+    } as unknown as LauncherService;
+  });
+  return { disconnect };
+}
+
+function mockInstance(overrides: Record<string, unknown> = {}) {
+  const disconnect = vi.fn();
+  vi.mocked(InstanceService).mockImplementation(function () {
+    return {
+      connect: vi.fn().mockResolvedValue(undefined),
+      disconnect,
+      ...overrides,
+    } as unknown as InstanceService;
+  });
+  return { disconnect };
+}
+
+function mockDb() {
+  const close = vi.fn();
+  vi.mocked(DatabaseClient).mockImplementation(function () {
+    return { close, db: {} } as unknown as DatabaseClient;
+  });
+  return { close };
+}
+
+function mockCampaignService(overrides: Record<string, unknown> = {}) {
+  vi.mocked(CampaignService).mockImplementation(function () {
+    return {
+      importPeopleFromUrls: vi.fn().mockResolvedValue({
+        actionId: 85,
+        successful: 2,
+        alreadyInQueue: 0,
+        alreadyProcessed: 0,
+        failed: 0,
+      }),
+      ...overrides,
+    } as unknown as CampaignService;
+  });
+}
+
+function setupSuccessPath() {
+  mockLauncher();
+  mockInstance();
+  mockDb();
+  mockCampaignService();
+  vi.mocked(discoverInstancePort).mockResolvedValue(55123);
+  vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+}
+
+describe("registerImportPeopleFromUrls", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("registers a tool named import-people-from-urls", () => {
+    const { server } = createMockServer();
+    registerImportPeopleFromUrls(server);
+
+    expect(server.tool).toHaveBeenCalledOnce();
+    expect(server.tool).toHaveBeenCalledWith(
+      "import-people-from-urls",
+      expect.any(String),
+      expect.any(Object),
+      expect.any(Function),
+    );
+  });
+
+  it("successfully imports people from URLs", async () => {
+    const { server, getHandler } = createMockServer();
+    registerImportPeopleFromUrls(server);
+    setupSuccessPath();
+
+    const handler = getHandler("import-people-from-urls");
+    const result = await handler({
+      campaignId: 14,
+      linkedInUrls: [
+        "https://www.linkedin.com/in/alice",
+        "https://www.linkedin.com/in/bob",
+      ],
+      cdpPort: 9222,
+    });
+
+    expect(result).toEqual({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(
+            {
+              success: true,
+              campaignId: 14,
+              actionId: 85,
+              imported: 2,
+              alreadyInQueue: 0,
+              alreadyProcessed: 0,
+              failed: 0,
+            },
+            null,
+            2,
+          ),
+        },
+      ],
+    });
+  });
+
+  it("returns error for non-existent campaign", async () => {
+    const { server, getHandler } = createMockServer();
+    registerImportPeopleFromUrls(server);
+
+    mockLauncher();
+    mockInstance();
+    mockDb();
+    vi.mocked(discoverInstancePort).mockResolvedValue(55123);
+    vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+    vi.mocked(CampaignService).mockImplementation(function () {
+      return {
+        importPeopleFromUrls: vi
+          .fn()
+          .mockRejectedValue(new CampaignNotFoundError(999)),
+      } as unknown as CampaignService;
+    });
+
+    const handler = getHandler("import-people-from-urls");
+    const result = await handler({
+      campaignId: 999,
+      linkedInUrls: ["https://www.linkedin.com/in/alice"],
+      cdpPort: 9222,
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "Campaign 999 not found.",
+        },
+      ],
+    });
+  });
+
+  it("returns error when LinkedHelper is not running", async () => {
+    const { server, getHandler } = createMockServer();
+    registerImportPeopleFromUrls(server);
+
+    vi.mocked(LauncherService).mockImplementation(function () {
+      return {
+        connect: vi
+          .fn()
+          .mockRejectedValue(new LinkedHelperNotRunningError(9222)),
+        disconnect: vi.fn(),
+      } as unknown as LauncherService;
+    });
+
+    const handler = getHandler("import-people-from-urls");
+    const result = await handler({
+      campaignId: 14,
+      linkedInUrls: ["https://www.linkedin.com/in/alice"],
+      cdpPort: 9222,
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "LinkedHelper is not running. Use launch-app first.",
+        },
+      ],
+    });
+  });
+
+  it("returns error when campaign has no actions", async () => {
+    const { server, getHandler } = createMockServer();
+    registerImportPeopleFromUrls(server);
+
+    mockLauncher();
+    mockInstance();
+    mockDb();
+    vi.mocked(discoverInstancePort).mockResolvedValue(55123);
+    vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+    vi.mocked(CampaignService).mockImplementation(function () {
+      return {
+        importPeopleFromUrls: vi
+          .fn()
+          .mockRejectedValue(
+            new CampaignExecutionError(
+              "Campaign 14 has no actions",
+              14,
+            ),
+          ),
+      } as unknown as CampaignService;
+    });
+
+    const handler = getHandler("import-people-from-urls");
+    const result = await handler({
+      campaignId: 14,
+      linkedInUrls: ["https://www.linkedin.com/in/alice"],
+      cdpPort: 9222,
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "Failed to import people: Campaign 14 has no actions",
+        },
+      ],
+    });
+  });
+
+  it("disconnects instance and closes db after success", async () => {
+    const { server, getHandler } = createMockServer();
+    registerImportPeopleFromUrls(server);
+
+    mockLauncher();
+    const { disconnect: instanceDisconnect } = mockInstance();
+    const { close: dbClose } = mockDb();
+    mockCampaignService();
+    vi.mocked(discoverInstancePort).mockResolvedValue(55123);
+    vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+
+    const handler = getHandler("import-people-from-urls");
+    await handler({
+      campaignId: 14,
+      linkedInUrls: ["https://www.linkedin.com/in/alice"],
+      cdpPort: 9222,
+    });
+
+    expect(instanceDisconnect).toHaveBeenCalledOnce();
+    expect(dbClose).toHaveBeenCalledOnce();
+  });
+
+  it("disconnects instance and closes db after error", async () => {
+    const { server, getHandler } = createMockServer();
+    registerImportPeopleFromUrls(server);
+
+    mockLauncher();
+    const { disconnect: instanceDisconnect } = mockInstance();
+    const { close: dbClose } = mockDb();
+    vi.mocked(discoverInstancePort).mockResolvedValue(55123);
+    vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+    vi.mocked(CampaignService).mockImplementation(function () {
+      return {
+        importPeopleFromUrls: vi
+          .fn()
+          .mockRejectedValue(new Error("test error")),
+      } as unknown as CampaignService;
+    });
+
+    const handler = getHandler("import-people-from-urls");
+    await handler({
+      campaignId: 14,
+      linkedInUrls: ["https://www.linkedin.com/in/alice"],
+      cdpPort: 9222,
+    });
+
+    expect(instanceDisconnect).toHaveBeenCalledOnce();
+    expect(dbClose).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/mcp/src/tools/import-people-from-urls.ts
+++ b/packages/mcp/src/tools/import-people-from-urls.ts
@@ -1,0 +1,211 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  type Account,
+  CampaignExecutionError,
+  CampaignNotFoundError,
+  CampaignService,
+  DatabaseClient,
+  discoverDatabase,
+  discoverInstancePort,
+  errorMessage,
+  InstanceNotRunningError,
+  InstanceService,
+  LauncherService,
+  LinkedHelperNotRunningError,
+} from "@lhremote/core";
+import { z } from "zod";
+
+export function registerImportPeopleFromUrls(server: McpServer): void {
+  server.tool(
+    "import-people-from-urls",
+    "Import LinkedIn profile URLs into a campaign action's target list. Idempotent — re-importing an already-targeted person is a no-op.",
+    {
+      campaignId: z
+        .number()
+        .int()
+        .positive()
+        .describe("Campaign ID to import people into"),
+      linkedInUrls: z
+        .array(z.string().url())
+        .nonempty()
+        .describe("LinkedIn profile URLs to import"),
+      cdpPort: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .default(9222)
+        .describe("CDP port (default: 9222)"),
+    },
+    async ({ campaignId, linkedInUrls, cdpPort }) => {
+      // Connect to launcher to find running instance
+      const launcher = new LauncherService(cdpPort);
+
+      try {
+        await launcher.connect();
+      } catch (error) {
+        if (error instanceof LinkedHelperNotRunningError) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: "LinkedHelper is not running. Use launch-app first.",
+              },
+            ],
+          };
+        }
+        const message = errorMessage(error);
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: `Failed to connect to LinkedHelper: ${message}`,
+            },
+          ],
+        };
+      }
+
+      let accountId: number;
+      try {
+        const accounts = await launcher.listAccounts();
+        if (accounts.length === 0) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: "No accounts found.",
+              },
+            ],
+          };
+        }
+        if (accounts.length > 1) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: "Multiple accounts found. Cannot determine which instance to use.",
+              },
+            ],
+          };
+        }
+        accountId = (accounts[0] as Account).id;
+      } catch (error) {
+        const message = errorMessage(error);
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: `Failed to list accounts: ${message}`,
+            },
+          ],
+        };
+      } finally {
+        launcher.disconnect();
+      }
+
+      // Discover instance CDP port
+      const instancePort = await discoverInstancePort(cdpPort);
+      if (instancePort === null) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: "No LinkedHelper instance is running. Use start-instance first.",
+            },
+          ],
+        };
+      }
+
+      // Connect to instance and import people
+      const instance = new InstanceService(instancePort);
+      let db: DatabaseClient | null = null;
+
+      try {
+        await instance.connect();
+
+        const dbPath = discoverDatabase(accountId);
+        db = new DatabaseClient(dbPath);
+
+        const campaignService = new CampaignService(instance, db);
+        const result = await campaignService.importPeopleFromUrls(
+          campaignId,
+          linkedInUrls,
+        );
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                {
+                  success: true,
+                  campaignId,
+                  actionId: result.actionId,
+                  imported: result.successful,
+                  alreadyInQueue: result.alreadyInQueue,
+                  alreadyProcessed: result.alreadyProcessed,
+                  failed: result.failed,
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      } catch (error) {
+        if (error instanceof InstanceNotRunningError) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: "No LinkedHelper instance is running. Use start-instance first.",
+              },
+            ],
+          };
+        }
+        if (error instanceof CampaignNotFoundError) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: `Campaign ${String(campaignId)} not found.`,
+              },
+            ],
+          };
+        }
+        if (error instanceof CampaignExecutionError) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: `Failed to import people: ${error.message}`,
+              },
+            ],
+          };
+        }
+        const message = errorMessage(error);
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: `Failed to import people: ${message}`,
+            },
+          ],
+        };
+      } finally {
+        instance.disconnect();
+        db?.close();
+      }
+    },
+  );
+}

--- a/packages/mcp/src/tools/index.ts
+++ b/packages/mcp/src/tools/index.ts
@@ -5,6 +5,7 @@ import { registerCampaignDelete } from "./campaign-delete.js";
 import { registerCampaignExport } from "./campaign-export.js";
 import { registerCampaignGet } from "./campaign-get.js";
 import { registerCampaignList } from "./campaign-list.js";
+import { registerImportPeopleFromUrls } from "./import-people-from-urls.js";
 import { registerCampaignStart } from "./campaign-start.js";
 import { registerCampaignStatus } from "./campaign-status.js";
 import { registerCampaignStop } from "./campaign-stop.js";
@@ -43,4 +44,5 @@ export function registerAllTools(server: McpServer): void {
   registerCheckReplies(server);
   registerCheckStatus(server);
   registerDescribeActions(server);
+  registerImportPeopleFromUrls(server);
 }


### PR DESCRIPTION
## Summary

- Add `CampaignService.importPeopleFromUrls()` to core — resolves campaign's first action and calls `source.people.actions.importPeopleFromUrls()` via CDP
- Add `import-people-from-urls` MCP tool with zod schema validation for campaignId, linkedInUrls array, and optional cdpPort
- Add `import-people-from-urls` CLI command with `--urls` (comma-separated) and `--urls-file` (file path) input options
- Add `ImportPeopleResult` type to core exports
- Add MCP tool tests (7 cases: registration, success, campaign not found, LH not running, no actions, cleanup after success/error)

The import is idempotent — re-importing an already-targeted person is a no-op.

Closes #114

## Test plan

- [x] Unit tests pass for MCP tool (7 test cases)
- [x] Existing CLI program test updated (22 commands)
- [x] Existing MCP server test updated (22 tools)
- [x] `pnpm lint` passes (7/7)
- [x] `pnpm test` passes (8/8, 412 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)