### PR TITLE
(feat) mcp,cli: add campaign-update tool

### DIFF
--- a/packages/cli/src/handlers/campaign-update.ts
+++ b/packages/cli/src/handlers/campaign-update.ts
@@ -1,0 +1,101 @@
+import {
+  type Account,
+  CampaignNotFoundError,
+  CampaignRepository,
+  DatabaseClient,
+  discoverDatabase,
+  errorMessage,
+  LauncherService,
+} from "@lhremote/core";
+
+export async function handleCampaignUpdate(
+  campaignId: number,
+  options: {
+    name?: string;
+    description?: string;
+    clearDescription?: boolean;
+    cdpPort?: number;
+    json?: boolean;
+  },
+): Promise<void> {
+  const cdpPort = options.cdpPort ?? 9222;
+
+  // Validate that at least one field is provided
+  if (
+    options.name === undefined &&
+    options.description === undefined &&
+    !options.clearDescription
+  ) {
+    process.stderr.write(
+      "At least one of --name, --description, or --clear-description is required.\n",
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  // Connect to launcher to find account
+  const launcher = new LauncherService(cdpPort);
+  let accountId: number;
+
+  try {
+    await launcher.connect();
+    const accounts = await launcher.listAccounts();
+    if (accounts.length === 0) {
+      process.stderr.write("No accounts found.\n");
+      process.exitCode = 1;
+      return;
+    }
+    if (accounts.length > 1) {
+      process.stderr.write(
+        "Multiple accounts found. Cannot determine which instance to use.\n",
+      );
+      process.exitCode = 1;
+      return;
+    }
+    accountId = (accounts[0] as Account).id;
+  } catch (error) {
+    const message = errorMessage(error);
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+    return;
+  } finally {
+    launcher.disconnect();
+  }
+
+  // Open database (writable) and update campaign
+  let db: DatabaseClient | null = null;
+
+  try {
+    const dbPath = discoverDatabase(accountId);
+    db = new DatabaseClient(dbPath, { readOnly: false });
+
+    const repo = new CampaignRepository(db);
+    const updates: { name?: string; description?: string | null } = {};
+    if (options.name !== undefined) updates.name = options.name;
+    if (options.clearDescription) {
+      updates.description = null;
+    } else if (options.description !== undefined) {
+      updates.description = options.description;
+    }
+
+    const campaign = repo.updateCampaign(campaignId, updates);
+
+    if (options.json) {
+      process.stdout.write(JSON.stringify(campaign, null, 2) + "\n");
+    } else {
+      process.stdout.write(
+        `Campaign updated: #${campaign.id} "${campaign.name}"\n`,
+      );
+    }
+  } catch (error) {
+    if (error instanceof CampaignNotFoundError) {
+      process.stderr.write(`Campaign ${String(campaignId)} not found.\n`);
+    } else {
+      const message = errorMessage(error);
+      process.stderr.write(`${message}\n`);
+    }
+    process.exitCode = 1;
+  } finally {
+    db?.close();
+  }
+}

--- a/packages/cli/src/handlers/index.ts
+++ b/packages/cli/src/handlers/index.ts
@@ -7,6 +7,7 @@ export { handleCampaignStart } from "./campaign-start.js";
 export { handleCampaignStatus } from "./campaign-status.js";
 export { handleImportPeopleFromUrls } from "./import-people-from-urls.js";
 export { handleCampaignStop } from "./campaign-stop.js";
+export { handleCampaignUpdate } from "./campaign-update.js";
 export { handleCheckReplies } from "./check-replies.js";
 export { handleDescribeActions } from "./describe-actions.js";
 export { handleCheckStatus } from "./check-status.js";

--- a/packages/cli/src/program.test.ts
+++ b/packages/cli/src/program.test.ts
@@ -51,11 +51,12 @@ describe("createProgram", () => {
     expect(commandNames).toContain("campaign-start");
     expect(commandNames).toContain("campaign-status");
     expect(commandNames).toContain("campaign-stop");
+    expect(commandNames).toContain("campaign-update");
     expect(commandNames).toContain("check-replies");
     expect(commandNames).toContain("check-status");
     expect(commandNames).toContain("describe-actions");
     expect(commandNames).toContain("import-people-from-urls");
-    expect(commandNames).toHaveLength(22);
+    expect(commandNames).toHaveLength(23);
   });
 
   describe("launch-app", () => {

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -11,6 +11,7 @@ import {
   handleCampaignStart,
   handleCampaignStatus,
   handleCampaignStop,
+  handleCampaignUpdate,
   handleImportPeopleFromUrls,
   handleCheckReplies,
   handleCheckStatus,
@@ -171,6 +172,17 @@ export function createProgram(): Command {
     .option("--cdp-port <port>", "CDP debugging port", parsePositiveInt)
     .option("--json", "Output as JSON")
     .action(handleCampaignStop);
+
+  program
+    .command("campaign-update")
+    .description("Update a campaign's name and/or description")
+    .argument("<campaignId>", "Campaign ID to update", parsePositiveInt)
+    .option("--name <name>", "New campaign name")
+    .option("--description <text>", "New campaign description")
+    .option("--clear-description", "Clear the campaign description")
+    .option("--cdp-port <port>", "CDP debugging port", parsePositiveInt)
+    .option("--json", "Output as JSON")
+    .action(handleCampaignUpdate);
 
   program
     .command("import-people-from-urls")

--- a/packages/core/src/db/repositories/campaign.test.ts
+++ b/packages/core/src/db/repositories/campaign.test.ts
@@ -352,6 +352,68 @@ describe("CampaignRepository", () => {
     });
   });
 
+  describe("updateCampaign", () => {
+    it("updates campaign name", () => {
+      const updated = repo.updateCampaign(1, { name: "New Name" });
+
+      expect(updated.id).toBe(1);
+      expect(updated.name).toBe("New Name");
+      expect(updated.description).toBe("Test outreach campaign");
+    });
+
+    it("updates campaign description", () => {
+      const updated = repo.updateCampaign(1, {
+        description: "New description",
+      });
+
+      expect(updated.id).toBe(1);
+      expect(updated.name).toBe("Outreach Campaign");
+      expect(updated.description).toBe("New description");
+    });
+
+    it("clears campaign description with null", () => {
+      const updated = repo.updateCampaign(1, { description: null });
+
+      expect(updated.id).toBe(1);
+      expect(updated.description).toBeNull();
+    });
+
+    it("updates both name and description", () => {
+      const updated = repo.updateCampaign(1, {
+        name: "Updated",
+        description: "Updated desc",
+      });
+
+      expect(updated.name).toBe("Updated");
+      expect(updated.description).toBe("Updated desc");
+    });
+
+    it("returns unchanged campaign when no fields provided", () => {
+      const updated = repo.updateCampaign(1, {});
+
+      expect(updated.name).toBe("Outreach Campaign");
+      expect(updated.description).toBe("Test outreach campaign");
+    });
+
+    it("throws CampaignNotFoundError for missing campaign", () => {
+      expect(() => repo.updateCampaign(999, { name: "X" })).toThrow(
+        CampaignNotFoundError,
+      );
+    });
+
+    it("preserves other campaign fields", () => {
+      const before = repo.getCampaign(1);
+      const updated = repo.updateCampaign(1, { name: "Changed" });
+
+      expect(updated.state).toBe(before.state);
+      expect(updated.liAccountId).toBe(before.liAccountId);
+      expect(updated.isPaused).toBe(before.isPaused);
+      expect(updated.isArchived).toBe(before.isArchived);
+      expect(updated.isValid).toBe(before.isValid);
+      expect(updated.createdAt).toBe(before.createdAt);
+    });
+  });
+
   describe("resetForRerun", () => {
     it("resets person state for re-run", () => {
       // Initial state: person 1 has state=2 (processed), person 3 has state=1 (queued)

--- a/packages/core/src/db/repositories/campaign.ts
+++ b/packages/core/src/db/repositories/campaign.ts
@@ -6,6 +6,7 @@ import type {
   CampaignAction,
   CampaignState,
   CampaignSummary,
+  CampaignUpdateConfig,
   GetResultsOptions,
   ListCampaignsOptions,
 } from "../../types/index.js";
@@ -280,6 +281,36 @@ export class CampaignRepository {
   getCampaignState(campaignId: number): CampaignState {
     const campaign = this.getCampaign(campaignId);
     return campaign.state;
+  }
+
+  /**
+   * Update a campaign's name and/or description.
+   *
+   * @throws {CampaignNotFoundError} if no campaign exists with the given ID.
+   */
+  updateCampaign(campaignId: number, updates: CampaignUpdateConfig): Campaign {
+    // Verify campaign exists
+    this.getCampaign(campaignId);
+
+    const setClauses: string[] = [];
+    const params: (string | number | null)[] = [];
+
+    if (updates.name !== undefined) {
+      setClauses.push("name = ?");
+      params.push(updates.name);
+    }
+    if (updates.description !== undefined) {
+      setClauses.push("description = ?");
+      params.push(updates.description);
+    }
+
+    if (setClauses.length > 0) {
+      params.push(campaignId);
+      const sql = `UPDATE campaigns SET ${setClauses.join(", ")} WHERE id = ?`;
+      this.client.db.prepare(sql).run(...params);
+    }
+
+    return this.getCampaign(campaignId);
   }
 
   /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,7 @@ export type {
   CampaignState,
   CampaignStatus,
   CampaignSummary,
+  CampaignUpdateConfig,
   Chat,
   ChatParticipant,
   ConversationMessages,

--- a/packages/core/src/services/campaign.ts
+++ b/packages/core/src/services/campaign.ts
@@ -5,6 +5,7 @@ import type {
   CampaignRunResult,
   CampaignStatus,
   CampaignSummary,
+  CampaignUpdateConfig,
   ImportPeopleResult,
   RunnerState,
 } from "../types/index.js";
@@ -94,6 +95,17 @@ export class CampaignService {
         { cause: error },
       );
     }
+  }
+
+  /**
+   * Update a campaign's name and/or description.
+   *
+   * This is a database-only operation — no CDP call is needed.
+   *
+   * @throws {CampaignNotFoundError} if the campaign does not exist.
+   */
+  update(campaignId: number, updates: CampaignUpdateConfig): Campaign {
+    return this.campaignRepo.updateCampaign(campaignId, updates);
   }
 
   /**

--- a/packages/core/src/types/campaign.ts
+++ b/packages/core/src/types/campaign.ts
@@ -187,6 +187,18 @@ export interface ImportPeopleResult {
 }
 
 /**
+ * Configuration for updating an existing campaign.
+ *
+ * At least one field must be provided.
+ */
+export interface CampaignUpdateConfig {
+  /** New campaign name. */
+  name?: string;
+  /** New campaign description (null to clear). */
+  description?: string | null;
+}
+
+/**
  * Aggregated results from a campaign run.
  */
 export interface CampaignRunResult {

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -43,6 +43,7 @@ export type {
   CampaignConfig,
   CampaignRunResult,
   CampaignState,
+  CampaignUpdateConfig,
   ImportPeopleResult,
   CampaignStatus,
   CampaignSummary,

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -90,10 +90,11 @@ describe("createServer", () => {
     expect(names).toContain("campaign-start");
     expect(names).toContain("campaign-status");
     expect(names).toContain("campaign-stop");
+    expect(names).toContain("campaign-update");
     expect(names).toContain("check-replies");
     expect(names).toContain("check-status");
     expect(names).toContain("describe-actions");
     expect(names).toContain("import-people-from-urls");
-    expect(names).toHaveLength(22);
+    expect(names).toHaveLength(23);
   });
 });

--- a/packages/mcp/src/tools/campaign-update.test.ts
+++ b/packages/mcp/src/tools/campaign-update.test.ts
@@ -1,0 +1,310 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return {
+    ...actual,
+    LauncherService: vi.fn(),
+    DatabaseClient: vi.fn(),
+    CampaignRepository: vi.fn(),
+    discoverDatabase: vi.fn(),
+  };
+});
+
+import {
+  type Account,
+  type Campaign,
+  CampaignNotFoundError,
+  CampaignRepository,
+  DatabaseClient,
+  discoverDatabase,
+  LauncherService,
+  LinkedHelperNotRunningError,
+} from "@lhremote/core";
+
+import { registerCampaignUpdate } from "./campaign-update.js";
+import { createMockServer } from "./testing/mock-server.js";
+
+const MOCK_CAMPAIGN: Campaign = {
+  id: 15,
+  name: "Updated Campaign",
+  description: "Updated description",
+  state: "active",
+  liAccountId: 1,
+  isPaused: false,
+  isArchived: false,
+  isValid: true,
+  createdAt: "2026-02-07T10:00:00Z",
+};
+
+function mockLauncher(overrides: Record<string, unknown> = {}) {
+  const disconnect = vi.fn();
+  vi.mocked(LauncherService).mockImplementation(function () {
+    return {
+      connect: vi.fn().mockResolvedValue(undefined),
+      disconnect,
+      listAccounts: vi
+        .fn()
+        .mockResolvedValue([{ id: 1, liId: 1, name: "Alice" } as Account]),
+      ...overrides,
+    } as unknown as LauncherService;
+  });
+  return { disconnect };
+}
+
+function mockDb() {
+  const close = vi.fn();
+  vi.mocked(DatabaseClient).mockImplementation(function () {
+    return { close, db: {} } as unknown as DatabaseClient;
+  });
+  return { close };
+}
+
+function mockCampaignRepo(campaign: Campaign = MOCK_CAMPAIGN) {
+  vi.mocked(CampaignRepository).mockImplementation(function () {
+    return {
+      updateCampaign: vi.fn().mockReturnValue(campaign),
+    } as unknown as CampaignRepository;
+  });
+}
+
+function setupSuccessPath() {
+  mockLauncher();
+  mockDb();
+  mockCampaignRepo();
+  vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+}
+
+describe("registerCampaignUpdate", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("registers a tool named campaign-update", () => {
+    const { server } = createMockServer();
+    registerCampaignUpdate(server);
+
+    expect(server.tool).toHaveBeenCalledOnce();
+    expect(server.tool).toHaveBeenCalledWith(
+      "campaign-update",
+      expect.any(String),
+      expect.any(Object),
+      expect.any(Function),
+    );
+  });
+
+  it("successfully updates a campaign name", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignUpdate(server);
+    setupSuccessPath();
+
+    const handler = getHandler("campaign-update");
+    const result = await handler({
+      campaignId: 15,
+      name: "Updated Campaign",
+      cdpPort: 9222,
+    });
+
+    expect(result).toEqual({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(MOCK_CAMPAIGN, null, 2),
+        },
+      ],
+    });
+  });
+
+  it("successfully updates a campaign description", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignUpdate(server);
+    setupSuccessPath();
+
+    const handler = getHandler("campaign-update");
+    const result = await handler({
+      campaignId: 15,
+      description: "Updated description",
+      cdpPort: 9222,
+    });
+
+    expect(result).toEqual({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(MOCK_CAMPAIGN, null, 2),
+        },
+      ],
+    });
+  });
+
+  it("returns error when no fields provided", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignUpdate(server);
+
+    const handler = getHandler("campaign-update");
+    const result = await handler({
+      campaignId: 15,
+      cdpPort: 9222,
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "At least one of name or description must be provided.",
+        },
+      ],
+    });
+  });
+
+  it("returns error for non-existent campaign", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignUpdate(server);
+
+    mockLauncher();
+    mockDb();
+    vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+    vi.mocked(CampaignRepository).mockImplementation(function () {
+      return {
+        updateCampaign: vi.fn().mockImplementation(() => {
+          throw new CampaignNotFoundError(999);
+        }),
+      } as unknown as CampaignRepository;
+    });
+
+    const handler = getHandler("campaign-update");
+    const result = await handler({
+      campaignId: 999,
+      name: "New Name",
+      cdpPort: 9222,
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "Campaign 999 not found.",
+        },
+      ],
+    });
+  });
+
+  it("returns error when LinkedHelper is not running", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignUpdate(server);
+
+    vi.mocked(LauncherService).mockImplementation(function () {
+      return {
+        connect: vi
+          .fn()
+          .mockRejectedValue(new LinkedHelperNotRunningError(9222)),
+        disconnect: vi.fn(),
+      } as unknown as LauncherService;
+    });
+
+    const handler = getHandler("campaign-update");
+    const result = await handler({
+      campaignId: 15,
+      name: "New Name",
+      cdpPort: 9222,
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "LinkedHelper is not running. Use launch-app first.",
+        },
+      ],
+    });
+  });
+
+  it("returns error when connection fails", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignUpdate(server);
+
+    vi.mocked(LauncherService).mockImplementation(function () {
+      return {
+        connect: vi.fn().mockRejectedValue(new Error("connection refused")),
+        disconnect: vi.fn(),
+      } as unknown as LauncherService;
+    });
+
+    const handler = getHandler("campaign-update");
+    const result = await handler({
+      campaignId: 15,
+      name: "New Name",
+      cdpPort: 9222,
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "Failed to connect to LinkedHelper: connection refused",
+        },
+      ],
+    });
+  });
+
+  it("opens database in writable mode", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignUpdate(server);
+
+    mockLauncher();
+    mockDb();
+    mockCampaignRepo();
+    vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+
+    const handler = getHandler("campaign-update");
+    await handler({ campaignId: 15, name: "New", cdpPort: 9222 });
+
+    expect(vi.mocked(DatabaseClient)).toHaveBeenCalledWith("/path/to/db", {
+      readOnly: false,
+    });
+  });
+
+  it("closes database after success", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignUpdate(server);
+
+    mockLauncher();
+    const { close: dbClose } = mockDb();
+    mockCampaignRepo();
+    vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+
+    const handler = getHandler("campaign-update");
+    await handler({ campaignId: 15, name: "New", cdpPort: 9222 });
+
+    expect(dbClose).toHaveBeenCalledOnce();
+  });
+
+  it("closes database after error", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignUpdate(server);
+
+    mockLauncher();
+    const { close: dbClose } = mockDb();
+    vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+    vi.mocked(CampaignRepository).mockImplementation(function () {
+      return {
+        updateCampaign: vi.fn().mockImplementation(() => {
+          throw new Error("db error");
+        }),
+      } as unknown as CampaignRepository;
+    });
+
+    const handler = getHandler("campaign-update");
+    await handler({ campaignId: 15, name: "New", cdpPort: 9222 });
+
+    expect(dbClose).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/mcp/src/tools/campaign-update.ts
+++ b/packages/mcp/src/tools/campaign-update.ts
@@ -1,0 +1,174 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  type Account,
+  CampaignNotFoundError,
+  CampaignRepository,
+  DatabaseClient,
+  discoverDatabase,
+  errorMessage,
+  LauncherService,
+  LinkedHelperNotRunningError,
+} from "@lhremote/core";
+import { z } from "zod";
+
+export function registerCampaignUpdate(server: McpServer): void {
+  server.tool(
+    "campaign-update",
+    "Update a campaign's name and/or description",
+    {
+      campaignId: z
+        .number()
+        .int()
+        .positive()
+        .describe("Campaign ID"),
+      name: z
+        .string()
+        .optional()
+        .describe("New campaign name"),
+      description: z
+        .string()
+        .nullable()
+        .optional()
+        .describe("New campaign description (null to clear)"),
+      cdpPort: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .default(9222)
+        .describe("CDP port (default: 9222)"),
+    },
+    async ({ campaignId, name, description, cdpPort }) => {
+      // Validate that at least one field is provided
+      if (name === undefined && description === undefined) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: "At least one of name or description must be provided.",
+            },
+          ],
+        };
+      }
+
+      // Connect to launcher to find account
+      const launcher = new LauncherService(cdpPort);
+
+      try {
+        await launcher.connect();
+      } catch (error) {
+        if (error instanceof LinkedHelperNotRunningError) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: "LinkedHelper is not running. Use launch-app first.",
+              },
+            ],
+          };
+        }
+        const message = errorMessage(error);
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: `Failed to connect to LinkedHelper: ${message}`,
+            },
+          ],
+        };
+      }
+
+      let accountId: number;
+      try {
+        const accounts = await launcher.listAccounts();
+        if (accounts.length === 0) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: "No accounts found.",
+              },
+            ],
+          };
+        }
+        if (accounts.length > 1) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: "Multiple accounts found. Cannot determine which instance to use.",
+              },
+            ],
+          };
+        }
+        accountId = (accounts[0] as Account).id;
+      } catch (error) {
+        const message = errorMessage(error);
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: `Failed to list accounts: ${message}`,
+            },
+          ],
+        };
+      } finally {
+        launcher.disconnect();
+      }
+
+      // Discover and open database (writable for update)
+      let db: DatabaseClient | null = null;
+
+      try {
+        const dbPath = discoverDatabase(accountId);
+        db = new DatabaseClient(dbPath, { readOnly: false });
+
+        const campaignRepo = new CampaignRepository(db);
+        const updates: { name?: string; description?: string | null } = {};
+        if (name !== undefined) updates.name = name;
+        if (description !== undefined) updates.description = description;
+
+        const campaign = campaignRepo.updateCampaign(campaignId, updates);
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(campaign, null, 2),
+            },
+          ],
+        };
+      } catch (error) {
+        if (error instanceof CampaignNotFoundError) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: `Campaign ${String(campaignId)} not found.`,
+              },
+            ],
+          };
+        }
+        const message = errorMessage(error);
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: `Failed to update campaign: ${message}`,
+            },
+          ],
+        };
+      } finally {
+        db?.close();
+      }
+    },
+  );
+}

