### PR TITLE
(feat) core,mcp,cli: add campaign action chain management tools

### DIFF
--- a/packages/cli/src/handlers/campaign-add-action.ts
+++ b/packages/cli/src/handlers/campaign-add-action.ts
@@ -1,0 +1,119 @@
+import {
+  type Account,
+  CampaignNotFoundError,
+  CampaignRepository,
+  DatabaseClient,
+  discoverDatabase,
+  errorMessage,
+  LauncherService,
+} from "@lhremote/core";
+
+export async function handleCampaignAddAction(
+  campaignId: number,
+  options: {
+    name: string;
+    actionType: string;
+    description?: string;
+    coolDown?: number;
+    maxResults?: number;
+    actionSettings?: string;
+    cdpPort?: number;
+    json?: boolean;
+  },
+): Promise<void> {
+  const cdpPort = options.cdpPort ?? 9222;
+
+  // Parse action settings JSON if provided
+  let parsedSettings: Record<string, unknown> = {};
+  if (options.actionSettings !== undefined) {
+    try {
+      parsedSettings = JSON.parse(options.actionSettings) as Record<
+        string,
+        unknown
+      >;
+    } catch {
+      process.stderr.write("Invalid JSON in --action-settings.\n");
+      process.exitCode = 1;
+      return;
+    }
+  }
+
+  // Connect to launcher to find account
+  const launcher = new LauncherService(cdpPort);
+  let accountId: number;
+
+  try {
+    await launcher.connect();
+    const accounts = await launcher.listAccounts();
+    if (accounts.length === 0) {
+      process.stderr.write("No accounts found.\n");
+      process.exitCode = 1;
+      return;
+    }
+    if (accounts.length > 1) {
+      process.stderr.write(
+        "Multiple accounts found. Cannot determine which instance to use.\n",
+      );
+      process.exitCode = 1;
+      return;
+    }
+    accountId = (accounts[0] as Account).id;
+  } catch (error) {
+    const message = errorMessage(error);
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+    return;
+  } finally {
+    launcher.disconnect();
+  }
+
+  // Open database (writable) and add action
+  let db: DatabaseClient | null = null;
+
+  try {
+    const dbPath = discoverDatabase(accountId);
+    db = new DatabaseClient(dbPath, { readOnly: false });
+
+    const repo = new CampaignRepository(db);
+    const campaign = repo.getCampaign(campaignId);
+
+    const actionConfig: import("@lhremote/core").CampaignActionConfig = {
+      name: options.name,
+      actionType: options.actionType,
+      actionSettings: parsedSettings,
+    };
+    if (options.description !== undefined) {
+      actionConfig.description = options.description;
+    }
+    if (options.coolDown !== undefined) {
+      actionConfig.coolDown = options.coolDown;
+    }
+    if (options.maxResults !== undefined) {
+      actionConfig.maxActionResultsPerIteration = options.maxResults;
+    }
+
+    const action = repo.addAction(
+      campaignId,
+      actionConfig,
+      campaign.liAccountId,
+    );
+
+    if (options.json) {
+      process.stdout.write(JSON.stringify(action, null, 2) + "\n");
+    } else {
+      process.stdout.write(
+        `Action added: #${action.id} "${action.name}" (${action.config.actionType}) to campaign #${campaign.id}\n`,
+      );
+    }
+  } catch (error) {
+    if (error instanceof CampaignNotFoundError) {
+      process.stderr.write(`Campaign ${String(campaignId)} not found.\n`);
+    } else {
+      const message = errorMessage(error);
+      process.stderr.write(`${message}\n`);
+    }
+    process.exitCode = 1;
+  } finally {
+    db?.close();
+  }
+}

