### PR TITLE
(feat) core: add URL validation to navigateToProfile

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -62,6 +62,7 @@ export {
   ExtractionTimeoutError,
   InstanceNotRunningError,
   InstanceService,
+  InvalidProfileUrlError,
   LauncherService,
   LinkedHelperNotRunningError,
   ServiceError,

--- a/packages/core/src/services/errors.test.ts
+++ b/packages/core/src/services/errors.test.ts
@@ -7,6 +7,7 @@ import {
   CampaignTimeoutError,
   ExtractionTimeoutError,
   InstanceNotRunningError,
+  InvalidProfileUrlError,
   LinkedHelperNotRunningError,
   ServiceError,
   StartInstanceError,
@@ -101,6 +102,13 @@ describe("Service errors", () => {
     const cause = new TypeError("CDP failed");
     const error = new ActionExecutionError("InMail", "action failed", { cause });
     expect(error.cause).toBe(cause);
+  });
+
+  it("should set correct name for InvalidProfileUrlError", () => {
+    const error = new InvalidProfileUrlError("file:///etc/passwd");
+    expect(error.name).toBe("InvalidProfileUrlError");
+    expect(error.message).toContain("file:///etc/passwd");
+    expect(error).toBeInstanceOf(ServiceError);
   });
 
   it("should set correct name for ExtractionTimeoutError", () => {

--- a/packages/core/src/services/errors.ts
+++ b/packages/core/src/services/errors.ts
@@ -97,6 +97,19 @@ export class ActionExecutionError extends ServiceError {
 }
 
 /**
+ * Thrown when a profile URL fails validation (e.g. not a LinkedIn
+ * profile path, or uses a forbidden scheme like `file://`).
+ */
+export class InvalidProfileUrlError extends ServiceError {
+  constructor(url: string) {
+    super(
+      `Invalid profile URL: ${url} — expected https://www.linkedin.com/in/<slug>`,
+    );
+    this.name = "InvalidProfileUrlError";
+  }
+}
+
+/**
  * Thrown when profile extraction times out waiting for data
  * to appear in the database.
  */

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -24,6 +24,7 @@ export {
   CampaignTimeoutError,
   ExtractionTimeoutError,
   InstanceNotRunningError,
+  InvalidProfileUrlError,
   LinkedHelperNotRunningError,
   ServiceError,
   StartInstanceError,

--- a/packages/core/src/services/instance.test.ts
+++ b/packages/core/src/services/instance.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { CdpTarget } from "../types/cdp.js";
-import { ActionExecutionError, ServiceError } from "./errors.js";
+import { ActionExecutionError, InvalidProfileUrlError, ServiceError } from "./errors.js";
 import { InstanceService } from "./instance.js";
 
 /** Per-instance mock method sets, keyed by the target ID passed to connect(). */
@@ -220,6 +220,62 @@ describe("InstanceService", () => {
       expect(uiClient.send).not.toHaveBeenCalled();
       expect(uiClient.navigate).not.toHaveBeenCalled();
       expect(uiClient.waitForEvent).not.toHaveBeenCalled();
+    });
+
+    it("accepts a profile URL with trailing slash", async () => {
+      mockedDiscoverTargets.mockResolvedValue([LINKEDIN_TARGET, UI_TARGET]);
+      await service.connect();
+
+      await service.navigateToProfile("https://www.linkedin.com/in/test-user/");
+
+      const liClient = getClientMocks("LI1");
+      expect(liClient.navigate).toHaveBeenCalledWith(
+        "https://www.linkedin.com/in/test-user/",
+      );
+    });
+
+    it("rejects file:// URLs", async () => {
+      await expect(
+        service.navigateToProfile("file:///etc/passwd"),
+      ).rejects.toThrow(InvalidProfileUrlError);
+    });
+
+    it("rejects javascript: URLs", async () => {
+      await expect(
+        service.navigateToProfile("javascript:alert(1)"),
+      ).rejects.toThrow(InvalidProfileUrlError);
+    });
+
+    it("rejects non-LinkedIn URLs", async () => {
+      await expect(
+        service.navigateToProfile("https://evil.com/in/someone"),
+      ).rejects.toThrow(InvalidProfileUrlError);
+    });
+
+    it("rejects LinkedIn URLs that are not profile paths", async () => {
+      await expect(
+        service.navigateToProfile("https://www.linkedin.com/feed/"),
+      ).rejects.toThrow(InvalidProfileUrlError);
+    });
+
+    it("rejects http:// LinkedIn profile URLs", async () => {
+      await expect(
+        service.navigateToProfile("http://www.linkedin.com/in/test"),
+      ).rejects.toThrow(InvalidProfileUrlError);
+    });
+
+    it("rejects profile URL with extra path segments", async () => {
+      await expect(
+        service.navigateToProfile(
+          "https://www.linkedin.com/in/test/detail/contact-info/",
+        ),
+      ).rejects.toThrow(InvalidProfileUrlError);
+    });
+
+    it("includes the invalid URL in the error message", async () => {
+      await expect(
+        service.navigateToProfile("https://evil.com"),
+      ).rejects.toThrow(/https:\/\/evil\.com/);
     });
 
     it("throws ServiceError when not connected", async () => {


### PR DESCRIPTION
## Summary
- Add `InvalidProfileUrlError` and `assertLinkedInProfileUrl` validation to `navigateToProfile()` in `InstanceService`
- Restrict navigation to `https://www.linkedin.com/in/<slug>` paths only — rejects `file://`, `javascript:`, `http://`, non-LinkedIn hosts, and non-profile LinkedIn paths
- Export `InvalidProfileUrlError` from package public API

## Test plan
- [x] Unit tests for all rejection cases: `file://`, `javascript:`, `http://`, non-LinkedIn hosts, non-profile paths, extra path segments
- [x] Unit test for valid URLs with and without trailing slash
- [x] Error message includes the rejected URL
- [x] Error class test for `InvalidProfileUrlError`
- [x] Full test suite passes (881 tests across 4 packages)
- [x] Lint and build pass

Closes #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)