### PR TITLE
(feat) core: advance CheckForReplies config schema

### DIFF
--- a/packages/cli/src/handlers/describe-actions.test.ts
+++ b/packages/cli/src/handlers/describe-actions.test.ts
@@ -123,7 +123,7 @@ describe("handleDescribeActions", () => {
   });
 
   it("does not show example when not available", () => {
-    handleDescribeActions({ type: "CheckForReplies" });
+    handleDescribeActions({ type: "ScrapeMessagingHistory" });
 
     const output = getStdout();
     expect(output).not.toContain("Example:");

--- a/packages/core/src/data/action-types.test.ts
+++ b/packages/core/src/data/action-types.test.ts
@@ -201,11 +201,24 @@ describe("getActionTypeInfo", () => {
     expect(info.example).toEqual({ extractProfile: true });
   });
 
-  it("returns no example when not available", () => {
+  it("returns correct fields for CheckForReplies", () => {
     const info = getActionTypeInfo("CheckForReplies");
     expect(info).toBeDefined();
     if (info === undefined) throw new Error("Expected info");
-    expect(info.example).toBeUndefined();
+    expect(info.category).toBe("messaging");
+    expect(info.configSchema).toHaveProperty("moveToSuccessfulAfterMs");
+    const moveField = info.configSchema["moveToSuccessfulAfterMs"];
+    expect(moveField).toBeDefined();
+    if (moveField === undefined) throw new Error("Expected field");
+    expect(moveField.type).toBe("number");
+    expect(moveField.required).toBe(true);
+    expect(info.configSchema).toHaveProperty("treatMessageAcceptedAsReply");
+    expect(info.configSchema).toHaveProperty("keepInQueueIfRequestIsNotAccepted");
+    expect(info.example).toEqual({
+      moveToSuccessfulAfterMs: 86400000,
+      treatMessageAcceptedAsReply: false,
+      keepInQueueIfRequestIsNotAccepted: true,
+    });
   });
 
   it("returns frozen objects", () => {

--- a/packages/core/src/data/action-types.ts
+++ b/packages/core/src/data/action-types.ts
@@ -220,7 +220,30 @@ const ACTION_TYPE_INFOS: ActionTypeInfo[] = [
     name: "CheckForReplies",
     description: "Check for new message replies from contacts in the campaign.",
     category: "messaging",
-    configSchema: {},
+    configSchema: {
+      moveToSuccessfulAfterMs: {
+        type: "number",
+        required: true,
+        description:
+          "Auto-mark as successful after N milliseconds without a reply (null = never).",
+      },
+      treatMessageAcceptedAsReply: {
+        type: "boolean",
+        required: false,
+        description: "Count message acceptance as a reply.",
+      },
+      keepInQueueIfRequestIsNotAccepted: {
+        type: "boolean",
+        required: false,
+        description:
+          "Keep checking if the connection request has not yet been accepted.",
+      },
+    },
+    example: {
+      moveToSuccessfulAfterMs: 86400000,
+      treatMessageAcceptedAsReply: false,
+      keepInQueueIfRequestIsNotAccepted: true,
+    },
   },
   {
     name: "ScrapeMessagingHistory",


### PR DESCRIPTION
## Summary
- Populate `CheckForReplies` configSchema with 3 documented fields: `moveToSuccessfulAfterMs` (required number), `treatMessageAcceptedAsReply` (optional boolean), `keepInQueueIfRequestIsNotAccepted` (optional boolean)
- Add typical example config matching observed database values (24h timeout, no message-accepted-as-reply, keep in queue)
- Update core and CLI tests to cover new schema fields

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)