### PR TITLE
(feat) core: advance DataEnrichment config schema

### DIFF
--- a/packages/core/src/data/action-types.test.ts
+++ b/packages/core/src/data/action-types.test.ts
@@ -221,6 +221,41 @@ describe("getActionTypeInfo", () => {
     });
   });
 
+  it("returns correct fields for DataEnrichment", () => {
+    const info = getActionTypeInfo("DataEnrichment");
+    expect(info).toBeDefined();
+    if (info === undefined) throw new Error("Expected info");
+    expect(info.category).toBe("crm");
+    expect(info.configSchema).toHaveProperty("profileInfo");
+    expect(info.configSchema).toHaveProperty("phones");
+    expect(info.configSchema).toHaveProperty("emails");
+    expect(info.configSchema).toHaveProperty("socials");
+    expect(info.configSchema).toHaveProperty("companies");
+    expect(info.configSchema).toHaveProperty("actualDate");
+    const profileInfoField = info.configSchema["profileInfo"];
+    expect(profileInfoField).toBeDefined();
+    if (profileInfoField === undefined) throw new Error("Expected field");
+    expect(profileInfoField.type).toBe("object");
+    expect(profileInfoField.required).toBe(true);
+    const emailsField = info.configSchema["emails"];
+    expect(emailsField).toBeDefined();
+    if (emailsField === undefined) throw new Error("Expected field");
+    expect(emailsField.type).toBe("object");
+    expect(emailsField.required).toBe(true);
+    const actualDateField = info.configSchema["actualDate"];
+    expect(actualDateField).toBeDefined();
+    if (actualDateField === undefined) throw new Error("Expected field");
+    expect(actualDateField.type).toBe("number");
+    expect(actualDateField.required).toBe(false);
+    expect(info.example).toEqual({
+      profileInfo: { shouldEnrich: false },
+      phones: { shouldEnrich: false },
+      emails: { shouldEnrich: false, types: ["personal", "business"] },
+      socials: { shouldEnrich: false },
+      companies: { shouldEnrich: true },
+    });
+  });
+
   it("returns correct fields for FilterContactsOutOfMyNetwork", () => {
     const info = getActionTypeInfo("FilterContactsOutOfMyNetwork");
     expect(info).toBeDefined();

--- a/packages/core/src/data/action-types.ts
+++ b/packages/core/src/data/action-types.ts
@@ -270,7 +270,51 @@ const ACTION_TYPE_INFOS: ActionTypeInfo[] = [
     description:
       "Enrich profile data by extracting additional information from LinkedIn.",
     category: "crm",
-    configSchema: {},
+    configSchema: {
+      profileInfo: {
+        type: "object",
+        required: true,
+        description:
+          "Enrich profile info ({shouldEnrich: boolean, actualDate?: number}).",
+      },
+      phones: {
+        type: "object",
+        required: true,
+        description:
+          "Enrich phone numbers ({shouldEnrich: boolean, actualDate?: number}).",
+      },
+      emails: {
+        type: "object",
+        required: true,
+        description:
+          'Enrich email addresses ({shouldEnrich: boolean, actualDate?: number, types: ["personal","business"]}).',
+      },
+      socials: {
+        type: "object",
+        required: true,
+        description:
+          "Enrich social profiles ({shouldEnrich: boolean, actualDate?: number}).",
+      },
+      companies: {
+        type: "object",
+        required: true,
+        description:
+          "Enrich company data ({shouldEnrich: boolean, actualDate?: number}).",
+      },
+      actualDate: {
+        type: "number",
+        required: false,
+        description:
+          "Only enrich data newer than this timestamp (min 0).",
+      },
+    },
+    example: {
+      profileInfo: { shouldEnrich: false },
+      phones: { shouldEnrich: false },
+      emails: { shouldEnrich: false, types: ["personal", "business"] },
+      socials: { shouldEnrich: false },
+      companies: { shouldEnrich: true },
+    },
   },
   {
     name: "PersonPostsLiker",


### PR DESCRIPTION
## Summary

- Populate the `DataEnrichment` `configSchema` with its six documented fields: `profileInfo`, `phones`, `emails`, `socials`, `companies` (all required objects representing enrichment state), and `actualDate` (optional number for staleness threshold)
- Add a typical `example` matching observed database configurations
- Add test coverage for the new schema fields and example

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)