--- a/packages/cli/src/handlers/campaign-remove-action.ts
+++ b/packages/cli/src/handlers/campaign-remove-action.ts
@@ -1,0 +1,106 @@
+import {
+  type Account,
+  ActionNotFoundError,
+  CampaignExecutionError,
+  CampaignNotFoundError,
+  CampaignService,
+  DatabaseClient,
+  discoverDatabase,
+  discoverInstancePort,
+  errorMessage,
+  InstanceService,
+  LauncherService,
+} from "@lhremote/core";
+
+export async function handleCampaignRemoveAction(
+  campaignId: number,
+  actionId: number,
+  options: {
+    cdpPort?: number;
+    json?: boolean;
+  },
+): Promise<void> {
+  const cdpPort = options.cdpPort ?? 9222;
+
+  // Connect to launcher to find account
+  const launcher = new LauncherService(cdpPort);
+  let accountId: number;
+
+  try {
+    await launcher.connect();
+    const accounts = await launcher.listAccounts();
+    if (accounts.length === 0) {
+      process.stderr.write("No accounts found.\n");
+      process.exitCode = 1;
+      return;
+    }
+    if (accounts.length > 1) {
+      process.stderr.write(
+        "Multiple accounts found. Cannot determine which instance to use.\n",
+      );
+      process.exitCode = 1;
+      return;
+    }
+    accountId = (accounts[0] as Account).id;
+  } catch (error) {
+    const message = errorMessage(error);
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+    return;
+  } finally {
+    launcher.disconnect();
+  }
+
+  // Discover instance
+  const instancePort = await discoverInstancePort(cdpPort);
+  if (instancePort === null) {
+    process.stderr.write(
+      "No LinkedHelper instance is running. Use start-instance first.\n",
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  // Connect and remove action
+  const instance = new InstanceService(instancePort);
+  let db: DatabaseClient | null = null;
+
+  try {
+    await instance.connect();
+    const dbPath = discoverDatabase(accountId);
+    db = new DatabaseClient(dbPath);
+
+    const campaignService = new CampaignService(instance, db);
+    await campaignService.removeAction(campaignId, actionId);
+
+    if (options.json) {
+      const response = {
+        success: true,
+        campaignId,
+        removedActionId: actionId,
+      };
+      process.stdout.write(JSON.stringify(response, null, 2) + "\n");
+    } else {
+      process.stdout.write(
+        `Action ${String(actionId)} removed from campaign ${String(campaignId)}.\n`,
+      );
+    }
+  } catch (error) {
+    if (error instanceof CampaignNotFoundError) {
+      process.stderr.write(`Campaign ${String(campaignId)} not found.\n`);
+    } else if (error instanceof ActionNotFoundError) {
+      process.stderr.write(
+        `Action ${String(actionId)} not found in campaign ${String(campaignId)}.\n`,
+      );
+    } else if (error instanceof CampaignExecutionError) {
+      process.stderr.write(`Failed to remove action: ${error.message}\n`);
+    } else {
+      const message = errorMessage(error);
+      process.stderr.write(`${message}\n`);
+    }
+    process.exitCode = 1;
+  } finally {
+    instance.disconnect();
+    db?.close();
+  }
+}

--- a/packages/cli/src/handlers/campaign-reorder-actions.ts
+++ b/packages/cli/src/handlers/campaign-reorder-actions.ts
@@ -1,0 +1,141 @@
+import {
+  type Account,
+  ActionNotFoundError,
+  CampaignExecutionError,
+  CampaignNotFoundError,
+  CampaignService,
+  DatabaseClient,
+  discoverDatabase,
+  discoverInstancePort,
+  errorMessage,
+  InstanceService,
+  LauncherService,
+} from "@lhremote/core";
+
+export async function handleCampaignReorderActions(
+  campaignId: number,
+  options: {
+    actionIds: string;
+    cdpPort?: number;
+    json?: boolean;
+  },
+): Promise<void> {
+  const cdpPort = options.cdpPort ?? 9222;
+
+  // Parse action IDs
+  const actionIds = options.actionIds
+    .split(",")
+    .map((s) => {
+      const n = Number(s.trim());
+      if (!Number.isInteger(n) || n <= 0) {
+        process.stderr.write(
+          `Invalid action ID: "${s.trim()}". Expected positive integers.\n`,
+        );
+        process.exitCode = 1;
+        return NaN;
+      }
+      return n;
+    });
+
+  if (actionIds.some((n) => Number.isNaN(n))) {
+    return;
+  }
+
+  if (actionIds.length === 0) {
+    process.stderr.write("No action IDs provided.\n");
+    process.exitCode = 1;
+    return;
+  }
+
+  // Connect to launcher to find account
+  const launcher = new LauncherService(cdpPort);
+  let accountId: number;
+
+  try {
+    await launcher.connect();
+    const accounts = await launcher.listAccounts();
+    if (accounts.length === 0) {
+      process.stderr.write("No accounts found.\n");
+      process.exitCode = 1;
+      return;
+    }
+    if (accounts.length > 1) {
+      process.stderr.write(
+        "Multiple accounts found. Cannot determine which instance to use.\n",
+      );
+      process.exitCode = 1;
+      return;
+    }
+    accountId = (accounts[0] as Account).id;
+  } catch (error) {
+    const message = errorMessage(error);
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+    return;
+  } finally {
+    launcher.disconnect();
+  }
+
+  // Discover instance
+  const instancePort = await discoverInstancePort(cdpPort);
+  if (instancePort === null) {
+    process.stderr.write(
+      "No LinkedHelper instance is running. Use start-instance first.\n",
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  // Connect and reorder actions
+  const instance = new InstanceService(instancePort);
+  let db: DatabaseClient | null = null;
+
+  try {
+    await instance.connect();
+    const dbPath = discoverDatabase(accountId);
+    db = new DatabaseClient(dbPath);
+
+    const campaignService = new CampaignService(instance, db);
+    const updatedActions = await campaignService.reorderActions(
+      campaignId,
+      actionIds,
+    );
+
+    if (options.json) {
+      const response = {
+        success: true,
+        campaignId,
+        actions: updatedActions,
+      };
+      process.stdout.write(JSON.stringify(response, null, 2) + "\n");
+    } else {
+      process.stdout.write(
+        `Actions reordered in campaign ${String(campaignId)}.\n`,
+      );
+      for (const action of updatedActions) {
+        process.stdout.write(
+          `  #${action.id} "${action.name}" (${action.config.actionType})\n`,
+        );
+      }
+    }
+  } catch (error) {
+    if (error instanceof CampaignNotFoundError) {
+      process.stderr.write(`Campaign ${String(campaignId)} not found.\n`);
+    } else if (error instanceof ActionNotFoundError) {
+      process.stderr.write(
+        `One or more action IDs not found in campaign ${String(campaignId)}.\n`,
+      );
+    } else if (error instanceof CampaignExecutionError) {
+      process.stderr.write(
+        `Failed to reorder actions: ${error.message}\n`,
+      );
+    } else {
+      const message = errorMessage(error);
+      process.stderr.write(`${message}\n`);
+    }
+    process.exitCode = 1;
+  } finally {
+    instance.disconnect();
+    db?.close();
+  }
+}

--- a/packages/cli/src/handlers/index.ts
+++ b/packages/cli/src/handlers/index.ts
@@ -1,9 +1,12 @@
+export { handleCampaignAddAction } from "./campaign-add-action.js";
 export { handleCampaignCreate } from "./campaign-create.js";
 export { handleCampaignDelete } from "./campaign-delete.js";
 export { handleCampaignExport } from "./campaign-export.js";
 export { handleCampaignGet } from "./campaign-get.js";
 export { handleCampaignList } from "./campaign-list.js";
 export { handleCampaignMoveNext } from "./campaign-move-next.js";
+export { handleCampaignRemoveAction } from "./campaign-remove-action.js";
+export { handleCampaignReorderActions } from "./campaign-reorder-actions.js";
 export { handleCampaignRetry } from "./campaign-retry.js";
 export { handleCampaignStart } from "./campaign-start.js";
 export { handleCampaignStatus } from "./campaign-status.js";

--- a/packages/cli/src/program.test.ts
+++ b/packages/cli/src/program.test.ts
@@ -58,7 +58,10 @@ describe("createProgram", () => {
     expect(commandNames).toContain("describe-actions");
     expect(commandNames).toContain("import-people-from-urls");
     expect(commandNames).toContain("campaign-move-next");
-    expect(commandNames).toHaveLength(25);
+    expect(commandNames).toContain("campaign-add-action");
+    expect(commandNames).toContain("campaign-remove-action");
+    expect(commandNames).toContain("campaign-reorder-actions");
+    expect(commandNames).toHaveLength(28);
   });
 
   describe("launch-app", () => {

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -3,12 +3,15 @@ import { createRequire } from "node:module";
 import { Command, InvalidArgumentError, Option } from "commander";
 
 import {
+  handleCampaignAddAction,
   handleCampaignCreate,
   handleCampaignDelete,
   handleCampaignExport,
   handleCampaignGet,
   handleCampaignList,
   handleCampaignMoveNext,
+  handleCampaignRemoveAction,
+  handleCampaignReorderActions,
   handleCampaignRetry,
   handleCampaignStart,
   handleCampaignStatus,
@@ -206,6 +209,52 @@ export function createProgram(): Command {
     .option("--cdp-port <port>", "CDP debugging port", parsePositiveInt)
     .option("--json", "Output as JSON")
     .action(handleCampaignUpdate);
+
+  program
+    .command("campaign-add-action")
+    .description("Add a new action to a campaign's action chain")
+    .argument("<campaignId>", "Campaign ID", parsePositiveInt)
+    .requiredOption("--name <name>", "Display name for the action")
+    .requiredOption(
+      "--action-type <type>",
+      "Action type identifier (e.g., 'VisitAndExtract', 'MessageToPerson')",
+    )
+    .option("--description <text>", "Action description")
+    .option(
+      "--cool-down <ms>",
+      "Milliseconds between action executions",
+      parsePositiveInt,
+    )
+    .option(
+      "--max-results <n>",
+      "Maximum results per iteration (-1 for unlimited)",
+      parseInt,
+    )
+    .option("--action-settings <json>", "Action-specific settings as JSON")
+    .option("--cdp-port <port>", "CDP debugging port", parsePositiveInt)
+    .option("--json", "Output as JSON")
+    .action(handleCampaignAddAction);
+
+  program
+    .command("campaign-remove-action")
+    .description("Remove an action from a campaign's action chain")
+    .argument("<campaignId>", "Campaign ID", parsePositiveInt)
+    .argument("<actionId>", "Action ID to remove", parsePositiveInt)
+    .option("--cdp-port <port>", "CDP debugging port", parsePositiveInt)
+    .option("--json", "Output as JSON")
+    .action(handleCampaignRemoveAction);
+
+  program
+    .command("campaign-reorder-actions")
+    .description("Reorder actions in a campaign's action chain")
+    .argument("<campaignId>", "Campaign ID", parsePositiveInt)
+    .requiredOption(
+      "--action-ids <ids>",
+      "Comma-separated action IDs in desired order",
+    )
+    .option("--cdp-port <port>", "CDP debugging port", parsePositiveInt)
+    .option("--json", "Output as JSON")
+    .action(handleCampaignReorderActions);
 
   program
     .command("import-people-from-urls")

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -97,6 +97,9 @@ describe("createServer", () => {
     expect(names).toContain("describe-actions");
     expect(names).toContain("import-people-from-urls");
     expect(names).toContain("campaign-move-next");
-    expect(names).toHaveLength(25);
+    expect(names).toContain("campaign-add-action");
+    expect(names).toContain("campaign-remove-action");
+    expect(names).toContain("campaign-reorder-actions");
+    expect(names).toHaveLength(28);
   });
 });

--- a/packages/mcp/src/tools/campaign-add-action.test.ts
+++ b/packages/mcp/src/tools/campaign-add-action.test.ts
@@ -1,0 +1,292 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return {
+    ...actual,
+    LauncherService: vi.fn(),
+    DatabaseClient: vi.fn(),
+    CampaignRepository: vi.fn(),
+    discoverDatabase: vi.fn(),
+  };
+});
+
+import {
+  type Account,
+  type CampaignAction,
+  CampaignNotFoundError,
+  CampaignRepository,
+  DatabaseClient,
+  discoverDatabase,
+  LauncherService,
+  LinkedHelperNotRunningError,
+} from "@lhremote/core";
+
+import { registerCampaignAddAction } from "./campaign-add-action.js";
+import { createMockServer } from "./testing/mock-server.js";
+
+const MOCK_ACTION: CampaignAction = {
+  id: 50,
+  campaignId: 15,
+  name: "Visit & Extract",
+  description: null,
+  config: {
+    id: 500,
+    actionType: "VisitAndExtract",
+    actionSettings: {},
+    coolDown: 60000,
+    maxActionResultsPerIteration: 10,
+    isDraft: false,
+  },
+  versionId: 5000,
+};
+
+function mockLauncher(overrides: Record<string, unknown> = {}) {
+  const disconnect = vi.fn();
+  vi.mocked(LauncherService).mockImplementation(function () {
+    return {
+      connect: vi.fn().mockResolvedValue(undefined),
+      disconnect,
+      listAccounts: vi
+        .fn()
+        .mockResolvedValue([{ id: 1, liId: 1, name: "Alice" } as Account]),
+      ...overrides,
+    } as unknown as LauncherService;
+  });
+  return { disconnect };
+}
+
+function mockDb() {
+  const close = vi.fn();
+  vi.mocked(DatabaseClient).mockImplementation(function () {
+    return { close, db: {} } as unknown as DatabaseClient;
+  });
+  return { close };
+}
+
+function mockCampaignRepo(overrides: Record<string, unknown> = {}) {
+  vi.mocked(CampaignRepository).mockImplementation(function () {
+    return {
+      getCampaign: vi.fn().mockReturnValue({
+        id: 15,
+        name: "Test Campaign",
+        liAccountId: 1,
+      }),
+      addAction: vi.fn().mockReturnValue(MOCK_ACTION),
+      ...overrides,
+    } as unknown as CampaignRepository;
+  });
+}
+
+function setupSuccessPath() {
+  mockLauncher();
+  mockDb();
+  mockCampaignRepo();
+  vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+}
+
+describe("registerCampaignAddAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("registers a tool named campaign-add-action", () => {
+    const { server } = createMockServer();
+    registerCampaignAddAction(server);
+
+    expect(server.tool).toHaveBeenCalledOnce();
+    expect(server.tool).toHaveBeenCalledWith(
+      "campaign-add-action",
+      expect.any(String),
+      expect.any(Object),
+      expect.any(Function),
+    );
+  });
+
+  it("successfully adds action with required params", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignAddAction(server);
+    setupSuccessPath();
+
+    const handler = getHandler("campaign-add-action");
+    const result = await handler({
+      campaignId: 15,
+      name: "Visit & Extract",
+      actionType: "VisitAndExtract",
+      cdpPort: 9222,
+    });
+
+    expect(result).toEqual({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(MOCK_ACTION, null, 2),
+        },
+      ],
+    });
+  });
+
+  it("returns error for invalid actionSettings JSON", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignAddAction(server);
+
+    const handler = getHandler("campaign-add-action");
+    const result = await handler({
+      campaignId: 15,
+      name: "Visit & Extract",
+      actionType: "VisitAndExtract",
+      actionSettings: "{not-valid-json",
+      cdpPort: 9222,
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "Invalid JSON in actionSettings.",
+        },
+      ],
+    });
+  });
+
+  it("returns error for non-existent campaign", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignAddAction(server);
+
+    mockLauncher();
+    mockDb();
+    vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+    vi.mocked(CampaignRepository).mockImplementation(function () {
+      return {
+        getCampaign: vi.fn().mockImplementation(() => {
+          throw new CampaignNotFoundError(999);
+        }),
+        addAction: vi.fn(),
+      } as unknown as CampaignRepository;
+    });
+
+    const handler = getHandler("campaign-add-action");
+    const result = await handler({
+      campaignId: 999,
+      name: "Visit",
+      actionType: "VisitAndExtract",
+      cdpPort: 9222,
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "Campaign 999 not found.",
+        },
+      ],
+    });
+  });
+
+  it("returns error when LinkedHelper is not running", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignAddAction(server);
+
+    vi.mocked(LauncherService).mockImplementation(function () {
+      return {
+        connect: vi
+          .fn()
+          .mockRejectedValue(new LinkedHelperNotRunningError(9222)),
+        disconnect: vi.fn(),
+      } as unknown as LauncherService;
+    });
+
+    const handler = getHandler("campaign-add-action");
+    const result = await handler({
+      campaignId: 15,
+      name: "Visit",
+      actionType: "VisitAndExtract",
+      cdpPort: 9222,
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "LinkedHelper is not running. Use launch-app first.",
+        },
+      ],
+    });
+  });
+
+  it("opens database in writable mode", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignAddAction(server);
+
+    mockLauncher();
+    mockDb();
+    mockCampaignRepo();
+    vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+
+    const handler = getHandler("campaign-add-action");
+    await handler({
+      campaignId: 15,
+      name: "Visit",
+      actionType: "VisitAndExtract",
+      cdpPort: 9222,
+    });
+
+    expect(vi.mocked(DatabaseClient)).toHaveBeenCalledWith("/path/to/db", {
+      readOnly: false,
+    });
+  });
+
+  it("closes database after success", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignAddAction(server);
+
+    mockLauncher();
+    const { close: dbClose } = mockDb();
+    mockCampaignRepo();
+    vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+
+    const handler = getHandler("campaign-add-action");
+    await handler({
+      campaignId: 15,
+      name: "Visit",
+      actionType: "VisitAndExtract",
+      cdpPort: 9222,
+    });
+
+    expect(dbClose).toHaveBeenCalledOnce();
+  });
+
+  it("closes database after error", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignAddAction(server);
+
+    mockLauncher();
+    const { close: dbClose } = mockDb();
+    vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+    vi.mocked(CampaignRepository).mockImplementation(function () {
+      return {
+        getCampaign: vi.fn().mockImplementation(() => {
+          throw new Error("db error");
+        }),
+        addAction: vi.fn(),
+      } as unknown as CampaignRepository;
+    });
+
+    const handler = getHandler("campaign-add-action");
+    await handler({
+      campaignId: 15,
+      name: "Visit",
+      actionType: "VisitAndExtract",
+      cdpPort: 9222,
+    });
+
+    expect(dbClose).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/mcp/src/tools/campaign-add-action.ts
+++ b/packages/mcp/src/tools/campaign-add-action.ts
@@ -1,0 +1,221 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  type Account,
+  CampaignNotFoundError,
+  CampaignRepository,
+  DatabaseClient,
+  discoverDatabase,
+  errorMessage,
+  LauncherService,
+  LinkedHelperNotRunningError,
+} from "@lhremote/core";
+import { z } from "zod";
+
+export function registerCampaignAddAction(server: McpServer): void {
+  server.tool(
+    "campaign-add-action",
+    "Add a new action to an existing campaign's action chain",
+    {
+      campaignId: z
+        .number()
+        .int()
+        .positive()
+        .describe("Campaign ID"),
+      name: z
+        .string()
+        .describe("Display name for the action"),
+      actionType: z
+        .string()
+        .describe("Action type identifier (e.g., 'VisitAndExtract', 'MessageToPerson')"),
+      description: z
+        .string()
+        .optional()
+        .describe("Optional action description"),
+      coolDown: z
+        .number()
+        .int()
+        .optional()
+        .describe("Milliseconds between action executions (default: 60000)"),
+      maxActionResultsPerIteration: z
+        .number()
+        .int()
+        .optional()
+        .describe("Maximum results per iteration (default: 10, -1 for unlimited)"),
+      actionSettings: z
+        .string()
+        .optional()
+        .describe("Action-specific settings as a JSON string"),
+      cdpPort: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .default(9222)
+        .describe("CDP port (default: 9222)"),
+    },
+    async ({
+      campaignId,
+      name,
+      actionType,
+      description,
+      coolDown,
+      maxActionResultsPerIteration,
+      actionSettings,
+      cdpPort,
+    }) => {
+      // Parse action settings JSON if provided
+      let parsedSettings: Record<string, unknown> = {};
+      if (actionSettings !== undefined) {
+        try {
+          parsedSettings = JSON.parse(actionSettings) as Record<string, unknown>;
+        } catch {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: "Invalid JSON in actionSettings.",
+              },
+            ],
+          };
+        }
+      }
+
+      // Connect to launcher to find account
+      const launcher = new LauncherService(cdpPort);
+
+      try {
+        await launcher.connect();
+      } catch (error) {
+        if (error instanceof LinkedHelperNotRunningError) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: "LinkedHelper is not running. Use launch-app first.",
+              },
+            ],
+          };
+        }
+        const message = errorMessage(error);
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: `Failed to connect to LinkedHelper: ${message}`,
+            },
+          ],
+        };
+      }
+
+      let accountId: number;
+      try {
+        const accounts = await launcher.listAccounts();
+        if (accounts.length === 0) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: "No accounts found.",
+              },
+            ],
+          };
+        }
+        if (accounts.length > 1) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: "Multiple accounts found. Cannot determine which instance to use.",
+              },
+            ],
+          };
+        }
+        accountId = (accounts[0] as Account).id;
+      } catch (error) {
+        const message = errorMessage(error);
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: `Failed to list accounts: ${message}`,
+            },
+          ],
+        };
+      } finally {
+        launcher.disconnect();
+      }
+
+      // Discover and open database (writable for add)
+      let db: DatabaseClient | null = null;
+
+      try {
+        const dbPath = discoverDatabase(accountId);
+        db = new DatabaseClient(dbPath, { readOnly: false });
+
+        const campaignRepo = new CampaignRepository(db);
+        const campaign = campaignRepo.getCampaign(campaignId);
+
+        const actionConfig: import("@lhremote/core").CampaignActionConfig = {
+          name,
+          actionType,
+          actionSettings: parsedSettings,
+        };
+        if (description !== undefined) {
+          actionConfig.description = description;
+        }
+        if (coolDown !== undefined) {
+          actionConfig.coolDown = coolDown;
+        }
+        if (maxActionResultsPerIteration !== undefined) {
+          actionConfig.maxActionResultsPerIteration =
+            maxActionResultsPerIteration;
+        }
+
+        const action = campaignRepo.addAction(
+          campaignId,
+          actionConfig,
+          campaign.liAccountId,
+        );
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(action, null, 2),
+            },
+          ],
+        };
+      } catch (error) {
+        if (error instanceof CampaignNotFoundError) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: `Campaign ${String(campaignId)} not found.`,
+              },
+            ],
+          };
+        }
+        const message = errorMessage(error);
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: `Failed to add action to campaign: ${message}`,
+            },
+          ],
+        };
+      } finally {
+        db?.close();
+      }
+    },
+  );
+}

