### PR TITLE
(feat) core: advance MessageToPerson config schema

### DIFF
--- a/packages/core/src/data/action-types.test.ts
+++ b/packages/core/src/data/action-types.test.ts
@@ -180,6 +180,7 @@ describe("getActionTypeInfo", () => {
     if (field === undefined) throw new Error("Expected field");
     expect(field.required).toBe(true);
     expect(info.configSchema).toHaveProperty("rejectIfReplied");
+    expect(info.configSchema).toHaveProperty("textInputMethod");
   });
 
   it("returns correct fields for Waiter", () => {

--- a/packages/core/src/data/action-types.ts
+++ b/packages/core/src/data/action-types.ts
@@ -99,6 +99,12 @@ const ACTION_TYPE_INFOS: ActionTypeInfo[] = [
           "Skip person if they were messaged after a previous campaign message.",
         default: false,
       },
+      textInputMethod: {
+        type: "string",
+        required: false,
+        description:
+          'How to input text — "insert", "type", or "random".',
+      },
     },
     example: {
       messageTemplate: {


### PR DESCRIPTION
## Summary
- Add `textInputMethod` field to `MessageToPerson` configSchema per research findings
- Update test assertions to verify the new field

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)