--- a/packages/mcp/src/tools/index.ts
+++ b/packages/mcp/src/tools/index.ts
@@ -9,6 +9,7 @@ import { registerImportPeopleFromUrls } from "./import-people-from-urls.js";
 import { registerCampaignStart } from "./campaign-start.js";
 import { registerCampaignStatus } from "./campaign-status.js";
 import { registerCampaignStop } from "./campaign-stop.js";
+import { registerCampaignUpdate } from "./campaign-update.js";
 import { registerCheckReplies } from "./check-replies.js";
 import { registerCheckStatus } from "./check-status.js";
 import { registerDescribeActions } from "./describe-actions.js";
@@ -31,6 +32,7 @@ export function registerAllTools(server: McpServer): void {
   registerCampaignStart(server);
   registerCampaignStatus(server);
   registerCampaignStop(server);
+  registerCampaignUpdate(server);
   registerFindApp(server);
   registerLaunchApp(server);
   registerQuitApp(server);


### PR DESCRIPTION
## Summary
- Add `campaign-update` MCP tool and CLI command to update campaign name and description after creation
- Add `updateCampaign()` to `CampaignRepository` with dynamic SQL for optional field updates
- Add `--clear-description` CLI flag to set description to null

Closes #117

## Test plan
- [x] Unit tests for repository method (7 tests: name, description, null description, both, no fields, not found, field preservation)
- [x] Unit tests for MCP tool (10 tests: registration, success cases, validation, error handling, cleanup)
- [x] CLI command registered with correct options
- [x] Build, lint, and all 730 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)