### PR TITLE
(feat) core: advance Follow config schema

### DIFF
--- a/packages/core/src/data/action-types.test.ts
+++ b/packages/core/src/data/action-types.test.ts
@@ -389,6 +389,30 @@ describe("getActionTypeInfo", () => {
     });
   });
 
+  it("returns correct fields for Follow", () => {
+    const info = getActionTypeInfo("Follow");
+    expect(info).toBeDefined();
+    if (info === undefined) throw new Error("Expected info");
+    expect(info.category).toBe("engagement");
+    expect(info.configSchema).toHaveProperty("mode");
+    expect(info.configSchema).toHaveProperty("skipIfUnfollowable");
+    const modeField = info.configSchema["mode"];
+    expect(modeField).toBeDefined();
+    if (modeField === undefined) throw new Error("Expected field");
+    expect(modeField.type).toBe("string");
+    expect(modeField.required).toBe(false);
+    expect(modeField.default).toBe("follow");
+    const skipField = info.configSchema["skipIfUnfollowable"];
+    expect(skipField).toBeDefined();
+    if (skipField === undefined) throw new Error("Expected field");
+    expect(skipField.type).toBe("boolean");
+    expect(skipField.required).toBe(true);
+    expect(info.example).toEqual({
+      mode: "follow",
+      skipIfUnfollowable: true,
+    });
+  });
+
   it("returns correct fields for EndorseSkills", () => {
     const info = getActionTypeInfo("EndorseSkills");
     expect(info).toBeDefined();

--- a/packages/core/src/data/action-types.ts
+++ b/packages/core/src/data/action-types.ts
@@ -262,14 +262,20 @@ const ACTION_TYPE_INFOS: ActionTypeInfo[] = [
     description: "Follow or unfollow a LinkedIn profile.",
     category: "engagement",
     configSchema: {
-      unfollow: {
-        type: "boolean",
+      mode: {
+        type: "string",
         required: false,
-        description: "If true, unfollow instead of follow.",
-        default: false,
+        description:
+          'Follow or unfollow the person. Must be "follow" or "unfollow" (default: follow).',
+        default: "follow",
+      },
+      skipIfUnfollowable: {
+        type: "boolean",
+        required: true,
+        description: "Skip if person can't be unfollowed.",
       },
     },
-    example: { unfollow: false },
+    example: { mode: "follow", skipIfUnfollowable: true },
   },
   {
     name: "EndorseSkills",


### PR DESCRIPTION
## Summary
- Replace `unfollow` boolean with `mode` string enum (`"follow"` | `"unfollow"`) per research findings
- Add `skipIfUnfollowable` required boolean field
- Update example to match typical config observed in DB
- Add field-level test coverage for Follow

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)