--- a/packages/mcp/src/tools/campaign-remove-action.test.ts
+++ b/packages/mcp/src/tools/campaign-remove-action.test.ts
@@ -1,0 +1,339 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return {
+    ...actual,
+    LauncherService: vi.fn(),
+    InstanceService: vi.fn(),
+    DatabaseClient: vi.fn(),
+    CampaignService: vi.fn(),
+    discoverInstancePort: vi.fn(),
+    discoverDatabase: vi.fn(),
+  };
+});
+
+import {
+  type Account,
+  ActionNotFoundError,
+  CampaignExecutionError,
+  CampaignNotFoundError,
+  CampaignService,
+  DatabaseClient,
+  discoverDatabase,
+  discoverInstancePort,
+  InstanceService,
+  LauncherService,
+  LinkedHelperNotRunningError,
+} from "@lhremote/core";
+
+import { registerCampaignRemoveAction } from "./campaign-remove-action.js";
+import { createMockServer } from "./testing/mock-server.js";
+
+function mockLauncher(overrides: Record<string, unknown> = {}) {
+  const disconnect = vi.fn();
+  vi.mocked(LauncherService).mockImplementation(function () {
+    return {
+      connect: vi.fn().mockResolvedValue(undefined),
+      disconnect,
+      listAccounts: vi
+        .fn()
+        .mockResolvedValue([{ id: 1, liId: 1, name: "Alice" } as Account]),
+      ...overrides,
+    } as unknown as LauncherService;
+  });
+  return { disconnect };
+}
+
+function mockInstance(overrides: Record<string, unknown> = {}) {
+  const disconnect = vi.fn();
+  vi.mocked(InstanceService).mockImplementation(function () {
+    return {
+      connect: vi.fn().mockResolvedValue(undefined),
+      disconnect,
+      ...overrides,
+    } as unknown as InstanceService;
+  });
+  return { disconnect };
+}
+
+function mockDb() {
+  const close = vi.fn();
+  vi.mocked(DatabaseClient).mockImplementation(function () {
+    return { close, db: {} } as unknown as DatabaseClient;
+  });
+  return { close };
+}
+
+function mockCampaignService(overrides: Record<string, unknown> = {}) {
+  vi.mocked(CampaignService).mockImplementation(function () {
+    return {
+      removeAction: vi.fn().mockResolvedValue(undefined),
+      ...overrides,
+    } as unknown as CampaignService;
+  });
+}
+
+function setupSuccessPath() {
+  mockLauncher();
+  mockInstance();
+  mockDb();
+  mockCampaignService();
+  vi.mocked(discoverInstancePort).mockResolvedValue(55123);
+  vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+}
+
+describe("registerCampaignRemoveAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("registers a tool named campaign-remove-action", () => {
+    const { server } = createMockServer();
+    registerCampaignRemoveAction(server);
+
+    expect(server.tool).toHaveBeenCalledOnce();
+    expect(server.tool).toHaveBeenCalledWith(
+      "campaign-remove-action",
+      expect.any(String),
+      expect.any(Object),
+      expect.any(Function),
+    );
+  });
+
+  it("successfully removes action", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignRemoveAction(server);
+    setupSuccessPath();
+
+    const handler = getHandler("campaign-remove-action");
+    const result = await handler({
+      campaignId: 15,
+      actionId: 50,
+      cdpPort: 9222,
+    });
+
+    expect(result).toEqual({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(
+            { success: true, campaignId: 15, removedActionId: 50 },
+            null,
+            2,
+          ),
+        },
+      ],
+    });
+  });
+
+  it("returns error for non-existent campaign", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignRemoveAction(server);
+
+    mockLauncher();
+    mockInstance();
+    mockDb();
+    vi.mocked(discoverInstancePort).mockResolvedValue(55123);
+    vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+    vi.mocked(CampaignService).mockImplementation(function () {
+      return {
+        removeAction: vi
+          .fn()
+          .mockRejectedValue(new CampaignNotFoundError(999)),
+      } as unknown as CampaignService;
+    });
+
+    const handler = getHandler("campaign-remove-action");
+    const result = await handler({
+      campaignId: 999,
+      actionId: 50,
+      cdpPort: 9222,
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "Campaign 999 not found.",
+        },
+      ],
+    });
+  });
+
+  it("returns error for non-existent action", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignRemoveAction(server);
+
+    mockLauncher();
+    mockInstance();
+    mockDb();
+    vi.mocked(discoverInstancePort).mockResolvedValue(55123);
+    vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+    vi.mocked(CampaignService).mockImplementation(function () {
+      return {
+        removeAction: vi
+          .fn()
+          .mockRejectedValue(new ActionNotFoundError(999, 15)),
+      } as unknown as CampaignService;
+    });
+
+    const handler = getHandler("campaign-remove-action");
+    const result = await handler({
+      campaignId: 15,
+      actionId: 999,
+      cdpPort: 9222,
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "Action 999 not found in campaign 15.",
+        },
+      ],
+    });
+  });
+
+  it("returns error when LinkedHelper is not running", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignRemoveAction(server);
+
+    vi.mocked(LauncherService).mockImplementation(function () {
+      return {
+        connect: vi
+          .fn()
+          .mockRejectedValue(new LinkedHelperNotRunningError(9222)),
+        disconnect: vi.fn(),
+      } as unknown as LauncherService;
+    });
+
+    const handler = getHandler("campaign-remove-action");
+    const result = await handler({
+      campaignId: 15,
+      actionId: 50,
+      cdpPort: 9222,
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "LinkedHelper is not running. Use launch-app first.",
+        },
+      ],
+    });
+  });
+
+  it("returns error when instance is not running", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignRemoveAction(server);
+
+    mockLauncher();
+    vi.mocked(discoverInstancePort).mockResolvedValue(null);
+
+    const handler = getHandler("campaign-remove-action");
+    const result = await handler({
+      campaignId: 15,
+      actionId: 50,
+      cdpPort: 9222,
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "No LinkedHelper instance is running. Use start-instance first.",
+        },
+      ],
+    });
+  });
+
+  it("returns error when CDP call fails", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignRemoveAction(server);
+
+    mockLauncher();
+    mockInstance();
+    mockDb();
+    vi.mocked(discoverInstancePort).mockResolvedValue(55123);
+    vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+    vi.mocked(CampaignService).mockImplementation(function () {
+      return {
+        removeAction: vi
+          .fn()
+          .mockRejectedValue(
+            new CampaignExecutionError(
+              "Failed to remove action 50 from campaign 15: UI error",
+              15,
+            ),
+          ),
+      } as unknown as CampaignService;
+    });
+
+    const handler = getHandler("campaign-remove-action");
+    const result = await handler({
+      campaignId: 15,
+      actionId: 50,
+      cdpPort: 9222,
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "Failed to remove action: Failed to remove action 50 from campaign 15: UI error",
+        },
+      ],
+    });
+  });
+
+  it("disconnects instance and closes db after success", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignRemoveAction(server);
+
+    mockLauncher();
+    const { disconnect: instanceDisconnect } = mockInstance();
+    const { close: dbClose } = mockDb();
+    mockCampaignService();
+    vi.mocked(discoverInstancePort).mockResolvedValue(55123);
+    vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+
+    const handler = getHandler("campaign-remove-action");
+    await handler({ campaignId: 15, actionId: 50, cdpPort: 9222 });
+
+    expect(instanceDisconnect).toHaveBeenCalledOnce();
+    expect(dbClose).toHaveBeenCalledOnce();
+  });
+
+  it("disconnects instance and closes db after error", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignRemoveAction(server);
+
+    mockLauncher();
+    const { disconnect: instanceDisconnect } = mockInstance();
+    const { close: dbClose } = mockDb();
+    vi.mocked(discoverInstancePort).mockResolvedValue(55123);
+    vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+    vi.mocked(CampaignService).mockImplementation(function () {
+      return {
+        removeAction: vi.fn().mockRejectedValue(new Error("test error")),
+      } as unknown as CampaignService;
+    });
+
+    const handler = getHandler("campaign-remove-action");
+    await handler({ campaignId: 15, actionId: 50, cdpPort: 9222 });
+
+    expect(instanceDisconnect).toHaveBeenCalledOnce();
+    expect(dbClose).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/mcp/src/tools/campaign-remove-action.ts
+++ b/packages/mcp/src/tools/campaign-remove-action.ts
@@ -1,0 +1,217 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  type Account,
+  ActionNotFoundError,
+  CampaignExecutionError,
+  CampaignNotFoundError,
+  CampaignService,
+  DatabaseClient,
+  discoverDatabase,
+  discoverInstancePort,
+  errorMessage,
+  InstanceNotRunningError,
+  InstanceService,
+  LauncherService,
+  LinkedHelperNotRunningError,
+} from "@lhremote/core";
+import { z } from "zod";
+
+export function registerCampaignRemoveAction(server: McpServer): void {
+  server.tool(
+    "campaign-remove-action",
+    "Remove an action from a campaign's action chain",
+    {
+      campaignId: z
+        .number()
+        .int()
+        .positive()
+        .describe("Campaign ID"),
+      actionId: z
+        .number()
+        .int()
+        .positive()
+        .describe("Action ID to remove"),
+      cdpPort: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .default(9222)
+        .describe("CDP port (default: 9222)"),
+    },
+    async ({ campaignId, actionId, cdpPort }) => {
+      // Connect to launcher to find running instance
+      const launcher = new LauncherService(cdpPort);
+
+      try {
+        await launcher.connect();
+      } catch (error) {
+        if (error instanceof LinkedHelperNotRunningError) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: "LinkedHelper is not running. Use launch-app first.",
+              },
+            ],
+          };
+        }
+        const message = errorMessage(error);
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: `Failed to connect to LinkedHelper: ${message}`,
+            },
+          ],
+        };
+      }
+
+      let accountId: number;
+      try {
+        const accounts = await launcher.listAccounts();
+        if (accounts.length === 0) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: "No accounts found.",
+              },
+            ],
+          };
+        }
+        if (accounts.length > 1) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: "Multiple accounts found. Cannot determine which instance to use.",
+              },
+            ],
+          };
+        }
+        accountId = (accounts[0] as Account).id;
+      } catch (error) {
+        const message = errorMessage(error);
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: `Failed to list accounts: ${message}`,
+            },
+          ],
+        };
+      } finally {
+        launcher.disconnect();
+      }
+
+      // Discover instance CDP port
+      const instancePort = await discoverInstancePort(cdpPort);
+      if (instancePort === null) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: "No LinkedHelper instance is running. Use start-instance first.",
+            },
+          ],
+        };
+      }
+
+      // Connect to instance and remove action
+      const instance = new InstanceService(instancePort);
+      let db: DatabaseClient | null = null;
+
+      try {
+        await instance.connect();
+
+        const dbPath = discoverDatabase(accountId);
+        db = new DatabaseClient(dbPath);
+
+        const campaignService = new CampaignService(instance, db);
+        await campaignService.removeAction(campaignId, actionId);
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                {
+                  success: true,
+                  campaignId,
+                  removedActionId: actionId,
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      } catch (error) {
+        if (error instanceof InstanceNotRunningError) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: "No LinkedHelper instance is running. Use start-instance first.",
+              },
+            ],
+          };
+        }
+        if (error instanceof CampaignNotFoundError) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: `Campaign ${String(campaignId)} not found.`,
+              },
+            ],
+          };
+        }
+        if (error instanceof ActionNotFoundError) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: `Action ${String(actionId)} not found in campaign ${String(campaignId)}.`,
+              },
+            ],
+          };
+        }
+        if (error instanceof CampaignExecutionError) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: `Failed to remove action: ${error.message}`,
+              },
+            ],
+          };
+        }
+        const message = errorMessage(error);
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: `Failed to remove action: ${message}`,
+            },
+          ],
+        };
+      } finally {
+        instance.disconnect();
+        db?.close();
+      }
+    },
+  );
+}

