### PR TITLE
(feat) core: advance EndorseSkills config schema

### DIFF
--- a/packages/core/src/data/action-types.test.ts
+++ b/packages/core/src/data/action-types.test.ts
@@ -389,6 +389,35 @@ describe("getActionTypeInfo", () => {
     });
   });
 
+  it("returns correct fields for EndorseSkills", () => {
+    const info = getActionTypeInfo("EndorseSkills");
+    expect(info).toBeDefined();
+    if (info === undefined) throw new Error("Expected info");
+    expect(info.category).toBe("engagement");
+    expect(info.configSchema).toHaveProperty("skillNames");
+    expect(info.configSchema).toHaveProperty("limit");
+    expect(info.configSchema).toHaveProperty("skipIfNotEndorsable");
+    const skillNamesField = info.configSchema["skillNames"];
+    expect(skillNamesField).toBeDefined();
+    if (skillNamesField === undefined) throw new Error("Expected field");
+    expect(skillNamesField.type).toBe("array");
+    expect(skillNamesField.required).toBe(false);
+    const limitField = info.configSchema["limit"];
+    expect(limitField).toBeDefined();
+    if (limitField === undefined) throw new Error("Expected field");
+    expect(limitField.type).toBe("number");
+    expect(limitField.required).toBe(false);
+    const skipField = info.configSchema["skipIfNotEndorsable"];
+    expect(skipField).toBeDefined();
+    if (skipField === undefined) throw new Error("Expected field");
+    expect(skipField.type).toBe("boolean");
+    expect(skipField.required).toBe(true);
+    expect(info.example).toEqual({
+      limit: 3,
+      skipIfNotEndorsable: true,
+    });
+  });
+
   it("returns frozen objects", () => {
     const info = getActionTypeInfo("VisitAndExtract");
     expect(info).toBeDefined();

--- a/packages/core/src/data/action-types.ts
+++ b/packages/core/src/data/action-types.ts
@@ -276,12 +276,25 @@ const ACTION_TYPE_INFOS: ActionTypeInfo[] = [
     description: "Endorse skills listed on a LinkedIn profile.",
     category: "engagement",
     configSchema: {
-      maxSkills: {
+      skillNames: {
+        type: "array",
+        required: false,
+        description:
+          "Specific skill names to endorse (mutually exclusive with limit).",
+      },
+      limit: {
         type: "number",
         required: false,
-        description: "Maximum number of skills to endorse.",
+        description:
+          "Max number of skills to endorse (mutually exclusive with skillNames).",
+      },
+      skipIfNotEndorsable: {
+        type: "boolean",
+        required: true,
+        description: "Skip if person has no endorsable skills.",
       },
     },
+    example: { limit: 3, skipIfNotEndorsable: true },
   },
   {
     name: "CheckForReplies",


### PR DESCRIPTION
## Summary

- Rename `maxSkills` to `limit` to match actual LinkedHelper field name
- Add `skillNames` (array, optional) and `skipIfNotEndorsable` (boolean, required) fields from research
- Add example matching typical config: `{limit: 3, skipIfNotEndorsable: true}`
- Add field-level test coverage for all EndorseSkills config fields

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)