### PR TITLE
(feat) mcp,cli: add campaign-retry tool

### DIFF
--- a/packages/cli/src/handlers/campaign-retry.ts
+++ b/packages/cli/src/handlers/campaign-retry.ts
@@ -1,0 +1,160 @@
+import { readFileSync } from "node:fs";
+
+import {
+  type Account,
+  CampaignNotFoundError,
+  CampaignRepository,
+  DatabaseClient,
+  discoverDatabase,
+  errorMessage,
+  LauncherService,
+} from "@lhremote/core";
+
+function parsePersonIds(raw: string): number[] {
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+    .map((s) => {
+      const n = Number(s);
+      if (!Number.isInteger(n) || n <= 0) {
+        throw new Error(`Invalid person ID: "${s}"`);
+      }
+      return n;
+    });
+}
+
+function readPersonIdsFile(filePath: string): number[] {
+  const content = readFileSync(filePath, "utf-8");
+  return content
+    .split(/[\n,]/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+    .map((s) => {
+      const n = Number(s);
+      if (!Number.isInteger(n) || n <= 0) {
+        throw new Error(`Invalid person ID in file: "${s}"`);
+      }
+      return n;
+    });
+}
+
+export async function handleCampaignRetry(
+  campaignId: number,
+  options: {
+    personIds?: string;
+    personIdsFile?: string;
+    cdpPort?: number;
+    json?: boolean;
+  },
+): Promise<void> {
+  const cdpPort = options.cdpPort ?? 9222;
+
+  // Reject conflicting options
+  if (options.personIds && options.personIdsFile) {
+    process.stderr.write(
+      "Use only one of --person-ids or --person-ids-file.\n",
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  // Parse person IDs from options
+  let personIds: number[];
+  if (options.personIds) {
+    try {
+      personIds = parsePersonIds(options.personIds);
+    } catch (error) {
+      const message = errorMessage(error);
+      process.stderr.write(`${message}\n`);
+      process.exitCode = 1;
+      return;
+    }
+  } else if (options.personIdsFile) {
+    try {
+      personIds = readPersonIdsFile(options.personIdsFile);
+    } catch (error) {
+      const message = errorMessage(error);
+      process.stderr.write(`${message}\n`);
+      process.exitCode = 1;
+      return;
+    }
+  } else {
+    process.stderr.write(
+      "Either --person-ids or --person-ids-file is required.\n",
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  if (personIds.length === 0) {
+    process.stderr.write("No person IDs provided.\n");
+    process.exitCode = 1;
+    return;
+  }
+
+  // Connect to launcher to find account
+  const launcher = new LauncherService(cdpPort);
+  let accountId: number;
+
+  try {
+    await launcher.connect();
+    const accounts = await launcher.listAccounts();
+    if (accounts.length === 0) {
+      process.stderr.write("No accounts found.\n");
+      process.exitCode = 1;
+      return;
+    }
+    if (accounts.length > 1) {
+      process.stderr.write(
+        "Multiple accounts found. Cannot determine which instance to use.\n",
+      );
+      process.exitCode = 1;
+      return;
+    }
+    accountId = (accounts[0] as Account).id;
+  } catch (error) {
+    const message = errorMessage(error);
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+    return;
+  } finally {
+    launcher.disconnect();
+  }
+
+  // Open database (writable) and reset persons for retry
+  let db: DatabaseClient | null = null;
+
+  try {
+    const dbPath = discoverDatabase(accountId);
+    db = new DatabaseClient(dbPath, { readOnly: false });
+
+    const repo = new CampaignRepository(db);
+    repo.resetForRerun(campaignId, personIds);
+
+    if (options.json) {
+      const response = {
+        success: true,
+        campaignId,
+        personsReset: personIds.length,
+        message:
+          "Persons reset for retry. Use campaign-start to run the campaign.",
+      };
+      process.stdout.write(JSON.stringify(response, null, 2) + "\n");
+    } else {
+      process.stdout.write(
+        `Campaign ${String(campaignId)}: ${String(personIds.length)} persons reset for retry.\n`,
+      );
+    }
+  } catch (error) {
+    if (error instanceof CampaignNotFoundError) {
+      process.stderr.write(`Campaign ${String(campaignId)} not found.\n`);
+    } else {
+      const message = errorMessage(error);
+      process.stderr.write(`${message}\n`);
+    }
+    process.exitCode = 1;
+  } finally {
+    db?.close();
+  }
+}

--- a/packages/cli/src/handlers/index.ts
+++ b/packages/cli/src/handlers/index.ts
@@ -3,6 +3,7 @@ export { handleCampaignDelete } from "./campaign-delete.js";
 export { handleCampaignExport } from "./campaign-export.js";
 export { handleCampaignGet } from "./campaign-get.js";
 export { handleCampaignList } from "./campaign-list.js";
+export { handleCampaignRetry } from "./campaign-retry.js";
 export { handleCampaignStart } from "./campaign-start.js";
 export { handleCampaignStatus } from "./campaign-status.js";
 export { handleImportPeopleFromUrls } from "./import-people-from-urls.js";

--- a/packages/cli/src/program.test.ts
+++ b/packages/cli/src/program.test.ts
@@ -48,6 +48,7 @@ describe("createProgram", () => {
     expect(commandNames).toContain("campaign-export");
     expect(commandNames).toContain("campaign-get");
     expect(commandNames).toContain("campaign-list");
+    expect(commandNames).toContain("campaign-retry");
     expect(commandNames).toContain("campaign-start");
     expect(commandNames).toContain("campaign-status");
     expect(commandNames).toContain("campaign-stop");
@@ -56,7 +57,7 @@ describe("createProgram", () => {
     expect(commandNames).toContain("check-status");
     expect(commandNames).toContain("describe-actions");
     expect(commandNames).toContain("import-people-from-urls");
-    expect(commandNames).toHaveLength(23);
+    expect(commandNames).toHaveLength(24);
   });
 
   describe("launch-app", () => {

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -8,6 +8,7 @@ import {
   handleCampaignExport,
   handleCampaignGet,
   handleCampaignList,
+  handleCampaignRetry,
   handleCampaignStart,
   handleCampaignStatus,
   handleCampaignStop,
@@ -154,6 +155,16 @@ export function createProgram(): Command {
     .option("--cdp-port <port>", "CDP debugging port", parsePositiveInt)
     .option("--json", "Output as JSON")
     .action(handleCampaignStatus);
+
+  program
+    .command("campaign-retry")
+    .description("Reset specified people for re-run in a campaign")
+    .argument("<campaignId>", "Campaign ID", parsePositiveInt)
+    .option("--person-ids <ids>", "Comma-separated person IDs")
+    .option("--person-ids-file <path>", "File containing person IDs")
+    .option("--cdp-port <port>", "CDP debugging port", parsePositiveInt)
+    .option("--json", "Output as JSON")
+    .action(handleCampaignRetry);
 
   program
     .command("campaign-start")

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -87,6 +87,7 @@ describe("createServer", () => {
     expect(names).toContain("campaign-export");
     expect(names).toContain("campaign-get");
     expect(names).toContain("campaign-list");
+    expect(names).toContain("campaign-retry");
     expect(names).toContain("campaign-start");
     expect(names).toContain("campaign-status");
     expect(names).toContain("campaign-stop");
@@ -95,6 +96,6 @@ describe("createServer", () => {
     expect(names).toContain("check-status");
     expect(names).toContain("describe-actions");
     expect(names).toContain("import-people-from-urls");
-    expect(names).toHaveLength(23);
+    expect(names).toHaveLength(24);
   });
 });

--- a/packages/mcp/src/tools/campaign-retry.test.ts
+++ b/packages/mcp/src/tools/campaign-retry.test.ts
@@ -1,0 +1,285 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return {
+    ...actual,
+    LauncherService: vi.fn(),
+    DatabaseClient: vi.fn(),
+    CampaignRepository: vi.fn(),
+    discoverDatabase: vi.fn(),
+  };
+});
+
+import {
+  type Account,
+  CampaignNotFoundError,
+  CampaignRepository,
+  DatabaseClient,
+  discoverDatabase,
+  LauncherService,
+  LinkedHelperNotRunningError,
+} from "@lhremote/core";
+
+import { registerCampaignRetry } from "./campaign-retry.js";
+import { createMockServer } from "./testing/mock-server.js";
+
+function mockLauncher(overrides: Record<string, unknown> = {}) {
+  const disconnect = vi.fn();
+  vi.mocked(LauncherService).mockImplementation(function () {
+    return {
+      connect: vi.fn().mockResolvedValue(undefined),
+      disconnect,
+      listAccounts: vi
+        .fn()
+        .mockResolvedValue([{ id: 1, liId: 1, name: "Alice" } as Account]),
+      ...overrides,
+    } as unknown as LauncherService;
+  });
+  return { disconnect };
+}
+
+function mockDb() {
+  const close = vi.fn();
+  vi.mocked(DatabaseClient).mockImplementation(function () {
+    return { close, db: {} } as unknown as DatabaseClient;
+  });
+  return { close };
+}
+
+function mockCampaignRepo() {
+  const resetForRerun = vi.fn();
+  vi.mocked(CampaignRepository).mockImplementation(function () {
+    return {
+      resetForRerun,
+    } as unknown as CampaignRepository;
+  });
+  return { resetForRerun };
+}
+
+function setupSuccessPath() {
+  mockLauncher();
+  mockDb();
+  mockCampaignRepo();
+  vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+}
+
+describe("registerCampaignRetry", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("registers a tool named campaign-retry", () => {
+    const { server } = createMockServer();
+    registerCampaignRetry(server);
+
+    expect(server.tool).toHaveBeenCalledOnce();
+    expect(server.tool).toHaveBeenCalledWith(
+      "campaign-retry",
+      expect.any(String),
+      expect.any(Object),
+      expect.any(Function),
+    );
+  });
+
+  it("successfully resets persons for retry", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignRetry(server);
+    setupSuccessPath();
+
+    const handler = getHandler("campaign-retry");
+    const result = await handler({
+      campaignId: 10,
+      personIds: [100, 200],
+      cdpPort: 9222,
+    });
+
+    expect(result).toEqual({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(
+            {
+              success: true,
+              campaignId: 10,
+              personsReset: 2,
+              message:
+                "Persons reset for retry. Use campaign-start to run the campaign.",
+            },
+            null,
+            2,
+          ),
+        },
+      ],
+    });
+  });
+
+  it("calls resetForRerun with correct arguments", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignRetry(server);
+
+    mockLauncher();
+    mockDb();
+    const { resetForRerun } = mockCampaignRepo();
+    vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+
+    const handler = getHandler("campaign-retry");
+    await handler({
+      campaignId: 10,
+      personIds: [100, 200],
+      cdpPort: 9222,
+    });
+
+    expect(resetForRerun).toHaveBeenCalledWith(10, [100, 200]);
+  });
+
+  it("returns error for non-existent campaign", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignRetry(server);
+
+    mockLauncher();
+    mockDb();
+    vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+    vi.mocked(CampaignRepository).mockImplementation(function () {
+      return {
+        resetForRerun: vi.fn().mockImplementation(() => {
+          throw new CampaignNotFoundError(999);
+        }),
+      } as unknown as CampaignRepository;
+    });
+
+    const handler = getHandler("campaign-retry");
+    const result = await handler({
+      campaignId: 999,
+      personIds: [100],
+      cdpPort: 9222,
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "Campaign 999 not found.",
+        },
+      ],
+    });
+  });
+
+  it("returns error when LinkedHelper is not running", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignRetry(server);
+
+    vi.mocked(LauncherService).mockImplementation(function () {
+      return {
+        connect: vi
+          .fn()
+          .mockRejectedValue(new LinkedHelperNotRunningError(9222)),
+        disconnect: vi.fn(),
+      } as unknown as LauncherService;
+    });
+
+    const handler = getHandler("campaign-retry");
+    const result = await handler({
+      campaignId: 10,
+      personIds: [100],
+      cdpPort: 9222,
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "LinkedHelper is not running. Use launch-app first.",
+        },
+      ],
+    });
+  });
+
+  it("returns error when connection fails", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignRetry(server);
+
+    vi.mocked(LauncherService).mockImplementation(function () {
+      return {
+        connect: vi.fn().mockRejectedValue(new Error("connection refused")),
+        disconnect: vi.fn(),
+      } as unknown as LauncherService;
+    });
+
+    const handler = getHandler("campaign-retry");
+    const result = await handler({
+      campaignId: 10,
+      personIds: [100],
+      cdpPort: 9222,
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "Failed to connect to LinkedHelper: connection refused",
+        },
+      ],
+    });
+  });
+
+  it("opens database in writable mode", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignRetry(server);
+
+    mockLauncher();
+    mockDb();
+    mockCampaignRepo();
+    vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+
+    const handler = getHandler("campaign-retry");
+    await handler({ campaignId: 10, personIds: [100], cdpPort: 9222 });
+
+    expect(vi.mocked(DatabaseClient)).toHaveBeenCalledWith("/path/to/db", {
+      readOnly: false,
+    });
+  });
+
+  it("closes database after success", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignRetry(server);
+
+    mockLauncher();
+    const { close: dbClose } = mockDb();
+    mockCampaignRepo();
+    vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+
+    const handler = getHandler("campaign-retry");
+    await handler({ campaignId: 10, personIds: [100], cdpPort: 9222 });
+
+    expect(dbClose).toHaveBeenCalledOnce();
+  });
+
+  it("closes database after error", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignRetry(server);
+
+    mockLauncher();
+    const { close: dbClose } = mockDb();
+    vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+    vi.mocked(CampaignRepository).mockImplementation(function () {
+      return {
+        resetForRerun: vi.fn().mockImplementation(() => {
+          throw new Error("db error");
+        }),
+      } as unknown as CampaignRepository;
+    });
+
+    const handler = getHandler("campaign-retry");
+    await handler({ campaignId: 10, personIds: [100], cdpPort: 9222 });
+
+    expect(dbClose).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/mcp/src/tools/campaign-retry.ts
+++ b/packages/mcp/src/tools/campaign-retry.ts
@@ -1,0 +1,162 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  type Account,
+  CampaignNotFoundError,
+  CampaignRepository,
+  DatabaseClient,
+  discoverDatabase,
+  errorMessage,
+  LauncherService,
+  LinkedHelperNotRunningError,
+} from "@lhremote/core";
+import { z } from "zod";
+
+export function registerCampaignRetry(server: McpServer): void {
+  server.tool(
+    "campaign-retry",
+    "Reset specified people for re-run in a campaign (three-table reset without starting the campaign)",
+    {
+      campaignId: z
+        .number()
+        .int()
+        .positive()
+        .describe("Campaign ID"),
+      personIds: z
+        .array(z.number().int().positive())
+        .nonempty()
+        .describe("Person IDs to reset for retry"),
+      cdpPort: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .default(9222)
+        .describe("CDP port (default: 9222)"),
+    },
+    async ({ campaignId, personIds, cdpPort }) => {
+      // Connect to launcher to find account
+      const launcher = new LauncherService(cdpPort);
+
+      try {
+        await launcher.connect();
+      } catch (error) {
+        if (error instanceof LinkedHelperNotRunningError) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: "LinkedHelper is not running. Use launch-app first.",
+              },
+            ],
+          };
+        }
+        const message = errorMessage(error);
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: `Failed to connect to LinkedHelper: ${message}`,
+            },
+          ],
+        };
+      }
+
+      let accountId: number;
+      try {
+        const accounts = await launcher.listAccounts();
+        if (accounts.length === 0) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: "No accounts found.",
+              },
+            ],
+          };
+        }
+        if (accounts.length > 1) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: "Multiple accounts found. Cannot determine which instance to use.",
+              },
+            ],
+          };
+        }
+        accountId = (accounts[0] as Account).id;
+      } catch (error) {
+        const message = errorMessage(error);
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: `Failed to list accounts: ${message}`,
+            },
+          ],
+        };
+      } finally {
+        launcher.disconnect();
+      }
+
+      // Discover and open database (writable for reset)
+      let db: DatabaseClient | null = null;
+
+      try {
+        const dbPath = discoverDatabase(accountId);
+        db = new DatabaseClient(dbPath, { readOnly: false });
+
+        const campaignRepo = new CampaignRepository(db);
+        campaignRepo.resetForRerun(campaignId, personIds);
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                {
+                  success: true,
+                  campaignId,
+                  personsReset: personIds.length,
+                  message:
+                    "Persons reset for retry. Use campaign-start to run the campaign.",
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      } catch (error) {
+        if (error instanceof CampaignNotFoundError) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: `Campaign ${String(campaignId)} not found.`,
+              },
+            ],
+          };
+        }
+        const message = errorMessage(error);
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: `Failed to reset persons for retry: ${message}`,
+            },
+          ],
+        };
+      } finally {
+        db?.close();
+      }
+    },
+  );
+}