--- a/packages/mcp/src/tools/campaign-reorder-actions.test.ts
+++ b/packages/mcp/src/tools/campaign-reorder-actions.test.ts
@@ -1,0 +1,339 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return {
+    ...actual,
+    LauncherService: vi.fn(),
+    InstanceService: vi.fn(),
+    DatabaseClient: vi.fn(),
+    CampaignService: vi.fn(),
+    discoverInstancePort: vi.fn(),
+    discoverDatabase: vi.fn(),
+  };
+});
+
+import {
+  type Account,
+  type CampaignAction,
+  ActionNotFoundError,
+  CampaignNotFoundError,
+  CampaignService,
+  DatabaseClient,
+  discoverDatabase,
+  discoverInstancePort,
+  InstanceService,
+  LauncherService,
+  LinkedHelperNotRunningError,
+} from "@lhremote/core";
+
+import { registerCampaignReorderActions } from "./campaign-reorder-actions.js";
+import { createMockServer } from "./testing/mock-server.js";
+
+const MOCK_ACTIONS: CampaignAction[] = [
+  {
+    id: 50,
+    campaignId: 15,
+    name: "Visit & Extract",
+    description: null,
+    config: {
+      id: 500,
+      actionType: "VisitAndExtract",
+      actionSettings: {},
+      coolDown: 60000,
+      maxActionResultsPerIteration: 10,
+      isDraft: false,
+    },
+    versionId: 5000,
+  },
+  {
+    id: 51,
+    campaignId: 15,
+    name: "Send Message",
+    description: null,
+    config: {
+      id: 501,
+      actionType: "MessageToPerson",
+      actionSettings: {},
+      coolDown: 60000,
+      maxActionResultsPerIteration: 10,
+      isDraft: false,
+    },
+    versionId: 5001,
+  },
+];
+
+function mockLauncher(overrides: Record<string, unknown> = {}) {
+  const disconnect = vi.fn();
+  vi.mocked(LauncherService).mockImplementation(function () {
+    return {
+      connect: vi.fn().mockResolvedValue(undefined),
+      disconnect,
+      listAccounts: vi
+        .fn()
+        .mockResolvedValue([{ id: 1, liId: 1, name: "Alice" } as Account]),
+      ...overrides,
+    } as unknown as LauncherService;
+  });
+  return { disconnect };
+}
+
+function mockInstance(overrides: Record<string, unknown> = {}) {
+  const disconnect = vi.fn();
+  vi.mocked(InstanceService).mockImplementation(function () {
+    return {
+      connect: vi.fn().mockResolvedValue(undefined),
+      disconnect,
+      ...overrides,
+    } as unknown as InstanceService;
+  });
+  return { disconnect };
+}
+
+function mockDb() {
+  const close = vi.fn();
+  vi.mocked(DatabaseClient).mockImplementation(function () {
+    return { close, db: {} } as unknown as DatabaseClient;
+  });
+  return { close };
+}
+
+function mockCampaignService(
+  actions: CampaignAction[] = MOCK_ACTIONS,
+  overrides: Record<string, unknown> = {},
+) {
+  vi.mocked(CampaignService).mockImplementation(function () {
+    return {
+      reorderActions: vi.fn().mockResolvedValue(actions),
+      ...overrides,
+    } as unknown as CampaignService;
+  });
+}
+
+function setupSuccessPath() {
+  mockLauncher();
+  mockInstance();
+  mockDb();
+  mockCampaignService();
+  vi.mocked(discoverInstancePort).mockResolvedValue(55123);
+  vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+}
+
+describe("registerCampaignReorderActions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("registers a tool named campaign-reorder-actions", () => {
+    const { server } = createMockServer();
+    registerCampaignReorderActions(server);
+
+    expect(server.tool).toHaveBeenCalledOnce();
+    expect(server.tool).toHaveBeenCalledWith(
+      "campaign-reorder-actions",
+      expect.any(String),
+      expect.any(Object),
+      expect.any(Function),
+    );
+  });
+
+  it("successfully reorders actions", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignReorderActions(server);
+    setupSuccessPath();
+
+    const handler = getHandler("campaign-reorder-actions");
+    const result = await handler({
+      campaignId: 15,
+      actionIds: [51, 50],
+      cdpPort: 9222,
+    });
+
+    expect(result).toEqual({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(
+            {
+              success: true,
+              campaignId: 15,
+              actions: MOCK_ACTIONS,
+            },
+            null,
+            2,
+          ),
+        },
+      ],
+    });
+  });
+
+  it("returns error for non-existent campaign", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignReorderActions(server);
+
+    mockLauncher();
+    mockInstance();
+    mockDb();
+    vi.mocked(discoverInstancePort).mockResolvedValue(55123);
+    vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+    vi.mocked(CampaignService).mockImplementation(function () {
+      return {
+        reorderActions: vi
+          .fn()
+          .mockRejectedValue(new CampaignNotFoundError(999)),
+      } as unknown as CampaignService;
+    });
+
+    const handler = getHandler("campaign-reorder-actions");
+    const result = await handler({
+      campaignId: 999,
+      actionIds: [50, 51],
+      cdpPort: 9222,
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "Campaign 999 not found.",
+        },
+      ],
+    });
+  });
+
+  it("returns error for invalid action IDs", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignReorderActions(server);
+
+    mockLauncher();
+    mockInstance();
+    mockDb();
+    vi.mocked(discoverInstancePort).mockResolvedValue(55123);
+    vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+    vi.mocked(CampaignService).mockImplementation(function () {
+      return {
+        reorderActions: vi
+          .fn()
+          .mockRejectedValue(new ActionNotFoundError(999, 15)),
+      } as unknown as CampaignService;
+    });
+
+    const handler = getHandler("campaign-reorder-actions");
+    const result = await handler({
+      campaignId: 15,
+      actionIds: [999, 50],
+      cdpPort: 9222,
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "One or more action IDs not found in campaign 15.",
+        },
+      ],
+    });
+  });
+
+  it("returns error when LinkedHelper is not running", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignReorderActions(server);
+
+    vi.mocked(LauncherService).mockImplementation(function () {
+      return {
+        connect: vi
+          .fn()
+          .mockRejectedValue(new LinkedHelperNotRunningError(9222)),
+        disconnect: vi.fn(),
+      } as unknown as LauncherService;
+    });
+
+    const handler = getHandler("campaign-reorder-actions");
+    const result = await handler({
+      campaignId: 15,
+      actionIds: [50, 51],
+      cdpPort: 9222,
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "LinkedHelper is not running. Use launch-app first.",
+        },
+      ],
+    });
+  });
+
+  it("returns error when instance is not running", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignReorderActions(server);
+
+    mockLauncher();
+    vi.mocked(discoverInstancePort).mockResolvedValue(null);
+
+    const handler = getHandler("campaign-reorder-actions");
+    const result = await handler({
+      campaignId: 15,
+      actionIds: [50, 51],
+      cdpPort: 9222,
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "No LinkedHelper instance is running. Use start-instance first.",
+        },
+      ],
+    });
+  });
+
+  it("disconnects instance and closes db after success", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignReorderActions(server);
+
+    mockLauncher();
+    const { disconnect: instanceDisconnect } = mockInstance();
+    const { close: dbClose } = mockDb();
+    mockCampaignService();
+    vi.mocked(discoverInstancePort).mockResolvedValue(55123);
+    vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+
+    const handler = getHandler("campaign-reorder-actions");
+    await handler({ campaignId: 15, actionIds: [51, 50], cdpPort: 9222 });
+
+    expect(instanceDisconnect).toHaveBeenCalledOnce();
+    expect(dbClose).toHaveBeenCalledOnce();
+  });
+
+  it("disconnects instance and closes db after error", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignReorderActions(server);
+
+    mockLauncher();
+    const { disconnect: instanceDisconnect } = mockInstance();
+    const { close: dbClose } = mockDb();
+    vi.mocked(discoverInstancePort).mockResolvedValue(55123);
+    vi.mocked(discoverDatabase).mockReturnValue("/path/to/db");
+    vi.mocked(CampaignService).mockImplementation(function () {
+      return {
+        reorderActions: vi.fn().mockRejectedValue(new Error("test error")),
+      } as unknown as CampaignService;
+    });
+
+    const handler = getHandler("campaign-reorder-actions");
+    await handler({ campaignId: 15, actionIds: [51, 50], cdpPort: 9222 });
+
+    expect(instanceDisconnect).toHaveBeenCalledOnce();
+    expect(dbClose).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/mcp/src/tools/campaign-reorder-actions.ts
+++ b/packages/mcp/src/tools/campaign-reorder-actions.ts
@@ -1,0 +1,219 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  type Account,
+  ActionNotFoundError,
+  CampaignExecutionError,
+  CampaignNotFoundError,
+  CampaignService,
+  DatabaseClient,
+  discoverDatabase,
+  discoverInstancePort,
+  errorMessage,
+  InstanceNotRunningError,
+  InstanceService,
+  LauncherService,
+  LinkedHelperNotRunningError,
+} from "@lhremote/core";
+import { z } from "zod";
+
+export function registerCampaignReorderActions(server: McpServer): void {
+  server.tool(
+    "campaign-reorder-actions",
+    "Reorder actions in a campaign's action chain",
+    {
+      campaignId: z
+        .number()
+        .int()
+        .positive()
+        .describe("Campaign ID"),
+      actionIds: z
+        .array(z.number().int().positive())
+        .nonempty()
+        .describe("Action IDs in the desired order"),
+      cdpPort: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .default(9222)
+        .describe("CDP port (default: 9222)"),
+    },
+    async ({ campaignId, actionIds, cdpPort }) => {
+      // Connect to launcher to find running instance
+      const launcher = new LauncherService(cdpPort);
+
+      try {
+        await launcher.connect();
+      } catch (error) {
+        if (error instanceof LinkedHelperNotRunningError) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: "LinkedHelper is not running. Use launch-app first.",
+              },
+            ],
+          };
+        }
+        const message = errorMessage(error);
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: `Failed to connect to LinkedHelper: ${message}`,
+            },
+          ],
+        };
+      }
+
+      let accountId: number;
+      try {
+        const accounts = await launcher.listAccounts();
+        if (accounts.length === 0) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: "No accounts found.",
+              },
+            ],
+          };
+        }
+        if (accounts.length > 1) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: "Multiple accounts found. Cannot determine which instance to use.",
+              },
+            ],
+          };
+        }
+        accountId = (accounts[0] as Account).id;
+      } catch (error) {
+        const message = errorMessage(error);
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: `Failed to list accounts: ${message}`,
+            },
+          ],
+        };
+      } finally {
+        launcher.disconnect();
+      }
+
+      // Discover instance CDP port
+      const instancePort = await discoverInstancePort(cdpPort);
+      if (instancePort === null) {
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: "No LinkedHelper instance is running. Use start-instance first.",
+            },
+          ],
+        };
+      }
+
+      // Connect to instance and reorder actions
+      const instance = new InstanceService(instancePort);
+      let db: DatabaseClient | null = null;
+
+      try {
+        await instance.connect();
+
+        const dbPath = discoverDatabase(accountId);
+        db = new DatabaseClient(dbPath);
+
+        const campaignService = new CampaignService(instance, db);
+        const updatedActions = await campaignService.reorderActions(
+          campaignId,
+          actionIds,
+        );
+
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify(
+                {
+                  success: true,
+                  campaignId,
+                  actions: updatedActions,
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      } catch (error) {
+        if (error instanceof InstanceNotRunningError) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: "No LinkedHelper instance is running. Use start-instance first.",
+              },
+            ],
+          };
+        }
+        if (error instanceof CampaignNotFoundError) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: `Campaign ${String(campaignId)} not found.`,
+              },
+            ],
+          };
+        }
+        if (error instanceof ActionNotFoundError) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: `One or more action IDs not found in campaign ${String(campaignId)}.`,
+              },
+            ],
+          };
+        }
+        if (error instanceof CampaignExecutionError) {
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text" as const,
+                text: `Failed to reorder actions: ${error.message}`,
+              },
+            ],
+          };
+        }
+        const message = errorMessage(error);
+        return {
+          isError: true,
+          content: [
+            {
+              type: "text" as const,
+              text: `Failed to reorder actions: ${message}`,
+            },
+          ],
+        };
+      } finally {
+        instance.disconnect();
+        db?.close();
+      }
+    },
+  );
+}

