### PR TITLE
(feat) core: advance minor action type config schemas

### DIFF
--- a/packages/cli/src/handlers/describe-actions.test.ts
+++ b/packages/cli/src/handlers/describe-actions.test.ts
@@ -123,7 +123,7 @@ describe("handleDescribeActions", () => {
   });
 
   it("does not show example when not available", () => {
-    handleDescribeActions({ type: "ScrapeMessagingHistory" });
+    handleDescribeActions({ type: "RemoveFromFirstConnection" });
 
     const output = getStdout();
     expect(output).not.toContain("Example:");

--- a/packages/core/src/data/action-types.test.ts
+++ b/packages/core/src/data/action-types.test.ts
@@ -194,6 +194,35 @@ describe("getActionTypeInfo", () => {
     if (field === undefined) throw new Error("Expected field");
     expect(field.required).toBe(true);
     expect(field.type).toBe("number");
+    expect(field.description).toContain("min 0");
+    expect(info.example).toEqual({ delay: 24 });
+  });
+
+  it("returns correct fields for ScrapeMessagingHistory", () => {
+    const info = getActionTypeInfo("ScrapeMessagingHistory");
+    expect(info).toBeDefined();
+    if (info === undefined) throw new Error("Expected info");
+    expect(info.category).toBe("messaging");
+    expect(info.configSchema).toHaveProperty("delays");
+    const delaysField = info.configSchema["delays"];
+    expect(delaysField).toBeDefined();
+    if (delaysField === undefined) throw new Error("Expected field");
+    expect(delaysField.type).toBe("object");
+    expect(delaysField.required).toBe(false);
+    expect(info.example).toEqual({});
+  });
+
+  it("returns correct fields for RemoveFromFirstConnection", () => {
+    const info = getActionTypeInfo("RemoveFromFirstConnection");
+    expect(info).toBeDefined();
+    if (info === undefined) throw new Error("Expected info");
+    expect(info.category).toBe("people");
+    expect(info.configSchema).toHaveProperty("delays");
+    const delaysField = info.configSchema["delays"];
+    expect(delaysField).toBeDefined();
+    if (delaysField === undefined) throw new Error("Expected field");
+    expect(delaysField.type).toBe("object");
+    expect(delaysField.required).toBe(false);
   });
 
   it("returns example when available", () => {

--- a/packages/core/src/data/action-types.ts
+++ b/packages/core/src/data/action-types.ts
@@ -340,7 +340,15 @@ const ACTION_TYPE_INFOS: ActionTypeInfo[] = [
     name: "ScrapeMessagingHistory",
     description: "Scrape all messaging history for the LinkedIn account.",
     category: "messaging",
-    configSchema: {},
+    configSchema: {
+      delays: {
+        type: "object",
+        required: false,
+        description:
+          "Per-step delay overrides (typePersonFullName, selectFoundPerson, sleepAfterScrollChatHistory, navigateToMessagingPage, navigateToProfile).",
+      },
+    },
+    example: {},
   },
   {
     name: "Waiter",
@@ -351,7 +359,7 @@ const ACTION_TYPE_INFOS: ActionTypeInfo[] = [
       delay: {
         type: "number",
         required: true,
-        description: "Delay in hours before proceeding to the next action.",
+        description: "Delay in hours before proceeding to the next action (min 0).",
       },
     },
     example: { delay: 24 },
@@ -482,7 +490,14 @@ const ACTION_TYPE_INFOS: ActionTypeInfo[] = [
     name: "RemoveFromFirstConnection",
     description: "Remove a person from 1st-degree connections (unfriend).",
     category: "people",
-    configSchema: {},
+    configSchema: {
+      delays: {
+        type: "object",
+        required: false,
+        description:
+          "Per-step delay overrides (navigateToProfile, clickOnMoreButton, clickOnRemoveConnectionButton).",
+      },
+    },
   },
   {
     name: "FilterContactsOutOfMyNetwork",


### PR DESCRIPTION
## Summary
- Add `delays` field (object, optional) to **ScrapeMessagingHistory** config schema with per-step delay overrides
- Add `delays` field (object, optional) to **RemoveFromFirstConnection** config schema with per-step delay overrides
- Add explicit `min 0` constraint to **Waiter** `delay` field description

## Test plan
- [x] Unit tests added for ScrapeMessagingHistory and RemoveFromFirstConnection config schemas
- [x] Waiter test updated to verify min 0 constraint in description
- [x] CLI test updated (RemoveFromFirstConnection now used for "no example" case)
- [x] All tests pass (`pnpm test`)
- [x] Lint passes (`pnpm lint`)

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)