--- a/packages/mcp/src/tools/index.ts
+++ b/packages/mcp/src/tools/index.ts
@@ -5,6 +5,7 @@ import { registerCampaignDelete } from "./campaign-delete.js";
 import { registerCampaignExport } from "./campaign-export.js";
 import { registerCampaignGet } from "./campaign-get.js";
 import { registerCampaignList } from "./campaign-list.js";
+import { registerCampaignRetry } from "./campaign-retry.js";
 import { registerImportPeopleFromUrls } from "./import-people-from-urls.js";
 import { registerCampaignStart } from "./campaign-start.js";
 import { registerCampaignStatus } from "./campaign-status.js";
@@ -29,6 +30,7 @@ export function registerAllTools(server: McpServer): void {
   registerCampaignExport(server);
   registerCampaignGet(server);
   registerCampaignList(server);
+  registerCampaignRetry(server);
   registerCampaignStart(server);
   registerCampaignStatus(server);
   registerCampaignStop(server);


### PR DESCRIPTION
## Summary

- Adds `campaign-retry` MCP tool and CLI command that performs the three-table reset for specified people in a campaign
- Reuses existing `CampaignRepository.resetForRerun()` to requeue persons without restarting the campaign
- Database-only operation (no instance connection needed) — follows `campaign-update` pattern

## Test plan

- [x] MCP tool unit tests (9 tests): registration, success path, argument passing, error handling, DB lifecycle
- [x] Server test updated for new tool count (24)
- [x] CLI program test updated for new command count (24)
- [x] Build, lint, and all 739 tests pass

Closes #118

🤖 Generated with [Claude Code](https://claude.com/claude-code)