### PR TITLE
(refactor) cli: extract shared CLI test helpers

### DIFF
--- a/packages/cli/src/handlers/list-accounts.test.ts
+++ b/packages/cli/src/handlers/list-accounts.test.ts
@@ -15,19 +15,7 @@ import {
 } from "@lhremote/core";
 
 import { handleListAccounts } from "./list-accounts.js";
-
-function mockLauncher(overrides: Partial<LauncherService> = {}) {
-  const disconnect = vi.fn();
-  vi.mocked(LauncherService).mockImplementation(function () {
-    return {
-      connect: vi.fn().mockResolvedValue(undefined),
-      disconnect,
-      listAccounts: vi.fn().mockResolvedValue([]),
-      ...overrides,
-    } as unknown as LauncherService;
-  });
-  return { disconnect };
-}
+import { mockLauncher } from "./testing/mock-helpers.js";
 
 describe("handleListAccounts", () => {
   const originalExitCode = process.exitCode;

--- a/packages/cli/src/handlers/query-messages.test.ts
+++ b/packages/cli/src/handlers/query-messages.test.ts
@@ -15,12 +15,11 @@ import {
   type ConversationThread,
   type Message,
   ChatNotFoundError,
-  DatabaseClient,
   MessageRepository,
-  discoverAllDatabases,
 } from "@lhremote/core";
 
 import { handleQueryMessages } from "./query-messages.js";
+import { mockDb, mockDiscovery } from "./testing/mock-helpers.js";
 
 const MOCK_CHAT: Chat = {
   id: 123,
@@ -53,14 +52,6 @@ const MOCK_THREAD: ConversationThread = {
   messages: [MOCK_MESSAGE],
 };
 
-function mockDb() {
-  const close = vi.fn();
-  vi.mocked(DatabaseClient).mockImplementation(function () {
-    return { close, db: {} } as unknown as DatabaseClient;
-  });
-  return { close };
-}
-
 function mockRepo(overrides?: {
   listChats?: Chat[];
   thread?: ConversationThread;
@@ -90,9 +81,7 @@ function mockRepoChatNotFound() {
 }
 
 function setupSuccessPath() {
-  vi.mocked(discoverAllDatabases).mockReturnValue(
-    new Map([[1, "/path/to/db"]]),
-  );
+  mockDiscovery();
   mockDb();
   mockRepo();
 }
@@ -115,7 +104,7 @@ describe("handleQueryMessages", () => {
       .spyOn(process.stderr, "write")
       .mockReturnValue(true);
 
-    vi.mocked(discoverAllDatabases).mockReturnValue(new Map());
+    mockDiscovery(new Map());
 
     await handleQueryMessages({});
 
@@ -242,9 +231,7 @@ describe("handleQueryMessages", () => {
       .spyOn(process.stdout, "write")
       .mockReturnValue(true);
 
-    vi.mocked(discoverAllDatabases).mockReturnValue(
-      new Map([[1, "/path/to/db"]]),
-    );
+    mockDiscovery();
     mockDb();
     mockRepo({ listChats: [] });
 
@@ -259,9 +246,7 @@ describe("handleQueryMessages", () => {
       .spyOn(process.stdout, "write")
       .mockReturnValue(true);
 
-    vi.mocked(discoverAllDatabases).mockReturnValue(
-      new Map([[1, "/path/to/db"]]),
-    );
+    mockDiscovery();
     mockDb();
     mockRepo({ searchMessages: [] });
 
@@ -278,9 +263,7 @@ describe("handleQueryMessages", () => {
       .spyOn(process.stderr, "write")
       .mockReturnValue(true);
 
-    vi.mocked(discoverAllDatabases).mockReturnValue(
-      new Map([[1, "/path/to/db"]]),
-    );
+    mockDiscovery();
     mockDb();
     mockRepoChatNotFound();
 
@@ -293,9 +276,7 @@ describe("handleQueryMessages", () => {
   it("closes database after successful query", async () => {
     vi.spyOn(process.stdout, "write").mockReturnValue(true);
 
-    vi.mocked(discoverAllDatabases).mockReturnValue(
-      new Map([[1, "/path/to/db"]]),
-    );
+    mockDiscovery();
     const { close } = mockDb();
     mockRepo();
 
@@ -307,9 +288,7 @@ describe("handleQueryMessages", () => {
   it("closes database after failed lookup", async () => {
     vi.spyOn(process.stderr, "write").mockReturnValue(true);
 
-    vi.mocked(discoverAllDatabases).mockReturnValue(
-      new Map([[1, "/path/to/db"]]),
-    );
+    mockDiscovery();
     const { close } = mockDb();
     mockRepoChatNotFound();
 
@@ -323,9 +302,7 @@ describe("handleQueryMessages", () => {
       .spyOn(process.stderr, "write")
       .mockReturnValue(true);
 
-    vi.mocked(discoverAllDatabases).mockReturnValue(
-      new Map([[1, "/path/to/db"]]),
-    );
+    mockDiscovery();
     mockDb();
     vi.mocked(MessageRepository).mockImplementation(function () {
       return {

--- a/packages/cli/src/handlers/query-profiles.test.ts
+++ b/packages/cli/src/handlers/query-profiles.test.ts
@@ -12,12 +12,11 @@ vi.mock("@lhremote/core", async (importOriginal) => {
 
 import {
   type ProfileSearchResult,
-  DatabaseClient,
   ProfileRepository,
-  discoverAllDatabases,
 } from "@lhremote/core";
 
 import { handleQueryProfiles } from "./query-profiles.js";
+import { mockDb, mockDiscovery } from "./testing/mock-helpers.js";
 
 const MOCK_SEARCH_RESULT: ProfileSearchResult = {
   profiles: [
@@ -41,14 +40,6 @@ const MOCK_SEARCH_RESULT: ProfileSearchResult = {
   total: 12,
 };
 
-function mockDb() {
-  const close = vi.fn();
-  vi.mocked(DatabaseClient).mockImplementation(function () {
-    return { close, db: {} } as unknown as DatabaseClient;
-  });
-  return { close };
-}
-
 function mockRepo(result: ProfileSearchResult = MOCK_SEARCH_RESULT) {
   vi.mocked(ProfileRepository).mockImplementation(function () {
     return {
@@ -58,9 +49,7 @@ function mockRepo(result: ProfileSearchResult = MOCK_SEARCH_RESULT) {
 }
 
 function setupSuccessPath() {
-  vi.mocked(discoverAllDatabases).mockReturnValue(
-    new Map([[1, "/path/to/db"]]),
-  );
+  mockDiscovery();
   mockDb();
   mockRepo();
 }
@@ -83,7 +72,7 @@ describe("handleQueryProfiles", () => {
       .spyOn(process.stderr, "write")
       .mockReturnValue(true);
 
-    vi.mocked(discoverAllDatabases).mockReturnValue(new Map());
+    mockDiscovery(new Map());
 
     await handleQueryProfiles({});
 
@@ -181,9 +170,7 @@ describe("handleQueryProfiles", () => {
       .spyOn(process.stdout, "write")
       .mockReturnValue(true);
 
-    vi.mocked(discoverAllDatabases).mockReturnValue(
-      new Map([[1, "/path/to/db"]]),
-    );
+    mockDiscovery();
     mockDb();
     mockRepo({ profiles: [], total: 0 });
 
@@ -200,9 +187,7 @@ describe("handleQueryProfiles", () => {
       .spyOn(process.stdout, "write")
       .mockReturnValue(true);
 
-    vi.mocked(discoverAllDatabases).mockReturnValue(
-      new Map([[1, "/path/to/db"]]),
-    );
+    mockDiscovery();
     mockDb();
     mockRepo({
       profiles: [
@@ -228,9 +213,7 @@ describe("handleQueryProfiles", () => {
   it("closes database after search", async () => {
     vi.spyOn(process.stdout, "write").mockReturnValue(true);
 
-    vi.mocked(discoverAllDatabases).mockReturnValue(
-      new Map([[1, "/path/to/db"]]),
-    );
+    mockDiscovery();
     const { close } = mockDb();
     mockRepo();
 
@@ -244,9 +227,7 @@ describe("handleQueryProfiles", () => {
       .spyOn(process.stderr, "write")
       .mockReturnValue(true);
 
-    vi.mocked(discoverAllDatabases).mockReturnValue(
-      new Map([[1, "/path/to/db"]]),
-    );
+    mockDiscovery();
     mockDb();
     vi.mocked(ProfileRepository).mockImplementation(function () {
       return {
@@ -265,9 +246,7 @@ describe("handleQueryProfiles", () => {
   it("passes parameters to repository", async () => {
     vi.spyOn(process.stdout, "write").mockReturnValue(true);
 
-    vi.mocked(discoverAllDatabases).mockReturnValue(
-      new Map([[1, "/path/to/db"]]),
-    );
+    mockDiscovery();
     mockDb();
 
     const searchFn = vi.fn().mockReturnValue({ profiles: [], total: 0 });

--- a/packages/cli/src/handlers/start-instance.test.ts
+++ b/packages/cli/src/handlers/start-instance.test.ts
@@ -16,6 +16,7 @@ import {
 } from "@lhremote/core";
 
 import { handleStartInstance } from "./start-instance.js";
+import { mockLauncher } from "./testing/mock-helpers.js";
 
 describe("handleStartInstance", () => {
   const originalExitCode = process.exitCode;
@@ -35,12 +36,7 @@ describe("handleStartInstance", () => {
       .spyOn(process.stdout, "write")
       .mockReturnValue(true);
 
-    vi.mocked(LauncherService).mockImplementation(function () {
-      return {
-        connect: vi.fn().mockResolvedValue(undefined),
-        disconnect: vi.fn(),
-      } as unknown as LauncherService;
-    });
+    mockLauncher();
     vi.mocked(startInstanceWithRecovery).mockResolvedValue({
       status: "started",
       port: 55123,
@@ -59,13 +55,10 @@ describe("handleStartInstance", () => {
       .spyOn(process.stderr, "write")
       .mockReturnValue(true);
 
-    vi.mocked(LauncherService).mockImplementation(function () {
-      return {
-        connect: vi
-          .fn()
-          .mockRejectedValue(new LinkedHelperNotRunningError(9222)),
-        disconnect: vi.fn(),
-      } as unknown as LauncherService;
+    mockLauncher({
+      connect: vi
+        .fn()
+        .mockRejectedValue(new LinkedHelperNotRunningError(9222)),
     });
 
     await handleStartInstance("42", {});
@@ -81,12 +74,7 @@ describe("handleStartInstance", () => {
       .spyOn(process.stdout, "write")
       .mockReturnValue(true);
 
-    vi.mocked(LauncherService).mockImplementation(function () {
-      return {
-        connect: vi.fn().mockResolvedValue(undefined),
-        disconnect: vi.fn(),
-      } as unknown as LauncherService;
-    });
+    mockLauncher();
     vi.mocked(startInstanceWithRecovery).mockResolvedValue({
       status: "already_running",
       port: 55123,
@@ -105,12 +93,7 @@ describe("handleStartInstance", () => {
       .spyOn(process.stderr, "write")
       .mockReturnValue(true);
 
-    vi.mocked(LauncherService).mockImplementation(function () {
-      return {
-        connect: vi.fn().mockResolvedValue(undefined),
-        disconnect: vi.fn(),
-      } as unknown as LauncherService;
-    });
+    mockLauncher();
     vi.mocked(startInstanceWithRecovery).mockRejectedValue(
       new Error("unexpected failure"),
     );
@@ -126,12 +109,7 @@ describe("handleStartInstance", () => {
   it("passes cdpPort option to LauncherService", async () => {
     vi.spyOn(process.stdout, "write").mockReturnValue(true);
 
-    vi.mocked(LauncherService).mockImplementation(function () {
-      return {
-        connect: vi.fn().mockResolvedValue(undefined),
-        disconnect: vi.fn(),
-      } as unknown as LauncherService;
-    });
+    mockLauncher();
     vi.mocked(startInstanceWithRecovery).mockResolvedValue({
       status: "started",
       port: 55123,
@@ -147,12 +125,7 @@ describe("handleStartInstance", () => {
       .spyOn(process.stderr, "write")
       .mockReturnValue(true);
 
-    vi.mocked(LauncherService).mockImplementation(function () {
-      return {
-        connect: vi.fn().mockResolvedValue(undefined),
-        disconnect: vi.fn(),
-      } as unknown as LauncherService;
-    });
+    mockLauncher();
     vi.mocked(startInstanceWithRecovery).mockResolvedValue({
       status: "timeout",
     });

--- a/packages/cli/src/handlers/stop-instance.test.ts
+++ b/packages/cli/src/handlers/stop-instance.test.ts
@@ -14,6 +14,7 @@ import {
 } from "@lhremote/core";
 
 import { handleStopInstance } from "./stop-instance.js";
+import { mockLauncher } from "./testing/mock-helpers.js";
 
 describe("handleStopInstance", () => {
   const originalExitCode = process.exitCode;
@@ -33,13 +34,7 @@ describe("handleStopInstance", () => {
       .spyOn(process.stdout, "write")
       .mockReturnValue(true);
 
-    vi.mocked(LauncherService).mockImplementation(function () {
-      return {
-        connect: vi.fn().mockResolvedValue(undefined),
-        disconnect: vi.fn(),
-        stopInstance: vi.fn().mockResolvedValue(undefined),
-      } as unknown as LauncherService;
-    });
+    mockLauncher({ stopInstance: vi.fn().mockResolvedValue(undefined) });
 
     await handleStopInstance("42", {});
 
@@ -54,13 +49,10 @@ describe("handleStopInstance", () => {
       .spyOn(process.stderr, "write")
       .mockReturnValue(true);
 
-    vi.mocked(LauncherService).mockImplementation(function () {
-      return {
-        connect: vi
-          .fn()
-          .mockRejectedValue(new LinkedHelperNotRunningError(9222)),
-        disconnect: vi.fn(),
-      } as unknown as LauncherService;
+    mockLauncher({
+      connect: vi
+        .fn()
+        .mockRejectedValue(new LinkedHelperNotRunningError(9222)),
     });
 
     await handleStopInstance("42", {});
@@ -76,14 +68,10 @@ describe("handleStopInstance", () => {
       .spyOn(process.stderr, "write")
       .mockReturnValue(true);
 
-    vi.mocked(LauncherService).mockImplementation(function () {
-      return {
-        connect: vi.fn().mockResolvedValue(undefined),
-        disconnect: vi.fn(),
-        stopInstance: vi
-          .fn()
-          .mockRejectedValue(new Error("unexpected failure")),
-      } as unknown as LauncherService;
+    mockLauncher({
+      stopInstance: vi
+        .fn()
+        .mockRejectedValue(new Error("unexpected failure")),
     });
 
     await handleStopInstance("42", {});
@@ -95,13 +83,7 @@ describe("handleStopInstance", () => {
   it("passes cdpPort option to LauncherService", async () => {
     vi.spyOn(process.stdout, "write").mockReturnValue(true);
 
-    vi.mocked(LauncherService).mockImplementation(function () {
-      return {
-        connect: vi.fn().mockResolvedValue(undefined),
-        disconnect: vi.fn(),
-        stopInstance: vi.fn().mockResolvedValue(undefined),
-      } as unknown as LauncherService;
-    });
+    mockLauncher({ stopInstance: vi.fn().mockResolvedValue(undefined) });
 
     await handleStopInstance("42", { cdpPort: 4567 });
 

--- a/packages/cli/src/handlers/testing/mock-helpers.ts
+++ b/packages/cli/src/handlers/testing/mock-helpers.ts
@@ -1,0 +1,89 @@
+import { vi } from "vitest";
+
+import type {
+  DatabaseClient,
+  InstanceDatabaseContext,
+  LauncherService,
+} from "@lhremote/core";
+import {
+  DatabaseClient as DatabaseClientCtor,
+  LauncherService as LauncherServiceCtor,
+  discoverAllDatabases,
+  resolveAccount,
+  withInstanceDatabase,
+} from "@lhremote/core";
+
+/**
+ * Mock {@link LauncherService} with optional method overrides.
+ *
+ * Returns the `disconnect` spy so callers can assert cleanup.
+ */
+export function mockLauncher(
+  overrides: Partial<LauncherService> = {},
+): { disconnect: ReturnType<typeof vi.fn> } {
+  const disconnect = vi.fn();
+  vi.mocked(LauncherServiceCtor).mockImplementation(function () {
+    return {
+      connect: vi.fn().mockResolvedValue(undefined),
+      disconnect,
+      listAccounts: vi.fn().mockResolvedValue([]),
+      ...overrides,
+    } as unknown as LauncherService;
+  });
+  return { disconnect };
+}
+
+/**
+ * Mock {@link DatabaseClient} with a no-op `close` and empty `db`.
+ *
+ * Returns the `close` spy so callers can assert cleanup.
+ */
+export function mockDb(): { close: ReturnType<typeof vi.fn> } {
+  const close = vi.fn();
+  vi.mocked(DatabaseClientCtor).mockImplementation(function () {
+    return { close, db: {} } as unknown as DatabaseClient;
+  });
+  return { close };
+}
+
+/**
+ * Mock {@link discoverAllDatabases} to return the given map.
+ *
+ * Defaults to a single account at id 1.
+ */
+export function mockDiscovery(
+  databases: Map<number, string> = new Map([[1, "/path/to/db"]]),
+): void {
+  vi.mocked(discoverAllDatabases).mockReturnValue(databases);
+}
+
+/**
+ * Mock {@link resolveAccount} to return the given account id.
+ */
+export function mockResolveAccount(accountId = 1): void {
+  vi.mocked(resolveAccount).mockResolvedValue(accountId);
+}
+
+/**
+ * Mock {@link withInstanceDatabase} so the callback receives a
+ * synthetic {@link InstanceDatabaseContext}.
+ *
+ * Returns the `executeAction` spy from the mock instance.
+ */
+export function mockWithInstanceDatabase(): {
+  executeAction: ReturnType<typeof vi.fn>;
+} {
+  const executeAction = vi.fn().mockResolvedValue(undefined);
+  vi.mocked(withInstanceDatabase).mockImplementation(
+    async (_cdpPort, _accountId, callback) => {
+      const mockInstance = { executeAction };
+      const mockDbObj = {};
+      return callback({
+        accountId: _accountId,
+        instance: mockInstance,
+        db: mockDbObj,
+      } as unknown as InstanceDatabaseContext);
+    },
+  );
+  return { executeAction };
+}


### PR DESCRIPTION
## Summary
- Extracts duplicated mock setup patterns from 7 CLI handler test files into `packages/cli/src/handlers/testing/mock-helpers.ts`
- Provides reusable `mockLauncher()`, `mockDb()`, `mockDiscovery()`, `mockResolveAccount()`, and `mockWithInstanceDatabase()` helpers
- Refactors all existing handler tests to use the shared helpers, reducing ~70 lines of duplicated boilerplate

## Test plan
- [x] All 100 CLI tests pass with no regressions
- [x] All 477 core tests pass
- [x] All 240 MCP tests pass
- [x] Lint passes cleanly

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)