### PR TITLE
(feat) core: advance VisitAndExtract config schema

### DIFF
--- a/packages/cli/src/handlers/describe-actions.test.ts
+++ b/packages/cli/src/handlers/describe-actions.test.ts
@@ -83,7 +83,7 @@ describe("handleDescribeActions", () => {
     expect(output).toContain("VisitAndExtract");
     expect(output).toContain("[people]");
     expect(output).toContain("Configuration:");
-    expect(output).toContain("extractProfile");
+    expect(output).toContain("extractCurrentOrganizations");
   });
 
   it("shows detail for a specific action type as JSON", () => {
@@ -119,7 +119,7 @@ describe("handleDescribeActions", () => {
 
     const output = getStdout();
     expect(output).toContain("Example:");
-    expect(output).toContain("extractProfile");
+    expect(output).toContain("extractCurrentOrganizations");
   });
 
   it("does not show example when not available", () => {

--- a/packages/core/src/data/action-types.test.ts
+++ b/packages/core/src/data/action-types.test.ts
@@ -161,11 +161,12 @@ describe("getActionTypeInfo", () => {
     expect(info).toBeDefined();
     if (info === undefined) throw new Error("Expected info");
     expect(info.category).toBe("people");
-    expect(info.configSchema).toHaveProperty("extractProfile");
-    const field = info.configSchema["extractProfile"];
+    expect(info.configSchema).toHaveProperty("extractCurrentOrganizations");
+    const field = info.configSchema["extractCurrentOrganizations"];
     expect(field).toBeDefined();
     if (field === undefined) throw new Error("Expected field");
     expect(field.type).toBe("boolean");
+    expect(field.required).toBe(false);
   });
 
   it("returns correct fields for MessageToPerson", () => {
@@ -198,7 +199,7 @@ describe("getActionTypeInfo", () => {
     const info = getActionTypeInfo("VisitAndExtract");
     expect(info).toBeDefined();
     if (info === undefined) throw new Error("Expected info");
-    expect(info.example).toEqual({ extractProfile: true });
+    expect(info.example).toEqual({ extractCurrentOrganizations: true });
   });
 
   it("returns correct fields for CheckForReplies", () => {

--- a/packages/core/src/data/action-types.ts
+++ b/packages/core/src/data/action-types.ts
@@ -49,14 +49,13 @@ const ACTION_TYPE_INFOS: ActionTypeInfo[] = [
     description: "Visit a LinkedIn profile and extract data (name, positions, education, skills).",
     category: "people",
     configSchema: {
-      extractProfile: {
+      extractCurrentOrganizations: {
         type: "boolean",
         required: false,
-        description: "Whether to extract full profile data after visiting.",
-        default: true,
+        description: "Extract current company info during profile visit.",
       },
     },
-    example: { extractProfile: true },
+    example: { extractCurrentOrganizations: true },
   },
   {
     name: "MessageToPerson",

--- a/packages/core/src/db/testing/create-fixture.ts
+++ b/packages/core/src/db/testing/create-fixture.ts
@@ -606,7 +606,7 @@ db.exec(`
   VALUES (2, 'Follow-up Campaign', 'Paused follow-up', 1, 1, 0, 1, 1, '2025-01-14T10:00:00.000Z', '${NOW}');
 
   INSERT INTO action_configs (id, actionType, actionSettings, coolDown, maxActionResultsPerIteration, isDraft)
-  VALUES (2, 'VisitAndExtract', '{"extractProfile":true}', 30000, 20, 0);
+  VALUES (2, 'VisitAndExtract', '{"extractCurrentOrganizations":true}', 30000, 20, 0);
 
   INSERT INTO actions (id, campaign_id, name, description, created_at, updated_at)
   VALUES (2, 2, 'Visit Profile', 'Extract profile data', '${NOW}', '${NOW}');

--- a/packages/core/src/formats/campaign-format.test.ts
+++ b/packages/core/src/formats/campaign-format.test.ts
@@ -26,7 +26,7 @@ settings:
 actions:
   - type: VisitAndExtract
     config:
-      extractProfile: true
+      extractCurrentOrganizations: true
   - type: MessageToPerson
     config:
       messageTemplate: "Hi {firstName}"
@@ -53,7 +53,7 @@ const MOCK_ACTIONS: CampaignAction[] = [
     config: {
       id: 100,
       actionType: "VisitAndExtract",
-      actionSettings: { extractProfile: true },
+      actionSettings: { extractCurrentOrganizations: true },
       coolDown: 60000,
       maxActionResultsPerIteration: 10,
       isDraft: false,
@@ -94,7 +94,7 @@ describe("parseCampaignYaml", () => {
     expect(config.description).toBe("A test campaign");
     expect(config.actions).toHaveLength(2);
     expect(config.actions[0]?.actionType).toBe("VisitAndExtract");
-    expect(config.actions[0]?.actionSettings).toEqual({ extractProfile: true });
+    expect(config.actions[0]?.actionSettings).toEqual({ extractCurrentOrganizations: true });
     expect(config.actions[1]?.actionType).toBe("MessageToPerson");
     expect(config.actions[1]?.actionSettings).toEqual({
       messageTemplate: "Hi {firstName}",
@@ -282,7 +282,7 @@ version: "1"
 name: "Test"
 actions:
   - config:
-      extractProfile: true
+      extractCurrentOrganizations: true
 `;
     expect(() => parseCampaignYaml(yaml)).toThrow(CampaignFormatError);
     expect(() => parseCampaignYaml(yaml)).toThrow(
@@ -392,7 +392,7 @@ describe("serializeCampaignYaml", () => {
   it("includes non-empty actionSettings as config", () => {
     const yaml = serializeCampaignYaml(MOCK_CAMPAIGN, MOCK_ACTIONS);
 
-    expect(yaml).toContain("extractProfile: true");
+    expect(yaml).toContain("extractCurrentOrganizations: true");
     expect(yaml).toContain("messageTemplate:");
   });
 });
@@ -428,7 +428,7 @@ describe("round-trip", () => {
     expect(config.description).toBe("Test description");
     expect(config.actions).toHaveLength(2);
     expect(config.actions[0]?.actionType).toBe("VisitAndExtract");
-    expect(config.actions[0]?.actionSettings).toEqual({ extractProfile: true });
+    expect(config.actions[0]?.actionSettings).toEqual({ extractCurrentOrganizations: true });
     expect(config.actions[0]?.coolDown).toBe(60000);
     expect(config.actions[0]?.maxActionResultsPerIteration).toBe(10);
     expect(config.actions[1]?.actionType).toBe("MessageToPerson");
@@ -445,7 +445,7 @@ describe("round-trip", () => {
     expect(config.description).toBe("Test description");
     expect(config.actions).toHaveLength(2);
     expect(config.actions[0]?.actionType).toBe("VisitAndExtract");
-    expect(config.actions[0]?.actionSettings).toEqual({ extractProfile: true });
+    expect(config.actions[0]?.actionSettings).toEqual({ extractCurrentOrganizations: true });
     expect(config.actions[1]?.actionType).toBe("MessageToPerson");
   });
 

--- a/packages/mcp/src/tools/campaign-export.test.ts
+++ b/packages/mcp/src/tools/campaign-export.test.ts
@@ -51,7 +51,7 @@ const MOCK_ACTIONS: CampaignAction[] = [
     config: {
       id: 100,
       actionType: "VisitAndExtract",
-      actionSettings: { extractProfile: true },
+      actionSettings: { extractCurrentOrganizations: true },
       coolDown: 60000,
       maxActionResultsPerIteration: 10,
       isDraft: false,

--- a/packages/mcp/src/tools/campaign-get.test.ts
+++ b/packages/mcp/src/tools/campaign-get.test.ts
@@ -47,7 +47,7 @@ const MOCK_ACTIONS: CampaignAction[] = [
     config: {
       id: 100,
       actionType: "VisitAndExtract",
-      actionSettings: { extractProfile: true },
+      actionSettings: { extractCurrentOrganizations: true },
       coolDown: 60000,
       maxActionResultsPerIteration: 10,
       isDraft: false,

--- a/packages/mcp/src/tools/describe-actions.test.ts
+++ b/packages/mcp/src/tools/describe-actions.test.ts
@@ -111,14 +111,14 @@ describe("registerDescribeActions", () => {
       description: "Visit a LinkedIn profile and extract data.",
       category: "people",
       configSchema: {
-        extractProfile: {
+        extractCurrentOrganizations: {
           type: "boolean",
           required: false,
           description: "Whether to extract full profile data.",
           default: true,
         },
       },
-      example: { extractProfile: true },
+      example: { extractCurrentOrganizations: true },
     };
 
     mockedGetActionTypeInfo.mockReturnValue(info);


### PR DESCRIPTION
## Summary
- Rename `extractProfile` to `extractCurrentOrganizations` per research — the actual LH field name
- Update description to match actual behavior (extract current company info)
- Remove incorrect `default: true` (field has no default in LH)
- Update test fixtures and assertions across core, cli, mcp packages

Closes #131

## Test plan
- [x] All 870 tests pass across all 4 packages
- [x] Lint passes
- [x] No remaining references to `extractProfile` in codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)