--- a/packages/mcp/src/tools/index.ts
+++ b/packages/mcp/src/tools/index.ts
@@ -1,11 +1,14 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
+import { registerCampaignAddAction } from "./campaign-add-action.js";
 import { registerCampaignCreate } from "./campaign-create.js";
 import { registerCampaignDelete } from "./campaign-delete.js";
 import { registerCampaignExport } from "./campaign-export.js";
 import { registerCampaignGet } from "./campaign-get.js";
 import { registerCampaignList } from "./campaign-list.js";
 import { registerCampaignMoveNext } from "./campaign-move-next.js";
+import { registerCampaignRemoveAction } from "./campaign-remove-action.js";
+import { registerCampaignReorderActions } from "./campaign-reorder-actions.js";
 import { registerCampaignRetry } from "./campaign-retry.js";
 import { registerImportPeopleFromUrls } from "./import-people-from-urls.js";
 import { registerCampaignStart } from "./campaign-start.js";
@@ -26,12 +29,15 @@ import { registerQueryProfile } from "./query-profile.js";
 import { registerQueryProfiles } from "./query-profiles.js";
 import { registerScrapeMessagingHistory } from "./scrape-messaging-history.js";
 export function registerAllTools(server: McpServer): void {
+  registerCampaignAddAction(server);
   registerCampaignCreate(server);
   registerCampaignDelete(server);
   registerCampaignExport(server);
   registerCampaignGet(server);
   registerCampaignList(server);
   registerCampaignMoveNext(server);
+  registerCampaignRemoveAction(server);
+  registerCampaignReorderActions(server);
   registerCampaignRetry(server);
   registerCampaignStart(server);
   registerCampaignStatus(server);


### PR DESCRIPTION
## Summary
- Add `campaign-add-action` tool (DB-only): creates action configs, actions, action versions, and exclude list chains in a transaction via `CampaignRepository.addAction()`
- Add `campaign-remove-action` tool (CDP-based): removes an action from a campaign chain via `removeActionFromCampaignChain` IPC API
- Add `campaign-reorder-actions` tool (CDP-based): reorders actions in a campaign chain via `moveActionInCampaignChain` IPC API
- All three implemented as MCP tools and CLI commands with full test coverage

## Test plan
- [x] Unit tests for all 3 MCP tools (campaign-add-action: 8, campaign-remove-action: 9, campaign-reorder-actions: 8)
- [x] Unit tests for CampaignService.removeAction (4 tests) and CampaignService.reorderActions (6 tests)
- [x] Server tool count test updated (25 → 28)
- [x] CLI program subcommand count test updated (25 → 28)
- [x] All tests pass: Core 437, MCP 253, CLI 100
- [x] Lint passes across all packages

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)