### PR TITLE
(feat) core: advance InMail config schema

### DIFF
--- a/packages/core/src/data/action-types.test.ts
+++ b/packages/core/src/data/action-types.test.ts
@@ -309,6 +309,58 @@ describe("getActionTypeInfo", () => {
     });
   });
 
+  it("returns correct fields for InMail", () => {
+    const info = getActionTypeInfo("InMail");
+    expect(info).toBeDefined();
+    if (info === undefined) throw new Error("Expected info");
+    expect(info.category).toBe("messaging");
+    expect(info.configSchema).toHaveProperty("messageTemplate");
+    expect(info.configSchema).toHaveProperty("subjectTemplate");
+    expect(info.configSchema).toHaveProperty("rejectIfReplied");
+    expect(info.configSchema).toHaveProperty("rejectIfRepliedWithinCampaign");
+    expect(info.configSchema).toHaveProperty("proceedOnOutOfCredits");
+    expect(info.configSchema).toHaveProperty("textInputMethod");
+    const messageField = info.configSchema["messageTemplate"];
+    expect(messageField).toBeDefined();
+    if (messageField === undefined) throw new Error("Expected field");
+    expect(messageField.type).toBe("object");
+    expect(messageField.required).toBe(true);
+    const subjectField = info.configSchema["subjectTemplate"];
+    expect(subjectField).toBeDefined();
+    if (subjectField === undefined) throw new Error("Expected field");
+    expect(subjectField.type).toBe("object");
+    expect(subjectField.required).toBe(false);
+    const rejectField = info.configSchema["rejectIfReplied"];
+    expect(rejectField).toBeDefined();
+    if (rejectField === undefined) throw new Error("Expected field");
+    expect(rejectField.type).toBe("boolean");
+    expect(rejectField.required).toBe(false);
+    expect(rejectField.default).toBe(false);
+    expect(info.example).toEqual({
+      messageTemplate: {
+        type: "variants",
+        variants: [
+          {
+            type: "variant",
+            child: {
+              type: "group",
+              children: [
+                { type: "text", value: "Hi " },
+                { type: "var", name: "firstName" },
+                { type: "text", value: ", message body here" },
+              ],
+            },
+          },
+        ],
+      },
+      subjectTemplate: {
+        type: "group",
+        children: [{ type: "text", value: "Subject line here" }],
+      },
+      rejectIfRepliedWithinCampaign: false,
+    });
+  });
+
   it("returns correct fields for FilterContactsOutOfMyNetwork", () => {
     const info = getActionTypeInfo("FilterContactsOutOfMyNetwork");
     expect(info).toBeDefined();

--- a/packages/core/src/data/action-types.ts
+++ b/packages/core/src/data/action-types.ts
@@ -143,6 +143,23 @@ const ACTION_TYPE_INFOS: ActionTypeInfo[] = [
         description: "Skip person if they already replied.",
         default: false,
       },
+      rejectIfRepliedWithinCampaign: {
+        type: "boolean",
+        required: false,
+        description: "Skip if person replied within this campaign.",
+      },
+      proceedOnOutOfCredits: {
+        type: "boolean",
+        required: false,
+        description:
+          "Continue processing even when InMail credits are exhausted.",
+      },
+      textInputMethod: {
+        type: "string",
+        required: false,
+        description:
+          'How to input text — "insert", "type", or "random".',
+      },
     },
     example: {
       messageTemplate: {
@@ -150,10 +167,24 @@ const ACTION_TYPE_INFOS: ActionTypeInfo[] = [
         variants: [
           {
             type: "variant",
-            child: { type: "text", value: "I would like to connect." },
+            child: {
+              type: "group",
+              children: [
+                { type: "text", value: "Hi " },
+                { type: "var", name: "firstName" },
+                { type: "text", value: ", message body here" },
+              ],
+            },
           },
         ],
       },
+      subjectTemplate: {
+        type: "group",
+        children: [
+          { type: "text", value: "Subject line here" },
+        ],
+      },
+      rejectIfRepliedWithinCampaign: false,
     },
   },
   {


### PR DESCRIPTION
## Summary
- Add 3 missing fields to `InMail` configSchema from research: `rejectIfRepliedWithinCampaign`, `proceedOnOutOfCredits`, `textInputMethod`
- Update example to match typical config from research (richer message template with variable substitution, subject template, rejectIfRepliedWithinCampaign)
- Add field-level test coverage for InMail action type

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)