### PR TITLE
Write unit tests for untested CLI handlers

### DIFF
--- a/packages/cli/src/handlers/campaign-add-action.test.ts
+++ b/packages/cli/src/handlers/campaign-add-action.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return {
+    ...actual,
+    resolveAccount: vi.fn(),
+    withDatabase: vi.fn(),
+    CampaignRepository: vi.fn(),
+  };
+});
+
+import {
+  CampaignNotFoundError,
+  CampaignRepository,
+  resolveAccount,
+} from "@lhremote/core";
+
+import { handleCampaignAddAction } from "./campaign-add-action.js";
+import { mockResolveAccount, mockWithDatabase } from "./testing/mock-helpers.js";
+
+const MOCK_CAMPAIGN = { id: 1, name: "Test", liAccountId: 42 };
+const MOCK_ACTION = {
+  id: 10,
+  name: "Visit",
+  config: { actionType: "VisitAndExtract" },
+};
+
+function mockRepo(campaign = MOCK_CAMPAIGN, action = MOCK_ACTION) {
+  const getCampaign = vi.fn().mockReturnValue(campaign);
+  const addAction = vi.fn().mockReturnValue(action);
+  vi.mocked(CampaignRepository).mockImplementation(function () {
+    return { getCampaign, addAction } as unknown as CampaignRepository;
+  });
+  return { getCampaign, addAction };
+}
+
+function setupSuccessPath() {
+  mockResolveAccount();
+  mockWithDatabase();
+  return mockRepo();
+}
+
+describe("handleCampaignAddAction", () => {
+  const originalExitCode = process.exitCode;
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    process.exitCode = undefined;
+    vi.clearAllMocks();
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    process.exitCode = originalExitCode;
+    vi.restoreAllMocks();
+  });
+
+  function getStdout(): string {
+    return stdoutSpy.mock.calls
+      .map((call: unknown[]) => String(call[0]))
+      .join("");
+  }
+
+  it("adds action and prints confirmation", async () => {
+    setupSuccessPath();
+
+    await handleCampaignAddAction(1, {
+      name: "Visit",
+      actionType: "VisitAndExtract",
+    });
+
+    expect(process.exitCode).toBeUndefined();
+    expect(getStdout()).toContain(
+      'Action added: #10 "Visit" (VisitAndExtract) to campaign #1',
+    );
+  });
+
+  it("prints JSON with --json", async () => {
+    setupSuccessPath();
+
+    await handleCampaignAddAction(1, {
+      name: "Visit",
+      actionType: "VisitAndExtract",
+      json: true,
+    });
+
+    expect(process.exitCode).toBeUndefined();
+    const parsed = JSON.parse(getStdout());
+    expect(parsed.id).toBe(10);
+    expect(parsed.name).toBe("Visit");
+  });
+
+  it("passes optional parameters to addAction", async () => {
+    const { addAction } = setupSuccessPath();
+
+    await handleCampaignAddAction(1, {
+      name: "Visit",
+      actionType: "VisitAndExtract",
+      description: "Visit and extract data",
+      coolDown: 30,
+      maxResults: 100,
+    });
+
+    expect(addAction).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({
+        name: "Visit",
+        actionType: "VisitAndExtract",
+        description: "Visit and extract data",
+        coolDown: 30,
+        maxActionResultsPerIteration: 100,
+      }),
+      42,
+    );
+  });
+
+  it("parses action settings JSON", async () => {
+    const { addAction } = setupSuccessPath();
+
+    await handleCampaignAddAction(1, {
+      name: "Visit",
+      actionType: "VisitAndExtract",
+      actionSettings: '{"extractEmails":true}',
+    });
+
+    expect(addAction).toHaveBeenCalledWith(
+      1,
+      expect.objectContaining({
+        actionSettings: { extractEmails: true },
+      }),
+      42,
+    );
+  });
+
+  it("sets exitCode 1 on invalid action settings JSON", async () => {
+    await handleCampaignAddAction(1, {
+      name: "Visit",
+      actionType: "VisitAndExtract",
+      actionSettings: "bad json",
+    });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "Invalid JSON in --action-settings.\n",
+    );
+  });
+
+  it("sets exitCode 1 when campaign not found", async () => {
+    mockResolveAccount();
+    mockWithDatabase();
+    vi.mocked(CampaignRepository).mockImplementation(function () {
+      return {
+        getCampaign: vi.fn().mockImplementation(() => {
+          throw new CampaignNotFoundError(999);
+        }),
+        addAction: vi.fn(),
+      } as unknown as CampaignRepository;
+    });
+
+    await handleCampaignAddAction(999, {
+      name: "Visit",
+      actionType: "VisitAndExtract",
+    });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("Campaign 999 not found.\n");
+  });
+
+  it("sets exitCode 1 when resolveAccount fails", async () => {
+    vi.mocked(resolveAccount).mockRejectedValue(new Error("timeout"));
+
+    await handleCampaignAddAction(1, {
+      name: "Visit",
+      actionType: "VisitAndExtract",
+    });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("timeout\n");
+  });
+});

--- a/packages/cli/src/handlers/campaign-create.test.ts
+++ b/packages/cli/src/handlers/campaign-create.test.ts
@@ -1,0 +1,226 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return {
+    ...actual,
+    resolveAccount: vi.fn(),
+    withInstanceDatabase: vi.fn(),
+    CampaignService: vi.fn(),
+    parseCampaignJson: vi.fn(),
+    parseCampaignYaml: vi.fn(),
+  };
+});
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    readFileSync: vi.fn(),
+  };
+});
+
+import {
+  CampaignExecutionError,
+  CampaignFormatError,
+  CampaignService,
+  InstanceNotRunningError,
+  parseCampaignJson,
+  parseCampaignYaml,
+  resolveAccount,
+  withInstanceDatabase,
+} from "@lhremote/core";
+import { readFileSync } from "node:fs";
+
+import { handleCampaignCreate } from "./campaign-create.js";
+import {
+  mockResolveAccount,
+  mockWithInstanceDatabase,
+} from "./testing/mock-helpers.js";
+
+const MOCK_CONFIG = { name: "Test Campaign", actions: [] };
+const MOCK_CAMPAIGN = { id: 1, name: "Test Campaign" };
+
+function mockCampaignService(campaign = MOCK_CAMPAIGN) {
+  vi.mocked(CampaignService).mockImplementation(function () {
+    return {
+      create: vi.fn().mockResolvedValue(campaign),
+    } as unknown as CampaignService;
+  });
+}
+
+function setupSuccessPath() {
+  mockResolveAccount();
+  mockWithInstanceDatabase();
+  mockCampaignService();
+  vi.mocked(parseCampaignJson).mockReturnValue(MOCK_CONFIG as never);
+  vi.mocked(parseCampaignYaml).mockReturnValue(MOCK_CONFIG as never);
+}
+
+describe("handleCampaignCreate", () => {
+  const originalExitCode = process.exitCode;
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    process.exitCode = undefined;
+    vi.clearAllMocks();
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    process.exitCode = originalExitCode;
+    vi.restoreAllMocks();
+  });
+
+  function getStdout(): string {
+    return stdoutSpy.mock.calls
+      .map((call: unknown[]) => String(call[0]))
+      .join("");
+  }
+
+  it("creates campaign from --json-input and prints result", async () => {
+    setupSuccessPath();
+
+    await handleCampaignCreate({ jsonInput: '{"name":"Test"}' });
+
+    expect(process.exitCode).toBeUndefined();
+    expect(getStdout()).toContain('Campaign created: #1 "Test Campaign"');
+    expect(parseCampaignJson).toHaveBeenCalledWith('{"name":"Test"}');
+  });
+
+  it("creates campaign from --yaml", async () => {
+    setupSuccessPath();
+
+    await handleCampaignCreate({ yaml: "name: Test" });
+
+    expect(process.exitCode).toBeUndefined();
+    expect(parseCampaignYaml).toHaveBeenCalledWith("name: Test");
+  });
+
+  it("creates campaign from --file with JSON extension", async () => {
+    setupSuccessPath();
+    vi.mocked(readFileSync).mockReturnValue('{"name":"Test"}');
+
+    await handleCampaignCreate({ file: "campaign.json" });
+
+    expect(process.exitCode).toBeUndefined();
+    expect(readFileSync).toHaveBeenCalledWith("campaign.json", "utf-8");
+    expect(parseCampaignJson).toHaveBeenCalled();
+  });
+
+  it("creates campaign from --file with YAML extension", async () => {
+    setupSuccessPath();
+    vi.mocked(readFileSync).mockReturnValue("name: Test");
+
+    await handleCampaignCreate({ file: "campaign.yaml" });
+
+    expect(process.exitCode).toBeUndefined();
+    expect(parseCampaignYaml).toHaveBeenCalled();
+  });
+
+  it("prints JSON with --json", async () => {
+    setupSuccessPath();
+
+    await handleCampaignCreate({ jsonInput: '{"name":"Test"}', json: true });
+
+    expect(process.exitCode).toBeUndefined();
+    const parsed = JSON.parse(getStdout());
+    expect(parsed.id).toBe(1);
+    expect(parsed.name).toBe("Test Campaign");
+  });
+
+  it("sets exitCode 1 when no input option provided", async () => {
+    await handleCampaignCreate({});
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "One of --file, --yaml, or --json-input is required.\n",
+    );
+  });
+
+  it("sets exitCode 1 when multiple input options provided", async () => {
+    await handleCampaignCreate({ yaml: "x", jsonInput: "y" });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "Use only one of --file, --yaml, or --json-input.\n",
+    );
+  });
+
+  it("sets exitCode 1 on CampaignFormatError", async () => {
+    mockResolveAccount();
+    vi.mocked(parseCampaignJson).mockImplementation(() => {
+      throw new CampaignFormatError("missing name");
+    });
+
+    await handleCampaignCreate({ jsonInput: "{}" });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "Invalid campaign configuration: missing name\n",
+    );
+  });
+
+  it("sets exitCode 1 on parse error", async () => {
+    mockResolveAccount();
+    vi.mocked(parseCampaignJson).mockImplementation(() => {
+      throw new SyntaxError("Unexpected token");
+    });
+
+    await handleCampaignCreate({ jsonInput: "bad" });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Failed to parse campaign configuration"),
+    );
+  });
+
+  it("sets exitCode 1 when resolveAccount fails", async () => {
+    vi.mocked(resolveAccount).mockRejectedValue(
+      new Error("No accounts found."),
+    );
+    vi.mocked(parseCampaignJson).mockReturnValue(MOCK_CONFIG as never);
+
+    await handleCampaignCreate({ jsonInput: '{"name":"Test"}' });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("No accounts found.\n");
+  });
+
+  it("sets exitCode 1 on CampaignExecutionError", async () => {
+    mockResolveAccount();
+    mockWithInstanceDatabase();
+    vi.mocked(parseCampaignJson).mockReturnValue(MOCK_CONFIG as never);
+    vi.mocked(CampaignService).mockImplementation(function () {
+      return {
+        create: vi.fn().mockRejectedValue(
+          new CampaignExecutionError("duplicate name"),
+        ),
+      } as unknown as CampaignService;
+    });
+
+    await handleCampaignCreate({ jsonInput: '{"name":"Test"}' });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "Failed to create campaign: duplicate name\n",
+    );
+  });
+
+  it("sets exitCode 1 on InstanceNotRunningError", async () => {
+    mockResolveAccount();
+    vi.mocked(parseCampaignJson).mockReturnValue(MOCK_CONFIG as never);
+    vi.mocked(withInstanceDatabase).mockRejectedValue(
+      new InstanceNotRunningError("No LinkedHelper instance is running."),
+    );
+
+    await handleCampaignCreate({ jsonInput: '{"name":"Test"}' });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "No LinkedHelper instance is running.\n",
+    );
+  });
+});

--- a/packages/cli/src/handlers/campaign-delete.test.ts
+++ b/packages/cli/src/handlers/campaign-delete.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return {
+    ...actual,
+    resolveAccount: vi.fn(),
+    withInstanceDatabase: vi.fn(),
+    CampaignService: vi.fn(),
+  };
+});
+
+import {
+  CampaignExecutionError,
+  CampaignNotFoundError,
+  CampaignService,
+  InstanceNotRunningError,
+  resolveAccount,
+  withInstanceDatabase,
+} from "@lhremote/core";
+
+import { handleCampaignDelete } from "./campaign-delete.js";
+import {
+  mockResolveAccount,
+  mockWithInstanceDatabase,
+} from "./testing/mock-helpers.js";
+
+function mockCampaignService() {
+  vi.mocked(CampaignService).mockImplementation(function () {
+    return {
+      delete: vi.fn().mockResolvedValue(undefined),
+    } as unknown as CampaignService;
+  });
+}
+
+function setupSuccessPath() {
+  mockResolveAccount();
+  mockWithInstanceDatabase();
+  mockCampaignService();
+}
+
+describe("handleCampaignDelete", () => {
+  const originalExitCode = process.exitCode;
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    process.exitCode = undefined;
+    vi.clearAllMocks();
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    process.exitCode = originalExitCode;
+    vi.restoreAllMocks();
+  });
+
+  function getStdout(): string {
+    return stdoutSpy.mock.calls
+      .map((call: unknown[]) => String(call[0]))
+      .join("");
+  }
+
+  it("archives campaign and prints confirmation", async () => {
+    setupSuccessPath();
+
+    await handleCampaignDelete(5, {});
+
+    expect(process.exitCode).toBeUndefined();
+    expect(getStdout()).toContain("Campaign 5 archived.");
+  });
+
+  it("prints JSON with --json", async () => {
+    setupSuccessPath();
+
+    await handleCampaignDelete(5, { json: true });
+
+    expect(process.exitCode).toBeUndefined();
+    const parsed = JSON.parse(getStdout());
+    expect(parsed.success).toBe(true);
+    expect(parsed.campaignId).toBe(5);
+    expect(parsed.action).toBe("archived");
+  });
+
+  it("sets exitCode 1 when campaign not found", async () => {
+    mockResolveAccount();
+    mockWithInstanceDatabase();
+    vi.mocked(CampaignService).mockImplementation(function () {
+      return {
+        delete: vi.fn().mockRejectedValue(new CampaignNotFoundError(999)),
+      } as unknown as CampaignService;
+    });
+
+    await handleCampaignDelete(999, {});
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("Campaign 999 not found.\n");
+  });
+
+  it("sets exitCode 1 on CampaignExecutionError", async () => {
+    mockResolveAccount();
+    mockWithInstanceDatabase();
+    vi.mocked(CampaignService).mockImplementation(function () {
+      return {
+        delete: vi.fn().mockRejectedValue(
+          new CampaignExecutionError("cannot delete running campaign"),
+        ),
+      } as unknown as CampaignService;
+    });
+
+    await handleCampaignDelete(5, {});
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "Failed to delete campaign: cannot delete running campaign\n",
+    );
+  });
+
+  it("sets exitCode 1 on InstanceNotRunningError", async () => {
+    mockResolveAccount();
+    vi.mocked(withInstanceDatabase).mockRejectedValue(
+      new InstanceNotRunningError("No LinkedHelper instance is running."),
+    );
+
+    await handleCampaignDelete(5, {});
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "No LinkedHelper instance is running.\n",
+    );
+  });
+
+  it("sets exitCode 1 when resolveAccount fails", async () => {
+    vi.mocked(resolveAccount).mockRejectedValue(new Error("connection error"));
+
+    await handleCampaignDelete(5, {});
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("connection error\n");
+  });
+});

--- a/packages/cli/src/handlers/campaign-exclude-add.test.ts
+++ b/packages/cli/src/handlers/campaign-exclude-add.test.ts
@@ -1,0 +1,234 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return {
+    ...actual,
+    resolveAccount: vi.fn(),
+    withDatabase: vi.fn(),
+    CampaignRepository: vi.fn(),
+  };
+});
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    readFileSync: vi.fn(),
+  };
+});
+
+import {
+  ActionNotFoundError,
+  CampaignNotFoundError,
+  CampaignRepository,
+  ExcludeListNotFoundError,
+  resolveAccount,
+} from "@lhremote/core";
+import { readFileSync } from "node:fs";
+
+import { handleCampaignExcludeAdd } from "./campaign-exclude-add.js";
+import { mockResolveAccount, mockWithDatabase } from "./testing/mock-helpers.js";
+
+function mockRepo(added = 2) {
+  const addToExcludeList = vi.fn().mockReturnValue(added);
+  vi.mocked(CampaignRepository).mockImplementation(function () {
+    return { addToExcludeList } as unknown as CampaignRepository;
+  });
+  return { addToExcludeList };
+}
+
+function setupSuccessPath() {
+  mockResolveAccount();
+  mockWithDatabase();
+  return mockRepo();
+}
+
+describe("handleCampaignExcludeAdd", () => {
+  const originalExitCode = process.exitCode;
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    process.exitCode = undefined;
+    vi.clearAllMocks();
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    process.exitCode = originalExitCode;
+    vi.restoreAllMocks();
+  });
+
+  function getStdout(): string {
+    return stdoutSpy.mock.calls
+      .map((call: unknown[]) => String(call[0]))
+      .join("");
+  }
+
+  it("adds persons to campaign-level exclude list", async () => {
+    setupSuccessPath();
+
+    await handleCampaignExcludeAdd(1, { personIds: "100,200" });
+
+    expect(process.exitCode).toBeUndefined();
+    expect(getStdout()).toContain(
+      "Added 2 person(s) to exclude list for campaign 1.",
+    );
+  });
+
+  it("adds persons to action-level exclude list", async () => {
+    setupSuccessPath();
+
+    await handleCampaignExcludeAdd(1, { personIds: "100,200", actionId: 10 });
+
+    expect(process.exitCode).toBeUndefined();
+    expect(getStdout()).toContain(
+      "Added 2 person(s) to exclude list for action 10 in campaign 1.",
+    );
+  });
+
+  it("shows already-excluded count", async () => {
+    mockResolveAccount();
+    mockWithDatabase();
+    mockRepo(1); // only 1 of 2 actually added
+
+    await handleCampaignExcludeAdd(1, { personIds: "100,200" });
+
+    const output = getStdout();
+    expect(output).toContain("Added 1 person(s)");
+    expect(output).toContain("1 person(s) already in exclude list.");
+  });
+
+  it("reads from --person-ids-file", async () => {
+    setupSuccessPath();
+    vi.mocked(readFileSync).mockReturnValue("100\n200\n300");
+
+    await handleCampaignExcludeAdd(1, { personIdsFile: "ids.txt" });
+
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it("prints JSON with --json", async () => {
+    setupSuccessPath();
+
+    await handleCampaignExcludeAdd(1, { personIds: "100,200", json: true });
+
+    expect(process.exitCode).toBeUndefined();
+    const parsed = JSON.parse(getStdout());
+    expect(parsed.success).toBe(true);
+    expect(parsed.campaignId).toBe(1);
+    expect(parsed.level).toBe("campaign");
+    expect(parsed.added).toBe(2);
+    expect(parsed.alreadyExcluded).toBe(0);
+  });
+
+  it("includes actionId in JSON when action-level", async () => {
+    setupSuccessPath();
+
+    await handleCampaignExcludeAdd(1, {
+      personIds: "100",
+      actionId: 10,
+      json: true,
+    });
+
+    const parsed = JSON.parse(getStdout());
+    expect(parsed.actionId).toBe(10);
+    expect(parsed.level).toBe("action");
+  });
+
+  it("sets exitCode 1 when both person-ids options provided", async () => {
+    await handleCampaignExcludeAdd(1, {
+      personIds: "100",
+      personIdsFile: "ids.txt",
+    });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "Use only one of --person-ids or --person-ids-file.\n",
+    );
+  });
+
+  it("sets exitCode 1 when no person-ids option provided", async () => {
+    await handleCampaignExcludeAdd(1, {});
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "Either --person-ids or --person-ids-file is required.\n",
+    );
+  });
+
+  it("sets exitCode 1 when person IDs are empty", async () => {
+    vi.mocked(readFileSync).mockReturnValue("");
+
+    await handleCampaignExcludeAdd(1, { personIdsFile: "empty.txt" });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("No person IDs provided.\n");
+  });
+
+  it("sets exitCode 1 when campaign not found", async () => {
+    mockResolveAccount();
+    mockWithDatabase();
+    vi.mocked(CampaignRepository).mockImplementation(function () {
+      return {
+        addToExcludeList: vi.fn().mockImplementation(() => {
+          throw new CampaignNotFoundError(999);
+        }),
+      } as unknown as CampaignRepository;
+    });
+
+    await handleCampaignExcludeAdd(999, { personIds: "100" });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("Campaign 999 not found.\n");
+  });
+
+  it("sets exitCode 1 when action not found", async () => {
+    mockResolveAccount();
+    mockWithDatabase();
+    vi.mocked(CampaignRepository).mockImplementation(function () {
+      return {
+        addToExcludeList: vi.fn().mockImplementation(() => {
+          throw new ActionNotFoundError(99, 1);
+        }),
+      } as unknown as CampaignRepository;
+    });
+
+    await handleCampaignExcludeAdd(1, { personIds: "100", actionId: 99 });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "Action 99 not found in campaign 1.\n",
+    );
+  });
+
+  it("sets exitCode 1 on ExcludeListNotFoundError", async () => {
+    mockResolveAccount();
+    mockWithDatabase();
+    vi.mocked(CampaignRepository).mockImplementation(function () {
+      return {
+        addToExcludeList: vi.fn().mockImplementation(() => {
+          throw new ExcludeListNotFoundError("campaign", 1);
+        }),
+      } as unknown as CampaignRepository;
+    });
+
+    await handleCampaignExcludeAdd(1, { personIds: "100" });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "Exclude list not found for campaign 1\n",
+    );
+  });
+
+  it("sets exitCode 1 when resolveAccount fails", async () => {
+    vi.mocked(resolveAccount).mockRejectedValue(new Error("timeout"));
+
+    await handleCampaignExcludeAdd(1, { personIds: "100" });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("timeout\n");
+  });
+});

--- a/packages/cli/src/handlers/campaign-exclude-list.test.ts
+++ b/packages/cli/src/handlers/campaign-exclude-list.test.ts
@@ -1,0 +1,183 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return {
+    ...actual,
+    resolveAccount: vi.fn(),
+    withDatabase: vi.fn(),
+    CampaignRepository: vi.fn(),
+  };
+});
+
+import {
+  ActionNotFoundError,
+  CampaignNotFoundError,
+  CampaignRepository,
+  ExcludeListNotFoundError,
+  resolveAccount,
+} from "@lhremote/core";
+
+import { handleCampaignExcludeList } from "./campaign-exclude-list.js";
+import { mockResolveAccount, mockWithDatabase } from "./testing/mock-helpers.js";
+
+const MOCK_ENTRIES = [{ personId: 100 }, { personId: 200 }];
+
+function mockRepo(entries = MOCK_ENTRIES) {
+  vi.mocked(CampaignRepository).mockImplementation(function () {
+    return {
+      getExcludeList: vi.fn().mockReturnValue(entries),
+    } as unknown as CampaignRepository;
+  });
+}
+
+function setupSuccessPath() {
+  mockResolveAccount();
+  mockWithDatabase();
+  mockRepo();
+}
+
+describe("handleCampaignExcludeList", () => {
+  const originalExitCode = process.exitCode;
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    process.exitCode = undefined;
+    vi.clearAllMocks();
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    process.exitCode = originalExitCode;
+    vi.restoreAllMocks();
+  });
+
+  function getStdout(): string {
+    return stdoutSpy.mock.calls
+      .map((call: unknown[]) => String(call[0]))
+      .join("");
+  }
+
+  it("prints campaign-level exclude list", async () => {
+    setupSuccessPath();
+
+    await handleCampaignExcludeList(1, {});
+
+    expect(process.exitCode).toBeUndefined();
+    const output = getStdout();
+    expect(output).toContain("Exclude list for campaign 1: 2 person(s)");
+    expect(output).toContain("Person IDs: 100, 200");
+  });
+
+  it("prints action-level exclude list", async () => {
+    setupSuccessPath();
+
+    await handleCampaignExcludeList(1, { actionId: 10 });
+
+    expect(process.exitCode).toBeUndefined();
+    expect(getStdout()).toContain(
+      "Exclude list for action 10 in campaign 1: 2 person(s)",
+    );
+  });
+
+  it("does not print person IDs when list is empty", async () => {
+    mockResolveAccount();
+    mockWithDatabase();
+    mockRepo([]);
+
+    await handleCampaignExcludeList(1, {});
+
+    const output = getStdout();
+    expect(output).toContain("0 person(s)");
+    expect(output).not.toContain("Person IDs:");
+  });
+
+  it("prints JSON with --json", async () => {
+    setupSuccessPath();
+
+    await handleCampaignExcludeList(1, { json: true });
+
+    expect(process.exitCode).toBeUndefined();
+    const parsed = JSON.parse(getStdout());
+    expect(parsed.campaignId).toBe(1);
+    expect(parsed.level).toBe("campaign");
+    expect(parsed.count).toBe(2);
+    expect(parsed.personIds).toEqual([100, 200]);
+  });
+
+  it("includes actionId in JSON when action-level", async () => {
+    setupSuccessPath();
+
+    await handleCampaignExcludeList(1, { actionId: 10, json: true });
+
+    const parsed = JSON.parse(getStdout());
+    expect(parsed.actionId).toBe(10);
+    expect(parsed.level).toBe("action");
+  });
+
+  it("sets exitCode 1 when campaign not found", async () => {
+    mockResolveAccount();
+    mockWithDatabase();
+    vi.mocked(CampaignRepository).mockImplementation(function () {
+      return {
+        getExcludeList: vi.fn().mockImplementation(() => {
+          throw new CampaignNotFoundError(999);
+        }),
+      } as unknown as CampaignRepository;
+    });
+
+    await handleCampaignExcludeList(999, {});
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("Campaign 999 not found.\n");
+  });
+
+  it("sets exitCode 1 when action not found", async () => {
+    mockResolveAccount();
+    mockWithDatabase();
+    vi.mocked(CampaignRepository).mockImplementation(function () {
+      return {
+        getExcludeList: vi.fn().mockImplementation(() => {
+          throw new ActionNotFoundError(99, 1);
+        }),
+      } as unknown as CampaignRepository;
+    });
+
+    await handleCampaignExcludeList(1, { actionId: 99 });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "Action 99 not found in campaign 1.\n",
+    );
+  });
+
+  it("sets exitCode 1 on ExcludeListNotFoundError", async () => {
+    mockResolveAccount();
+    mockWithDatabase();
+    vi.mocked(CampaignRepository).mockImplementation(function () {
+      return {
+        getExcludeList: vi.fn().mockImplementation(() => {
+          throw new ExcludeListNotFoundError("campaign", 1);
+        }),
+      } as unknown as CampaignRepository;
+    });
+
+    await handleCampaignExcludeList(1, {});
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "Exclude list not found for campaign 1\n",
+    );
+  });
+
+  it("sets exitCode 1 when resolveAccount fails", async () => {
+    vi.mocked(resolveAccount).mockRejectedValue(new Error("timeout"));
+
+    await handleCampaignExcludeList(1, {});
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("timeout\n");
+  });
+});

--- a/packages/cli/src/handlers/campaign-exclude-remove.test.ts
+++ b/packages/cli/src/handlers/campaign-exclude-remove.test.ts
@@ -1,0 +1,237 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return {
+    ...actual,
+    resolveAccount: vi.fn(),
+    withDatabase: vi.fn(),
+    CampaignRepository: vi.fn(),
+  };
+});
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    readFileSync: vi.fn(),
+  };
+});
+
+import {
+  ActionNotFoundError,
+  CampaignNotFoundError,
+  CampaignRepository,
+  ExcludeListNotFoundError,
+  resolveAccount,
+} from "@lhremote/core";
+import { readFileSync } from "node:fs";
+
+import { handleCampaignExcludeRemove } from "./campaign-exclude-remove.js";
+import { mockResolveAccount, mockWithDatabase } from "./testing/mock-helpers.js";
+
+function mockRepo(removed = 2) {
+  const removeFromExcludeList = vi.fn().mockReturnValue(removed);
+  vi.mocked(CampaignRepository).mockImplementation(function () {
+    return { removeFromExcludeList } as unknown as CampaignRepository;
+  });
+  return { removeFromExcludeList };
+}
+
+function setupSuccessPath() {
+  mockResolveAccount();
+  mockWithDatabase();
+  return mockRepo();
+}
+
+describe("handleCampaignExcludeRemove", () => {
+  const originalExitCode = process.exitCode;
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    process.exitCode = undefined;
+    vi.clearAllMocks();
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    process.exitCode = originalExitCode;
+    vi.restoreAllMocks();
+  });
+
+  function getStdout(): string {
+    return stdoutSpy.mock.calls
+      .map((call: unknown[]) => String(call[0]))
+      .join("");
+  }
+
+  it("removes persons from campaign-level exclude list", async () => {
+    setupSuccessPath();
+
+    await handleCampaignExcludeRemove(1, { personIds: "100,200" });
+
+    expect(process.exitCode).toBeUndefined();
+    expect(getStdout()).toContain(
+      "Removed 2 person(s) from exclude list for campaign 1.",
+    );
+  });
+
+  it("removes persons from action-level exclude list", async () => {
+    setupSuccessPath();
+
+    await handleCampaignExcludeRemove(1, {
+      personIds: "100,200",
+      actionId: 10,
+    });
+
+    expect(process.exitCode).toBeUndefined();
+    expect(getStdout()).toContain(
+      "Removed 2 person(s) from exclude list for action 10 in campaign 1.",
+    );
+  });
+
+  it("shows not-in-list count", async () => {
+    mockResolveAccount();
+    mockWithDatabase();
+    mockRepo(1); // only 1 of 2 actually removed
+
+    await handleCampaignExcludeRemove(1, { personIds: "100,200" });
+
+    const output = getStdout();
+    expect(output).toContain("Removed 1 person(s)");
+    expect(output).toContain("1 person(s) were not in the exclude list.");
+  });
+
+  it("reads from --person-ids-file", async () => {
+    setupSuccessPath();
+    vi.mocked(readFileSync).mockReturnValue("100\n200");
+
+    await handleCampaignExcludeRemove(1, { personIdsFile: "ids.txt" });
+
+    expect(process.exitCode).toBeUndefined();
+  });
+
+  it("prints JSON with --json", async () => {
+    setupSuccessPath();
+
+    await handleCampaignExcludeRemove(1, { personIds: "100,200", json: true });
+
+    expect(process.exitCode).toBeUndefined();
+    const parsed = JSON.parse(getStdout());
+    expect(parsed.success).toBe(true);
+    expect(parsed.campaignId).toBe(1);
+    expect(parsed.level).toBe("campaign");
+    expect(parsed.removed).toBe(2);
+    expect(parsed.notInList).toBe(0);
+  });
+
+  it("includes actionId in JSON when action-level", async () => {
+    setupSuccessPath();
+
+    await handleCampaignExcludeRemove(1, {
+      personIds: "100",
+      actionId: 10,
+      json: true,
+    });
+
+    const parsed = JSON.parse(getStdout());
+    expect(parsed.actionId).toBe(10);
+    expect(parsed.level).toBe("action");
+  });
+
+  it("sets exitCode 1 when both person-ids options provided", async () => {
+    await handleCampaignExcludeRemove(1, {
+      personIds: "100",
+      personIdsFile: "ids.txt",
+    });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "Use only one of --person-ids or --person-ids-file.\n",
+    );
+  });
+
+  it("sets exitCode 1 when no person-ids option provided", async () => {
+    await handleCampaignExcludeRemove(1, {});
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "Either --person-ids or --person-ids-file is required.\n",
+    );
+  });
+
+  it("sets exitCode 1 when person IDs are empty", async () => {
+    vi.mocked(readFileSync).mockReturnValue("");
+
+    await handleCampaignExcludeRemove(1, { personIdsFile: "empty.txt" });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("No person IDs provided.\n");
+  });
+
+  it("sets exitCode 1 when campaign not found", async () => {
+    mockResolveAccount();
+    mockWithDatabase();
+    vi.mocked(CampaignRepository).mockImplementation(function () {
+      return {
+        removeFromExcludeList: vi.fn().mockImplementation(() => {
+          throw new CampaignNotFoundError(999);
+        }),
+      } as unknown as CampaignRepository;
+    });
+
+    await handleCampaignExcludeRemove(999, { personIds: "100" });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("Campaign 999 not found.\n");
+  });
+
+  it("sets exitCode 1 when action not found", async () => {
+    mockResolveAccount();
+    mockWithDatabase();
+    vi.mocked(CampaignRepository).mockImplementation(function () {
+      return {
+        removeFromExcludeList: vi.fn().mockImplementation(() => {
+          throw new ActionNotFoundError(99, 1);
+        }),
+      } as unknown as CampaignRepository;
+    });
+
+    await handleCampaignExcludeRemove(1, { personIds: "100", actionId: 99 });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "Action 99 not found in campaign 1.\n",
+    );
+  });
+
+  it("sets exitCode 1 on ExcludeListNotFoundError", async () => {
+    mockResolveAccount();
+    mockWithDatabase();
+    vi.mocked(CampaignRepository).mockImplementation(function () {
+      return {
+        removeFromExcludeList: vi.fn().mockImplementation(() => {
+          throw new ExcludeListNotFoundError("campaign", 1);
+        }),
+      } as unknown as CampaignRepository;
+    });
+
+    await handleCampaignExcludeRemove(1, { personIds: "100" });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "Exclude list not found for campaign 1\n",
+    );
+  });
+
+  it("sets exitCode 1 when resolveAccount fails", async () => {
+    vi.mocked(resolveAccount).mockRejectedValue(new Error("timeout"));
+
+    await handleCampaignExcludeRemove(1, { personIds: "100" });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("timeout\n");
+  });
+});

--- a/packages/cli/src/handlers/campaign-export.test.ts
+++ b/packages/cli/src/handlers/campaign-export.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return {
+    ...actual,
+    resolveAccount: vi.fn(),
+    withDatabase: vi.fn(),
+    CampaignRepository: vi.fn(),
+    serializeCampaignJson: vi.fn(),
+    serializeCampaignYaml: vi.fn(),
+  };
+});
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    writeFileSync: vi.fn(),
+  };
+});
+
+import {
+  CampaignNotFoundError,
+  CampaignRepository,
+  resolveAccount,
+  serializeCampaignJson,
+  serializeCampaignYaml,
+} from "@lhremote/core";
+import { writeFileSync } from "node:fs";
+
+import { handleCampaignExport } from "./campaign-export.js";
+import { mockResolveAccount, mockWithDatabase } from "./testing/mock-helpers.js";
+
+const MOCK_CAMPAIGN = { id: 1, name: "Test Campaign" };
+const MOCK_ACTIONS = [{ id: 10, name: "Visit" }];
+
+function mockRepo(campaign = MOCK_CAMPAIGN, actions = MOCK_ACTIONS) {
+  vi.mocked(CampaignRepository).mockImplementation(function () {
+    return {
+      getCampaign: vi.fn().mockReturnValue(campaign),
+      getCampaignActions: vi.fn().mockReturnValue(actions),
+    } as unknown as CampaignRepository;
+  });
+}
+
+function setupSuccessPath() {
+  mockResolveAccount();
+  mockWithDatabase();
+  mockRepo();
+  vi.mocked(serializeCampaignYaml).mockReturnValue("name: Test Campaign\n");
+  vi.mocked(serializeCampaignJson).mockReturnValue('{"name":"Test Campaign"}\n');
+}
+
+describe("handleCampaignExport", () => {
+  const originalExitCode = process.exitCode;
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    process.exitCode = undefined;
+    vi.clearAllMocks();
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    process.exitCode = originalExitCode;
+    vi.restoreAllMocks();
+  });
+
+  function getStdout(): string {
+    return stdoutSpy.mock.calls
+      .map((call: unknown[]) => String(call[0]))
+      .join("");
+  }
+
+  it("exports campaign as YAML to stdout by default", async () => {
+    setupSuccessPath();
+
+    await handleCampaignExport(1, {});
+
+    expect(process.exitCode).toBeUndefined();
+    expect(serializeCampaignYaml).toHaveBeenCalled();
+    expect(getStdout()).toContain("name: Test Campaign");
+  });
+
+  it("exports campaign as JSON when --format json", async () => {
+    setupSuccessPath();
+
+    await handleCampaignExport(1, { format: "json" });
+
+    expect(process.exitCode).toBeUndefined();
+    expect(serializeCampaignJson).toHaveBeenCalled();
+  });
+
+  it("writes to file when --output specified", async () => {
+    setupSuccessPath();
+
+    await handleCampaignExport(1, { output: "campaign.yaml" });
+
+    expect(process.exitCode).toBeUndefined();
+    expect(writeFileSync).toHaveBeenCalledWith(
+      "campaign.yaml",
+      "name: Test Campaign\n",
+      "utf-8",
+    );
+    expect(getStdout()).toContain("Campaign 1 exported to campaign.yaml");
+  });
+
+  it("sets exitCode 1 on unsupported format", async () => {
+    await handleCampaignExport(1, { format: "xml" });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      'Unsupported format "xml". Use "yaml" or "json".\n',
+    );
+  });
+
+  it("sets exitCode 1 when campaign not found", async () => {
+    mockResolveAccount();
+    mockWithDatabase();
+    vi.mocked(CampaignRepository).mockImplementation(function () {
+      return {
+        getCampaign: vi.fn().mockImplementation(() => {
+          throw new CampaignNotFoundError(999);
+        }),
+        getCampaignActions: vi.fn(),
+      } as unknown as CampaignRepository;
+    });
+
+    await handleCampaignExport(999, {});
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("Campaign 999 not found.\n");
+  });
+
+  it("sets exitCode 1 when resolveAccount fails", async () => {
+    vi.mocked(resolveAccount).mockRejectedValue(new Error("timeout"));
+
+    await handleCampaignExport(1, {});
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("timeout\n");
+  });
+});

--- a/packages/cli/src/handlers/campaign-get.test.ts
+++ b/packages/cli/src/handlers/campaign-get.test.ts
@@ -1,0 +1,184 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return {
+    ...actual,
+    resolveAccount: vi.fn(),
+    withDatabase: vi.fn(),
+    CampaignRepository: vi.fn(),
+  };
+});
+
+import {
+  CampaignNotFoundError,
+  CampaignRepository,
+  resolveAccount,
+} from "@lhremote/core";
+
+import { handleCampaignGet } from "./campaign-get.js";
+import { mockResolveAccount, mockWithDatabase } from "./testing/mock-helpers.js";
+
+const MOCK_CAMPAIGN = {
+  id: 1,
+  name: "Outreach Q1",
+  state: "running",
+  isPaused: false,
+  isArchived: false,
+  description: "Q1 outreach campaign",
+  createdAt: "2025-01-01T00:00:00Z",
+  liAccountId: 42,
+};
+
+const MOCK_ACTIONS = [
+  {
+    id: 10,
+    name: "Visit Profile",
+    config: { actionType: "VisitAndExtract" },
+  },
+  {
+    id: 11,
+    name: "Send Message",
+    config: { actionType: "MessageToPerson" },
+  },
+];
+
+function mockRepo(
+  campaign = MOCK_CAMPAIGN,
+  actions = MOCK_ACTIONS,
+) {
+  vi.mocked(CampaignRepository).mockImplementation(function () {
+    return {
+      getCampaign: vi.fn().mockReturnValue(campaign),
+      getCampaignActions: vi.fn().mockReturnValue(actions),
+    } as unknown as CampaignRepository;
+  });
+}
+
+function setupSuccessPath() {
+  mockResolveAccount();
+  mockWithDatabase();
+  mockRepo();
+}
+
+describe("handleCampaignGet", () => {
+  const originalExitCode = process.exitCode;
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    process.exitCode = undefined;
+    vi.clearAllMocks();
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    process.exitCode = originalExitCode;
+    vi.restoreAllMocks();
+  });
+
+  function getStdout(): string {
+    return stdoutSpy.mock.calls
+      .map((call: unknown[]) => String(call[0]))
+      .join("");
+  }
+
+  it("prints JSON with --json", async () => {
+    setupSuccessPath();
+
+    await handleCampaignGet(1, { json: true });
+
+    expect(process.exitCode).toBeUndefined();
+    const parsed = JSON.parse(getStdout());
+    expect(parsed.id).toBe(1);
+    expect(parsed.name).toBe("Outreach Q1");
+    expect(parsed.actions).toHaveLength(2);
+  });
+
+  it("prints human-readable output", async () => {
+    setupSuccessPath();
+
+    await handleCampaignGet(1, {});
+
+    expect(process.exitCode).toBeUndefined();
+    const output = getStdout();
+    expect(output).toContain("Campaign #1: Outreach Q1");
+    expect(output).toContain("State: running");
+    expect(output).toContain("Paused: no");
+    expect(output).toContain("Archived: no");
+    expect(output).toContain("Description: Q1 outreach campaign");
+    expect(output).toContain("Actions (2):");
+    expect(output).toContain("#10  Visit Profile [VisitAndExtract]");
+    expect(output).toContain("#11  Send Message [MessageToPerson]");
+  });
+
+  it("omits description when absent", async () => {
+    mockResolveAccount();
+    mockWithDatabase();
+    mockRepo({ ...MOCK_CAMPAIGN, description: null as unknown as string }, []);
+
+    await handleCampaignGet(1, {});
+
+    const output = getStdout();
+    expect(output).not.toContain("Description:");
+  });
+
+  it("omits actions section when empty", async () => {
+    mockResolveAccount();
+    mockWithDatabase();
+    mockRepo(MOCK_CAMPAIGN, []);
+
+    await handleCampaignGet(1, {});
+
+    const output = getStdout();
+    expect(output).not.toContain("Actions");
+  });
+
+  it("sets exitCode 1 when campaign not found", async () => {
+    mockResolveAccount();
+    mockWithDatabase();
+    vi.mocked(CampaignRepository).mockImplementation(function () {
+      return {
+        getCampaign: vi.fn().mockImplementation(() => {
+          throw new CampaignNotFoundError(999);
+        }),
+        getCampaignActions: vi.fn(),
+      } as unknown as CampaignRepository;
+    });
+
+    await handleCampaignGet(999, {});
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("Campaign 999 not found.\n");
+  });
+
+  it("sets exitCode 1 when resolveAccount fails", async () => {
+    vi.mocked(resolveAccount).mockRejectedValue(
+      new Error("No accounts found."),
+    );
+
+    await handleCampaignGet(1, {});
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("No accounts found.\n");
+  });
+
+  it("sets exitCode 1 on unexpected error", async () => {
+    mockResolveAccount();
+    mockWithDatabase();
+    vi.mocked(CampaignRepository).mockImplementation(function () {
+      return {
+        getCampaign: vi.fn().mockImplementation(() => {
+          throw new Error("disk failure");
+        }),
+        getCampaignActions: vi.fn(),
+      } as unknown as CampaignRepository;
+    });
+
+    await handleCampaignGet(1, {});
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("disk failure\n");
+  });
+});

--- a/packages/cli/src/handlers/campaign-list.test.ts
+++ b/packages/cli/src/handlers/campaign-list.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return {
+    ...actual,
+    DatabaseClient: vi.fn(),
+    CampaignRepository: vi.fn(),
+    discoverAllDatabases: vi.fn(),
+  };
+});
+
+import { type CampaignSummary, CampaignRepository } from "@lhremote/core";
+
+import { handleCampaignList } from "./campaign-list.js";
+import { mockDb, mockDiscovery } from "./testing/mock-helpers.js";
+
+const MOCK_CAMPAIGNS: CampaignSummary[] = [
+  {
+    id: 1,
+    name: "Outreach Q1",
+    state: "active",
+    liAccountId: 42,
+    actionCount: 3,
+    createdAt: "2025-01-01T00:00:00Z",
+    description: "Q1 outreach campaign",
+  },
+  {
+    id: 2,
+    name: "Follow-Up",
+    state: "paused",
+    liAccountId: 42,
+    actionCount: 1,
+    createdAt: "2025-01-02T00:00:00Z",
+    description: null,
+  },
+];
+
+function mockRepo(campaigns: CampaignSummary[] = MOCK_CAMPAIGNS) {
+  vi.mocked(CampaignRepository).mockImplementation(function () {
+    return {
+      listCampaigns: vi.fn().mockReturnValue(campaigns),
+    } as unknown as CampaignRepository;
+  });
+}
+
+function setupSuccessPath() {
+  mockDiscovery();
+  mockDb();
+  mockRepo();
+}
+
+describe("handleCampaignList", () => {
+  const originalExitCode = process.exitCode;
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    process.exitCode = undefined;
+    vi.clearAllMocks();
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    process.exitCode = originalExitCode;
+    vi.restoreAllMocks();
+  });
+
+  function getStdout(): string {
+    return stdoutSpy.mock.calls
+      .map((call: unknown[]) => String(call[0]))
+      .join("");
+  }
+
+  it("prints JSON with --json", async () => {
+    setupSuccessPath();
+
+    await handleCampaignList({ json: true });
+
+    expect(process.exitCode).toBeUndefined();
+    const parsed = JSON.parse(getStdout());
+    expect(parsed.campaigns).toHaveLength(2);
+    expect(parsed.total).toBe(2);
+  });
+
+  it("prints human-readable output", async () => {
+    setupSuccessPath();
+
+    await handleCampaignList({});
+
+    expect(process.exitCode).toBeUndefined();
+    const output = getStdout();
+    expect(output).toContain("Campaigns (2 total):");
+    expect(output).toContain("#1  Outreach Q1");
+    expect(output).toContain("[active]");
+    expect(output).toContain("3 actions");
+    expect(output).toContain("Q1 outreach campaign");
+    expect(output).toContain("#2  Follow-Up");
+    expect(output).toContain("[paused]");
+  });
+
+  it("prints 'No campaigns found' when empty", async () => {
+    mockDiscovery();
+    mockDb();
+    mockRepo([]);
+
+    await handleCampaignList({});
+
+    expect(process.exitCode).toBeUndefined();
+    expect(getStdout()).toContain("No campaigns found.");
+  });
+
+  it("sets exitCode 1 when no databases found", async () => {
+    mockDiscovery(new Map());
+
+    await handleCampaignList({});
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "No LinkedHelper databases found.\n",
+    );
+  });
+
+  it("passes includeArchived option to repository", async () => {
+    mockDiscovery();
+    mockDb();
+    const listCampaigns = vi.fn().mockReturnValue([]);
+    vi.mocked(CampaignRepository).mockImplementation(function () {
+      return { listCampaigns } as unknown as CampaignRepository;
+    });
+
+    await handleCampaignList({ includeArchived: true });
+
+    expect(listCampaigns).toHaveBeenCalledWith({ includeArchived: true });
+  });
+
+  it("closes database after listing", async () => {
+    mockDiscovery();
+    const { close } = mockDb();
+    mockRepo();
+
+    await handleCampaignList({});
+
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("sets exitCode 1 on database error", async () => {
+    mockDiscovery();
+    mockDb();
+    vi.mocked(CampaignRepository).mockImplementation(function () {
+      return {
+        listCampaigns: vi.fn().mockImplementation(() => {
+          throw new Error("database locked");
+        }),
+      } as unknown as CampaignRepository;
+    });
+
+    await handleCampaignList({});
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining("database locked"),
+    );
+  });
+});

--- a/packages/cli/src/handlers/campaign-move-next.test.ts
+++ b/packages/cli/src/handlers/campaign-move-next.test.ts
@@ -1,0 +1,215 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return {
+    ...actual,
+    resolveAccount: vi.fn(),
+    withDatabase: vi.fn(),
+    CampaignRepository: vi.fn(),
+  };
+});
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    readFileSync: vi.fn(),
+  };
+});
+
+import {
+  ActionNotFoundError,
+  CampaignNotFoundError,
+  CampaignRepository,
+  NoNextActionError,
+  resolveAccount,
+} from "@lhremote/core";
+import { readFileSync } from "node:fs";
+
+import { handleCampaignMoveNext } from "./campaign-move-next.js";
+import { mockResolveAccount, mockWithDatabase } from "./testing/mock-helpers.js";
+
+function mockRepo(nextActionId = 11) {
+  const moveToNextAction = vi.fn().mockReturnValue({ nextActionId });
+  vi.mocked(CampaignRepository).mockImplementation(function () {
+    return { moveToNextAction } as unknown as CampaignRepository;
+  });
+  return { moveToNextAction };
+}
+
+function setupSuccessPath() {
+  mockResolveAccount();
+  mockWithDatabase();
+  return mockRepo();
+}
+
+describe("handleCampaignMoveNext", () => {
+  const originalExitCode = process.exitCode;
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    process.exitCode = undefined;
+    vi.clearAllMocks();
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    process.exitCode = originalExitCode;
+    vi.restoreAllMocks();
+  });
+
+  function getStdout(): string {
+    return stdoutSpy.mock.calls
+      .map((call: unknown[]) => String(call[0]))
+      .join("");
+  }
+
+  it("moves persons to next action with --person-ids", async () => {
+    setupSuccessPath();
+
+    await handleCampaignMoveNext(1, 10, { personIds: "100,200" });
+
+    expect(process.exitCode).toBeUndefined();
+    expect(getStdout()).toContain(
+      "Campaign 1: 2 persons moved from action 10 to action 11.",
+    );
+  });
+
+  it("moves persons with --person-ids-file", async () => {
+    setupSuccessPath();
+    vi.mocked(readFileSync).mockReturnValue("100\n200\n300");
+
+    await handleCampaignMoveNext(1, 10, { personIdsFile: "ids.txt" });
+
+    expect(process.exitCode).toBeUndefined();
+    expect(getStdout()).toContain("3 persons moved");
+  });
+
+  it("prints JSON with --json", async () => {
+    setupSuccessPath();
+
+    await handleCampaignMoveNext(1, 10, { personIds: "100", json: true });
+
+    expect(process.exitCode).toBeUndefined();
+    const parsed = JSON.parse(getStdout());
+    expect(parsed.success).toBe(true);
+    expect(parsed.campaignId).toBe(1);
+    expect(parsed.fromActionId).toBe(10);
+    expect(parsed.toActionId).toBe(11);
+    expect(parsed.personsMoved).toBe(1);
+  });
+
+  it("passes person IDs to repository", async () => {
+    const { moveToNextAction } = setupSuccessPath();
+
+    await handleCampaignMoveNext(1, 10, { personIds: "100,200" });
+
+    expect(moveToNextAction).toHaveBeenCalledWith(1, 10, [100, 200]);
+  });
+
+  it("sets exitCode 1 when both person-ids options provided", async () => {
+    await handleCampaignMoveNext(1, 10, {
+      personIds: "100",
+      personIdsFile: "ids.txt",
+    });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "Use only one of --person-ids or --person-ids-file.\n",
+    );
+  });
+
+  it("sets exitCode 1 when no person-ids option provided", async () => {
+    await handleCampaignMoveNext(1, 10, {});
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "Either --person-ids or --person-ids-file is required.\n",
+    );
+  });
+
+  it("sets exitCode 1 when person IDs are empty", async () => {
+    vi.mocked(readFileSync).mockReturnValue("");
+
+    await handleCampaignMoveNext(1, 10, { personIdsFile: "empty.txt" });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("No person IDs provided.\n");
+  });
+
+  it("sets exitCode 1 on invalid person ID", async () => {
+    await handleCampaignMoveNext(1, 10, { personIds: "100,abc" });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Invalid person ID: "abc"'),
+    );
+  });
+
+  it("sets exitCode 1 when campaign not found", async () => {
+    mockResolveAccount();
+    mockWithDatabase();
+    vi.mocked(CampaignRepository).mockImplementation(function () {
+      return {
+        moveToNextAction: vi.fn().mockImplementation(() => {
+          throw new CampaignNotFoundError(999);
+        }),
+      } as unknown as CampaignRepository;
+    });
+
+    await handleCampaignMoveNext(999, 10, { personIds: "100" });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("Campaign 999 not found.\n");
+  });
+
+  it("sets exitCode 1 when action not found", async () => {
+    mockResolveAccount();
+    mockWithDatabase();
+    vi.mocked(CampaignRepository).mockImplementation(function () {
+      return {
+        moveToNextAction: vi.fn().mockImplementation(() => {
+          throw new ActionNotFoundError(99, 1);
+        }),
+      } as unknown as CampaignRepository;
+    });
+
+    await handleCampaignMoveNext(1, 99, { personIds: "100" });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "Action 99 not found in campaign 1.\n",
+    );
+  });
+
+  it("sets exitCode 1 when no next action", async () => {
+    mockResolveAccount();
+    mockWithDatabase();
+    vi.mocked(CampaignRepository).mockImplementation(function () {
+      return {
+        moveToNextAction: vi.fn().mockImplementation(() => {
+          throw new NoNextActionError(10, 1);
+        }),
+      } as unknown as CampaignRepository;
+    });
+
+    await handleCampaignMoveNext(1, 10, { personIds: "100" });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "Action 10 is the last action in campaign 1.\n",
+    );
+  });
+
+  it("sets exitCode 1 when resolveAccount fails", async () => {
+    vi.mocked(resolveAccount).mockRejectedValue(new Error("timeout"));
+
+    await handleCampaignMoveNext(1, 10, { personIds: "100" });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("timeout\n");
+  });
+});

--- a/packages/cli/src/handlers/campaign-remove-action.test.ts
+++ b/packages/cli/src/handlers/campaign-remove-action.test.ts
@@ -1,0 +1,162 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return {
+    ...actual,
+    resolveAccount: vi.fn(),
+    withInstanceDatabase: vi.fn(),
+    CampaignService: vi.fn(),
+  };
+});
+
+import {
+  ActionNotFoundError,
+  CampaignExecutionError,
+  CampaignNotFoundError,
+  CampaignService,
+  InstanceNotRunningError,
+  resolveAccount,
+  withInstanceDatabase,
+} from "@lhremote/core";
+
+import { handleCampaignRemoveAction } from "./campaign-remove-action.js";
+import {
+  mockResolveAccount,
+  mockWithInstanceDatabase,
+} from "./testing/mock-helpers.js";
+
+function mockCampaignService() {
+  vi.mocked(CampaignService).mockImplementation(function () {
+    return {
+      removeAction: vi.fn().mockResolvedValue(undefined),
+    } as unknown as CampaignService;
+  });
+}
+
+function setupSuccessPath() {
+  mockResolveAccount();
+  mockWithInstanceDatabase();
+  mockCampaignService();
+}
+
+describe("handleCampaignRemoveAction", () => {
+  const originalExitCode = process.exitCode;
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    process.exitCode = undefined;
+    vi.clearAllMocks();
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    process.exitCode = originalExitCode;
+    vi.restoreAllMocks();
+  });
+
+  function getStdout(): string {
+    return stdoutSpy.mock.calls
+      .map((call: unknown[]) => String(call[0]))
+      .join("");
+  }
+
+  it("removes action and prints confirmation", async () => {
+    setupSuccessPath();
+
+    await handleCampaignRemoveAction(1, 10, {});
+
+    expect(process.exitCode).toBeUndefined();
+    expect(getStdout()).toContain("Action 10 removed from campaign 1.");
+  });
+
+  it("prints JSON with --json", async () => {
+    setupSuccessPath();
+
+    await handleCampaignRemoveAction(1, 10, { json: true });
+
+    expect(process.exitCode).toBeUndefined();
+    const parsed = JSON.parse(getStdout());
+    expect(parsed.success).toBe(true);
+    expect(parsed.campaignId).toBe(1);
+    expect(parsed.removedActionId).toBe(10);
+  });
+
+  it("sets exitCode 1 when campaign not found", async () => {
+    mockResolveAccount();
+    mockWithInstanceDatabase();
+    vi.mocked(CampaignService).mockImplementation(function () {
+      return {
+        removeAction: vi
+          .fn()
+          .mockRejectedValue(new CampaignNotFoundError(999)),
+      } as unknown as CampaignService;
+    });
+
+    await handleCampaignRemoveAction(999, 10, {});
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("Campaign 999 not found.\n");
+  });
+
+  it("sets exitCode 1 when action not found", async () => {
+    mockResolveAccount();
+    mockWithInstanceDatabase();
+    vi.mocked(CampaignService).mockImplementation(function () {
+      return {
+        removeAction: vi
+          .fn()
+          .mockRejectedValue(new ActionNotFoundError(99, 1)),
+      } as unknown as CampaignService;
+    });
+
+    await handleCampaignRemoveAction(1, 99, {});
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "Action 99 not found in campaign 1.\n",
+    );
+  });
+
+  it("sets exitCode 1 on CampaignExecutionError", async () => {
+    mockResolveAccount();
+    mockWithInstanceDatabase();
+    vi.mocked(CampaignService).mockImplementation(function () {
+      return {
+        removeAction: vi
+          .fn()
+          .mockRejectedValue(new CampaignExecutionError("in use")),
+      } as unknown as CampaignService;
+    });
+
+    await handleCampaignRemoveAction(1, 10, {});
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("Failed to remove action: in use\n");
+  });
+
+  it("sets exitCode 1 on InstanceNotRunningError", async () => {
+    mockResolveAccount();
+    vi.mocked(withInstanceDatabase).mockRejectedValue(
+      new InstanceNotRunningError("No LinkedHelper instance is running."),
+    );
+
+    await handleCampaignRemoveAction(1, 10, {});
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "No LinkedHelper instance is running.\n",
+    );
+  });
+
+  it("sets exitCode 1 when resolveAccount fails", async () => {
+    vi.mocked(resolveAccount).mockRejectedValue(new Error("timeout"));
+
+    await handleCampaignRemoveAction(1, 10, {});
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("timeout\n");
+  });
+});

--- a/packages/cli/src/handlers/campaign-reorder-actions.test.ts
+++ b/packages/cli/src/handlers/campaign-reorder-actions.test.ts
@@ -1,0 +1,181 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return {
+    ...actual,
+    resolveAccount: vi.fn(),
+    withInstanceDatabase: vi.fn(),
+    CampaignService: vi.fn(),
+  };
+});
+
+import {
+  ActionNotFoundError,
+  CampaignExecutionError,
+  CampaignNotFoundError,
+  CampaignService,
+  InstanceNotRunningError,
+  resolveAccount,
+  withInstanceDatabase,
+} from "@lhremote/core";
+
+import { handleCampaignReorderActions } from "./campaign-reorder-actions.js";
+import {
+  mockResolveAccount,
+  mockWithInstanceDatabase,
+} from "./testing/mock-helpers.js";
+
+const MOCK_REORDERED = [
+  { id: 2, name: "Send Message", config: { actionType: "MessageToPerson" } },
+  { id: 1, name: "Visit Profile", config: { actionType: "VisitAndExtract" } },
+];
+
+function mockCampaignService(reordered = MOCK_REORDERED) {
+  vi.mocked(CampaignService).mockImplementation(function () {
+    return {
+      reorderActions: vi.fn().mockResolvedValue(reordered),
+    } as unknown as CampaignService;
+  });
+}
+
+function setupSuccessPath() {
+  mockResolveAccount();
+  mockWithInstanceDatabase();
+  mockCampaignService();
+}
+
+describe("handleCampaignReorderActions", () => {
+  const originalExitCode = process.exitCode;
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    process.exitCode = undefined;
+    vi.clearAllMocks();
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    process.exitCode = originalExitCode;
+    vi.restoreAllMocks();
+  });
+
+  function getStdout(): string {
+    return stdoutSpy.mock.calls
+      .map((call: unknown[]) => String(call[0]))
+      .join("");
+  }
+
+  it("reorders actions and prints confirmation", async () => {
+    setupSuccessPath();
+
+    await handleCampaignReorderActions(1, { actionIds: "2,1" });
+
+    expect(process.exitCode).toBeUndefined();
+    const output = getStdout();
+    expect(output).toContain("Actions reordered in campaign 1.");
+    expect(output).toContain('#2 "Send Message" (MessageToPerson)');
+    expect(output).toContain('#1 "Visit Profile" (VisitAndExtract)');
+  });
+
+  it("prints JSON with --json", async () => {
+    setupSuccessPath();
+
+    await handleCampaignReorderActions(1, { actionIds: "2,1", json: true });
+
+    expect(process.exitCode).toBeUndefined();
+    const parsed = JSON.parse(getStdout());
+    expect(parsed.success).toBe(true);
+    expect(parsed.campaignId).toBe(1);
+    expect(parsed.actions).toHaveLength(2);
+  });
+
+  it("sets exitCode 1 on invalid action ID", async () => {
+    await handleCampaignReorderActions(1, { actionIds: "1,abc" });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Invalid action ID: "abc"'),
+    );
+  });
+
+  it("sets exitCode 1 when campaign not found", async () => {
+    mockResolveAccount();
+    mockWithInstanceDatabase();
+    vi.mocked(CampaignService).mockImplementation(function () {
+      return {
+        reorderActions: vi
+          .fn()
+          .mockRejectedValue(new CampaignNotFoundError(999)),
+      } as unknown as CampaignService;
+    });
+
+    await handleCampaignReorderActions(999, { actionIds: "1,2" });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("Campaign 999 not found.\n");
+  });
+
+  it("sets exitCode 1 when action not found", async () => {
+    mockResolveAccount();
+    mockWithInstanceDatabase();
+    vi.mocked(CampaignService).mockImplementation(function () {
+      return {
+        reorderActions: vi
+          .fn()
+          .mockRejectedValue(new ActionNotFoundError(99, 1)),
+      } as unknown as CampaignService;
+    });
+
+    await handleCampaignReorderActions(1, { actionIds: "99,1" });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "One or more action IDs not found in campaign 1.\n",
+    );
+  });
+
+  it("sets exitCode 1 on CampaignExecutionError", async () => {
+    mockResolveAccount();
+    mockWithInstanceDatabase();
+    vi.mocked(CampaignService).mockImplementation(function () {
+      return {
+        reorderActions: vi
+          .fn()
+          .mockRejectedValue(new CampaignExecutionError("count mismatch")),
+      } as unknown as CampaignService;
+    });
+
+    await handleCampaignReorderActions(1, { actionIds: "1" });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "Failed to reorder actions: count mismatch\n",
+    );
+  });
+
+  it("sets exitCode 1 on InstanceNotRunningError", async () => {
+    mockResolveAccount();
+    vi.mocked(withInstanceDatabase).mockRejectedValue(
+      new InstanceNotRunningError("No LinkedHelper instance is running."),
+    );
+
+    await handleCampaignReorderActions(1, { actionIds: "1,2" });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "No LinkedHelper instance is running.\n",
+    );
+  });
+
+  it("sets exitCode 1 when resolveAccount fails", async () => {
+    vi.mocked(resolveAccount).mockRejectedValue(new Error("timeout"));
+
+    await handleCampaignReorderActions(1, { actionIds: "1,2" });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("timeout\n");
+  });
+});

--- a/packages/cli/src/handlers/campaign-retry.test.ts
+++ b/packages/cli/src/handlers/campaign-retry.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return {
+    ...actual,
+    resolveAccount: vi.fn(),
+    withDatabase: vi.fn(),
+    CampaignRepository: vi.fn(),
+  };
+});
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    readFileSync: vi.fn(),
+  };
+});
+
+import {
+  CampaignNotFoundError,
+  CampaignRepository,
+  resolveAccount,
+} from "@lhremote/core";
+import { readFileSync } from "node:fs";
+
+import { handleCampaignRetry } from "./campaign-retry.js";
+import { mockResolveAccount, mockWithDatabase } from "./testing/mock-helpers.js";
+
+function mockRepo() {
+  const resetForRerun = vi.fn();
+  vi.mocked(CampaignRepository).mockImplementation(function () {
+    return { resetForRerun } as unknown as CampaignRepository;
+  });
+  return { resetForRerun };
+}
+
+function setupSuccessPath() {
+  mockResolveAccount();
+  mockWithDatabase();
+  return mockRepo();
+}
+
+describe("handleCampaignRetry", () => {
+  const originalExitCode = process.exitCode;
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    process.exitCode = undefined;
+    vi.clearAllMocks();
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    process.exitCode = originalExitCode;
+    vi.restoreAllMocks();
+  });
+
+  function getStdout(): string {
+    return stdoutSpy.mock.calls
+      .map((call: unknown[]) => String(call[0]))
+      .join("");
+  }
+
+  it("resets persons for retry with --person-ids", async () => {
+    setupSuccessPath();
+
+    await handleCampaignRetry(1, { personIds: "100,200" });
+
+    expect(process.exitCode).toBeUndefined();
+    expect(getStdout()).toContain("Campaign 1: 2 persons reset for retry.");
+  });
+
+  it("resets persons for retry with --person-ids-file", async () => {
+    setupSuccessPath();
+    vi.mocked(readFileSync).mockReturnValue("100\n200\n300");
+
+    await handleCampaignRetry(1, { personIdsFile: "ids.txt" });
+
+    expect(process.exitCode).toBeUndefined();
+    expect(getStdout()).toContain("3 persons reset for retry.");
+  });
+
+  it("prints JSON with --json", async () => {
+    setupSuccessPath();
+
+    await handleCampaignRetry(1, { personIds: "100", json: true });
+
+    expect(process.exitCode).toBeUndefined();
+    const parsed = JSON.parse(getStdout());
+    expect(parsed.success).toBe(true);
+    expect(parsed.campaignId).toBe(1);
+    expect(parsed.personsReset).toBe(1);
+  });
+
+  it("passes person IDs to repository", async () => {
+    const { resetForRerun } = setupSuccessPath();
+
+    await handleCampaignRetry(1, { personIds: "100,200" });
+
+    expect(resetForRerun).toHaveBeenCalledWith(1, [100, 200]);
+  });
+
+  it("sets exitCode 1 when both person-ids options provided", async () => {
+    await handleCampaignRetry(1, {
+      personIds: "100",
+      personIdsFile: "ids.txt",
+    });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "Use only one of --person-ids or --person-ids-file.\n",
+    );
+  });
+
+  it("sets exitCode 1 when no person-ids option provided", async () => {
+    await handleCampaignRetry(1, {});
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "Either --person-ids or --person-ids-file is required.\n",
+    );
+  });
+
+  it("sets exitCode 1 when person IDs are empty", async () => {
+    vi.mocked(readFileSync).mockReturnValue("");
+
+    await handleCampaignRetry(1, { personIdsFile: "empty.txt" });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("No person IDs provided.\n");
+  });
+
+  it("sets exitCode 1 on invalid person ID", async () => {
+    await handleCampaignRetry(1, { personIds: "100,abc" });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Invalid person ID: "abc"'),
+    );
+  });
+
+  it("sets exitCode 1 when campaign not found", async () => {
+    mockResolveAccount();
+    mockWithDatabase();
+    vi.mocked(CampaignRepository).mockImplementation(function () {
+      return {
+        resetForRerun: vi.fn().mockImplementation(() => {
+          throw new CampaignNotFoundError(999);
+        }),
+      } as unknown as CampaignRepository;
+    });
+
+    await handleCampaignRetry(999, { personIds: "100" });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("Campaign 999 not found.\n");
+  });
+
+  it("sets exitCode 1 when resolveAccount fails", async () => {
+    vi.mocked(resolveAccount).mockRejectedValue(new Error("timeout"));
+
+    await handleCampaignRetry(1, { personIds: "100" });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("timeout\n");
+  });
+});

--- a/packages/cli/src/handlers/campaign-start.test.ts
+++ b/packages/cli/src/handlers/campaign-start.test.ts
@@ -1,0 +1,220 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return {
+    ...actual,
+    resolveAccount: vi.fn(),
+    withInstanceDatabase: vi.fn(),
+    CampaignService: vi.fn(),
+  };
+});
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    readFileSync: vi.fn(),
+  };
+});
+
+import {
+  CampaignExecutionError,
+  CampaignNotFoundError,
+  CampaignService,
+  CampaignTimeoutError,
+  InstanceNotRunningError,
+  resolveAccount,
+  withInstanceDatabase,
+} from "@lhremote/core";
+import { readFileSync } from "node:fs";
+
+import { handleCampaignStart } from "./campaign-start.js";
+import {
+  mockResolveAccount,
+  mockWithInstanceDatabase,
+} from "./testing/mock-helpers.js";
+
+function mockCampaignService() {
+  vi.mocked(CampaignService).mockImplementation(function () {
+    return {
+      start: vi.fn().mockResolvedValue(undefined),
+    } as unknown as CampaignService;
+  });
+}
+
+function setupSuccessPath() {
+  mockResolveAccount();
+  mockWithInstanceDatabase();
+  mockCampaignService();
+}
+
+describe("handleCampaignStart", () => {
+  const originalExitCode = process.exitCode;
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    process.exitCode = undefined;
+    vi.clearAllMocks();
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    process.exitCode = originalExitCode;
+    vi.restoreAllMocks();
+  });
+
+  function getStdout(): string {
+    return stdoutSpy.mock.calls
+      .map((call: unknown[]) => String(call[0]))
+      .join("");
+  }
+
+  it("starts campaign with --person-ids", async () => {
+    setupSuccessPath();
+
+    await handleCampaignStart(1, { personIds: "100,200,300" });
+
+    expect(process.exitCode).toBeUndefined();
+    expect(getStdout()).toContain("Campaign 1 started with 3 persons queued.");
+  });
+
+  it("starts campaign with --person-ids-file", async () => {
+    setupSuccessPath();
+    vi.mocked(readFileSync).mockReturnValue("100\n200\n300");
+
+    await handleCampaignStart(1, { personIdsFile: "ids.txt" });
+
+    expect(process.exitCode).toBeUndefined();
+    expect(getStdout()).toContain("3 persons queued.");
+  });
+
+  it("prints JSON with --json", async () => {
+    setupSuccessPath();
+
+    await handleCampaignStart(1, { personIds: "100", json: true });
+
+    expect(process.exitCode).toBeUndefined();
+    const parsed = JSON.parse(getStdout());
+    expect(parsed.success).toBe(true);
+    expect(parsed.campaignId).toBe(1);
+    expect(parsed.personsQueued).toBe(1);
+  });
+
+  it("sets exitCode 1 when both person-ids options provided", async () => {
+    await handleCampaignStart(1, {
+      personIds: "100",
+      personIdsFile: "ids.txt",
+    });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "Use only one of --person-ids or --person-ids-file.\n",
+    );
+  });
+
+  it("sets exitCode 1 when no person-ids option provided", async () => {
+    await handleCampaignStart(1, {});
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "Either --person-ids or --person-ids-file is required.\n",
+    );
+  });
+
+  it("sets exitCode 1 when person IDs are empty", async () => {
+    vi.mocked(readFileSync).mockReturnValue("");
+
+    await handleCampaignStart(1, { personIdsFile: "empty.txt" });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("No person IDs provided.\n");
+  });
+
+  it("sets exitCode 1 on invalid person ID", async () => {
+    await handleCampaignStart(1, { personIds: "100,abc" });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Invalid person ID: "abc"'),
+    );
+  });
+
+  it("sets exitCode 1 when campaign not found", async () => {
+    mockResolveAccount();
+    mockWithInstanceDatabase();
+    vi.mocked(CampaignService).mockImplementation(function () {
+      return {
+        start: vi.fn().mockRejectedValue(new CampaignNotFoundError(999)),
+      } as unknown as CampaignService;
+    });
+
+    await handleCampaignStart(999, { personIds: "100" });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("Campaign 999 not found.\n");
+  });
+
+  it("sets exitCode 1 on CampaignTimeoutError", async () => {
+    mockResolveAccount();
+    mockWithInstanceDatabase();
+    vi.mocked(CampaignService).mockImplementation(function () {
+      return {
+        start: vi.fn().mockRejectedValue(
+          new CampaignTimeoutError("timed out after 60s"),
+        ),
+      } as unknown as CampaignService;
+    });
+
+    await handleCampaignStart(1, { personIds: "100" });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "Campaign start timed out: timed out after 60s\n",
+    );
+  });
+
+  it("sets exitCode 1 on CampaignExecutionError", async () => {
+    mockResolveAccount();
+    mockWithInstanceDatabase();
+    vi.mocked(CampaignService).mockImplementation(function () {
+      return {
+        start: vi.fn().mockRejectedValue(
+          new CampaignExecutionError("execution failed"),
+        ),
+      } as unknown as CampaignService;
+    });
+
+    await handleCampaignStart(1, { personIds: "100" });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "Failed to start campaign: execution failed\n",
+    );
+  });
+
+  it("sets exitCode 1 on InstanceNotRunningError", async () => {
+    mockResolveAccount();
+    vi.mocked(withInstanceDatabase).mockRejectedValue(
+      new InstanceNotRunningError("No LinkedHelper instance is running."),
+    );
+
+    await handleCampaignStart(1, { personIds: "100" });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "No LinkedHelper instance is running.\n",
+    );
+  });
+
+  it("sets exitCode 1 when resolveAccount fails", async () => {
+    vi.mocked(resolveAccount).mockRejectedValue(new Error("timeout"));
+
+    await handleCampaignStart(1, { personIds: "100" });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("timeout\n");
+  });
+});

--- a/packages/cli/src/handlers/campaign-statistics.test.ts
+++ b/packages/cli/src/handlers/campaign-statistics.test.ts
@@ -1,0 +1,217 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return {
+    ...actual,
+    resolveAccount: vi.fn(),
+    withDatabase: vi.fn(),
+    CampaignRepository: vi.fn(),
+  };
+});
+
+import {
+  ActionNotFoundError,
+  CampaignNotFoundError,
+  CampaignRepository,
+  resolveAccount,
+} from "@lhremote/core";
+
+import { handleCampaignStatistics } from "./campaign-statistics.js";
+import { mockResolveAccount, mockWithDatabase } from "./testing/mock-helpers.js";
+
+const MOCK_ACTION = {
+  actionId: 1,
+  actionName: "Visit Profile",
+  actionType: "VisitAndExtract",
+  successful: 80,
+  replied: 10,
+  failed: 5,
+  skipped: 5,
+  total: 100,
+  successRate: 80,
+  firstResultAt: "2025-01-01T00:00:00Z",
+  lastResultAt: "2025-01-15T00:00:00Z",
+  topErrors: [
+    {
+      code: 429,
+      count: 3,
+      whoToBlame: "linkedin",
+      isException: false,
+    },
+  ],
+};
+
+const MOCK_STATISTICS = {
+  totals: {
+    successful: 80,
+    replied: 10,
+    failed: 5,
+    skipped: 5,
+    total: 100,
+    successRate: 80,
+  },
+  actions: [MOCK_ACTION],
+};
+
+function mockRepo(statistics = MOCK_STATISTICS) {
+  const getStatistics = vi.fn().mockReturnValue(statistics);
+  vi.mocked(CampaignRepository).mockImplementation(function () {
+    return { getStatistics } as unknown as CampaignRepository;
+  });
+  return { getStatistics };
+}
+
+function setupSuccessPath() {
+  mockResolveAccount();
+  mockWithDatabase();
+  return mockRepo();
+}
+
+describe("handleCampaignStatistics", () => {
+  const originalExitCode = process.exitCode;
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    process.exitCode = undefined;
+    vi.clearAllMocks();
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    process.exitCode = originalExitCode;
+    vi.restoreAllMocks();
+  });
+
+  function getStdout(): string {
+    return stdoutSpy.mock.calls
+      .map((call: unknown[]) => String(call[0]))
+      .join("");
+  }
+
+  it("prints human-readable statistics", async () => {
+    setupSuccessPath();
+
+    await handleCampaignStatistics(1, {});
+
+    expect(process.exitCode).toBeUndefined();
+    const output = getStdout();
+    expect(output).toContain("Campaign #1 Statistics");
+    expect(output).toContain("80 successful");
+    expect(output).toContain("10 replied");
+    expect(output).toContain("5 failed");
+    expect(output).toContain("80% success rate");
+    expect(output).toContain("Action #1 — Visit Profile (VisitAndExtract)");
+    expect(output).toContain("Timeline: 2025-01-01");
+    expect(output).toContain("Code 429: 3x — blame: linkedin");
+  });
+
+  it("prints JSON with --json", async () => {
+    setupSuccessPath();
+
+    await handleCampaignStatistics(1, { json: true });
+
+    expect(process.exitCode).toBeUndefined();
+    const parsed = JSON.parse(getStdout());
+    expect(parsed.totals.successful).toBe(80);
+    expect(parsed.actions).toHaveLength(1);
+  });
+
+  it("passes actionId and maxErrors options", async () => {
+    const { getStatistics } = setupSuccessPath();
+
+    await handleCampaignStatistics(1, { actionId: 5, maxErrors: 3 });
+
+    expect(getStatistics).toHaveBeenCalledWith(1, {
+      actionId: 5,
+      maxErrors: 3,
+    });
+  });
+
+  it("omits timeline when firstResultAt is null", async () => {
+    mockResolveAccount();
+    mockWithDatabase();
+    mockRepo({
+      ...MOCK_STATISTICS,
+      actions: [
+        {
+          ...MOCK_ACTION,
+          firstResultAt: null as unknown as string,
+          lastResultAt: null as unknown as string,
+          topErrors: [],
+        },
+      ],
+    });
+
+    await handleCampaignStatistics(1, {});
+
+    expect(getStdout()).not.toContain("Timeline:");
+  });
+
+  it("shows exception label for exception errors", async () => {
+    mockResolveAccount();
+    mockWithDatabase();
+    mockRepo({
+      ...MOCK_STATISTICS,
+      actions: [
+        {
+          ...MOCK_ACTION,
+          topErrors: [
+            { code: 500, count: 1, whoToBlame: "system", isException: true },
+          ],
+        },
+      ],
+    });
+
+    await handleCampaignStatistics(1, {});
+
+    expect(getStdout()).toContain("(exception)");
+  });
+
+  it("sets exitCode 1 when campaign not found", async () => {
+    mockResolveAccount();
+    mockWithDatabase();
+    vi.mocked(CampaignRepository).mockImplementation(function () {
+      return {
+        getStatistics: vi.fn().mockImplementation(() => {
+          throw new CampaignNotFoundError(999);
+        }),
+      } as unknown as CampaignRepository;
+    });
+
+    await handleCampaignStatistics(999, {});
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("Campaign 999 not found.\n");
+  });
+
+  it("sets exitCode 1 when action not found", async () => {
+    mockResolveAccount();
+    mockWithDatabase();
+    vi.mocked(CampaignRepository).mockImplementation(function () {
+      return {
+        getStatistics: vi.fn().mockImplementation(() => {
+          throw new ActionNotFoundError(99, 1);
+        }),
+      } as unknown as CampaignRepository;
+    });
+
+    await handleCampaignStatistics(1, { actionId: 99 });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "Action 99 not found in campaign 1.\n",
+    );
+  });
+
+  it("sets exitCode 1 when resolveAccount fails", async () => {
+    vi.mocked(resolveAccount).mockRejectedValue(new Error("timeout"));
+
+    await handleCampaignStatistics(1, {});
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("timeout\n");
+  });
+});

--- a/packages/cli/src/handlers/campaign-status.test.ts
+++ b/packages/cli/src/handlers/campaign-status.test.ts
@@ -1,0 +1,208 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return {
+    ...actual,
+    resolveAccount: vi.fn(),
+    withInstanceDatabase: vi.fn(),
+    CampaignService: vi.fn(),
+  };
+});
+
+import {
+  CampaignExecutionError,
+  CampaignNotFoundError,
+  CampaignService,
+  InstanceNotRunningError,
+  resolveAccount,
+  withInstanceDatabase,
+} from "@lhremote/core";
+
+import { handleCampaignStatus } from "./campaign-status.js";
+import {
+  mockResolveAccount,
+  mockWithInstanceDatabase,
+} from "./testing/mock-helpers.js";
+
+const MOCK_STATUS = {
+  campaignState: "running",
+  isPaused: false,
+  runnerState: "active",
+  actionCounts: [
+    { actionId: 1, queued: 10, processed: 5, successful: 4, failed: 1 },
+  ],
+};
+
+const MOCK_RESULTS = {
+  results: [
+    { personId: 100, result: "success", actionVersionId: 1 },
+    { personId: 101, result: "failed", actionVersionId: 1 },
+  ],
+};
+
+function mockCampaignService(
+  status = MOCK_STATUS,
+  results = MOCK_RESULTS,
+) {
+  vi.mocked(CampaignService).mockImplementation(function () {
+    return {
+      getStatus: vi.fn().mockResolvedValue(status),
+      getResults: vi.fn().mockResolvedValue(results),
+    } as unknown as CampaignService;
+  });
+}
+
+function setupSuccessPath() {
+  mockResolveAccount();
+  mockWithInstanceDatabase();
+  mockCampaignService();
+}
+
+describe("handleCampaignStatus", () => {
+  const originalExitCode = process.exitCode;
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    process.exitCode = undefined;
+    vi.clearAllMocks();
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    process.exitCode = originalExitCode;
+    vi.restoreAllMocks();
+  });
+
+  function getStdout(): string {
+    return stdoutSpy.mock.calls
+      .map((call: unknown[]) => String(call[0]))
+      .join("");
+  }
+
+  it("prints human-readable status", async () => {
+    setupSuccessPath();
+
+    await handleCampaignStatus(1, {});
+
+    expect(process.exitCode).toBeUndefined();
+    const output = getStdout();
+    expect(output).toContain("Campaign #1 Status");
+    expect(output).toContain("State: running");
+    expect(output).toContain("Paused: no");
+    expect(output).toContain("Runner: active");
+    expect(output).toContain("Action #1: 10 queued, 5 processed, 4 successful, 1 failed");
+  });
+
+  it("prints JSON with --json", async () => {
+    setupSuccessPath();
+
+    await handleCampaignStatus(1, { json: true });
+
+    expect(process.exitCode).toBeUndefined();
+    const parsed = JSON.parse(getStdout());
+    expect(parsed.campaignId).toBe(1);
+    expect(parsed.campaignState).toBe("running");
+    expect(parsed.actionCounts).toHaveLength(1);
+  });
+
+  it("includes results with --include-results", async () => {
+    setupSuccessPath();
+
+    await handleCampaignStatus(1, { includeResults: true });
+
+    expect(process.exitCode).toBeUndefined();
+    const output = getStdout();
+    expect(output).toContain("Results (2):");
+    expect(output).toContain("Person 100: result=success");
+    expect(output).toContain("Person 101: result=failed");
+  });
+
+  it("includes results in JSON with --include-results --json", async () => {
+    setupSuccessPath();
+
+    await handleCampaignStatus(1, { includeResults: true, json: true });
+
+    const parsed = JSON.parse(getStdout());
+    expect(parsed.results).toHaveLength(2);
+  });
+
+  it("prints 'No results yet' when results empty", async () => {
+    mockResolveAccount();
+    mockWithInstanceDatabase();
+    mockCampaignService(MOCK_STATUS, { results: [] });
+
+    await handleCampaignStatus(1, { includeResults: true });
+
+    expect(getStdout()).toContain("No results yet.");
+  });
+
+  it("omits action counts section when empty", async () => {
+    mockResolveAccount();
+    mockWithInstanceDatabase();
+    mockCampaignService({ ...MOCK_STATUS, actionCounts: [] });
+
+    await handleCampaignStatus(1, {});
+
+    expect(getStdout()).not.toContain("Action Counts:");
+  });
+
+  it("sets exitCode 1 when campaign not found", async () => {
+    mockResolveAccount();
+    mockWithInstanceDatabase();
+    vi.mocked(CampaignService).mockImplementation(function () {
+      return {
+        getStatus: vi.fn().mockRejectedValue(new CampaignNotFoundError(999)),
+      } as unknown as CampaignService;
+    });
+
+    await handleCampaignStatus(999, {});
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("Campaign 999 not found.\n");
+  });
+
+  it("sets exitCode 1 on CampaignExecutionError", async () => {
+    mockResolveAccount();
+    mockWithInstanceDatabase();
+    vi.mocked(CampaignService).mockImplementation(function () {
+      return {
+        getStatus: vi.fn().mockRejectedValue(
+          new CampaignExecutionError("status unavailable"),
+        ),
+      } as unknown as CampaignService;
+    });
+
+    await handleCampaignStatus(1, {});
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "Failed to get campaign status: status unavailable\n",
+    );
+  });
+
+  it("sets exitCode 1 on InstanceNotRunningError", async () => {
+    mockResolveAccount();
+    vi.mocked(withInstanceDatabase).mockRejectedValue(
+      new InstanceNotRunningError("No LinkedHelper instance is running."),
+    );
+
+    await handleCampaignStatus(1, {});
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "No LinkedHelper instance is running.\n",
+    );
+  });
+
+  it("sets exitCode 1 when resolveAccount fails", async () => {
+    vi.mocked(resolveAccount).mockRejectedValue(new Error("timeout"));
+
+    await handleCampaignStatus(1, {});
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("timeout\n");
+  });
+});

--- a/packages/cli/src/handlers/campaign-stop.test.ts
+++ b/packages/cli/src/handlers/campaign-stop.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return {
+    ...actual,
+    resolveAccount: vi.fn(),
+    withInstanceDatabase: vi.fn(),
+    CampaignService: vi.fn(),
+  };
+});
+
+import {
+  CampaignExecutionError,
+  CampaignNotFoundError,
+  CampaignService,
+  InstanceNotRunningError,
+  resolveAccount,
+  withInstanceDatabase,
+} from "@lhremote/core";
+
+import { handleCampaignStop } from "./campaign-stop.js";
+import {
+  mockResolveAccount,
+  mockWithInstanceDatabase,
+} from "./testing/mock-helpers.js";
+
+function mockCampaignService() {
+  vi.mocked(CampaignService).mockImplementation(function () {
+    return {
+      stop: vi.fn().mockResolvedValue(undefined),
+    } as unknown as CampaignService;
+  });
+}
+
+function setupSuccessPath() {
+  mockResolveAccount();
+  mockWithInstanceDatabase();
+  mockCampaignService();
+}
+
+describe("handleCampaignStop", () => {
+  const originalExitCode = process.exitCode;
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    process.exitCode = undefined;
+    vi.clearAllMocks();
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    process.exitCode = originalExitCode;
+    vi.restoreAllMocks();
+  });
+
+  function getStdout(): string {
+    return stdoutSpy.mock.calls
+      .map((call: unknown[]) => String(call[0]))
+      .join("");
+  }
+
+  it("pauses campaign and prints confirmation", async () => {
+    setupSuccessPath();
+
+    await handleCampaignStop(5, {});
+
+    expect(process.exitCode).toBeUndefined();
+    expect(getStdout()).toContain("Campaign 5 paused.");
+  });
+
+  it("prints JSON with --json", async () => {
+    setupSuccessPath();
+
+    await handleCampaignStop(5, { json: true });
+
+    expect(process.exitCode).toBeUndefined();
+    const parsed = JSON.parse(getStdout());
+    expect(parsed.success).toBe(true);
+    expect(parsed.campaignId).toBe(5);
+    expect(parsed.message).toBe("Campaign paused");
+  });
+
+  it("sets exitCode 1 when campaign not found", async () => {
+    mockResolveAccount();
+    mockWithInstanceDatabase();
+    vi.mocked(CampaignService).mockImplementation(function () {
+      return {
+        stop: vi.fn().mockRejectedValue(new CampaignNotFoundError(999)),
+      } as unknown as CampaignService;
+    });
+
+    await handleCampaignStop(999, {});
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("Campaign 999 not found.\n");
+  });
+
+  it("sets exitCode 1 on CampaignExecutionError", async () => {
+    mockResolveAccount();
+    mockWithInstanceDatabase();
+    vi.mocked(CampaignService).mockImplementation(function () {
+      return {
+        stop: vi.fn().mockRejectedValue(
+          new CampaignExecutionError("already stopped"),
+        ),
+      } as unknown as CampaignService;
+    });
+
+    await handleCampaignStop(5, {});
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "Failed to stop campaign: already stopped\n",
+    );
+  });
+
+  it("sets exitCode 1 on InstanceNotRunningError", async () => {
+    mockResolveAccount();
+    vi.mocked(withInstanceDatabase).mockRejectedValue(
+      new InstanceNotRunningError("No LinkedHelper instance is running."),
+    );
+
+    await handleCampaignStop(5, {});
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "No LinkedHelper instance is running.\n",
+    );
+  });
+
+  it("sets exitCode 1 when resolveAccount fails", async () => {
+    vi.mocked(resolveAccount).mockRejectedValue(new Error("timeout"));
+
+    await handleCampaignStop(5, {});
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("timeout\n");
+  });
+});

--- a/packages/cli/src/handlers/campaign-update.test.ts
+++ b/packages/cli/src/handlers/campaign-update.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return {
+    ...actual,
+    resolveAccount: vi.fn(),
+    withDatabase: vi.fn(),
+    CampaignRepository: vi.fn(),
+  };
+});
+
+import {
+  CampaignNotFoundError,
+  CampaignRepository,
+  resolveAccount,
+} from "@lhremote/core";
+
+import { handleCampaignUpdate } from "./campaign-update.js";
+import { mockResolveAccount, mockWithDatabase } from "./testing/mock-helpers.js";
+
+const MOCK_UPDATED = { id: 1, name: "Updated Name" };
+
+function mockRepo(updated = MOCK_UPDATED) {
+  const updateCampaign = vi.fn().mockReturnValue(updated);
+  vi.mocked(CampaignRepository).mockImplementation(function () {
+    return { updateCampaign } as unknown as CampaignRepository;
+  });
+  return { updateCampaign };
+}
+
+function setupSuccessPath() {
+  mockResolveAccount();
+  mockWithDatabase();
+  return mockRepo();
+}
+
+describe("handleCampaignUpdate", () => {
+  const originalExitCode = process.exitCode;
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    process.exitCode = undefined;
+    vi.clearAllMocks();
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    process.exitCode = originalExitCode;
+    vi.restoreAllMocks();
+  });
+
+  function getStdout(): string {
+    return stdoutSpy.mock.calls
+      .map((call: unknown[]) => String(call[0]))
+      .join("");
+  }
+
+  it("updates campaign name and prints confirmation", async () => {
+    setupSuccessPath();
+
+    await handleCampaignUpdate(1, { name: "Updated Name" });
+
+    expect(process.exitCode).toBeUndefined();
+    expect(getStdout()).toContain('Campaign updated: #1 "Updated Name"');
+  });
+
+  it("prints JSON with --json", async () => {
+    setupSuccessPath();
+
+    await handleCampaignUpdate(1, { name: "Updated Name", json: true });
+
+    expect(process.exitCode).toBeUndefined();
+    const parsed = JSON.parse(getStdout());
+    expect(parsed.id).toBe(1);
+    expect(parsed.name).toBe("Updated Name");
+  });
+
+  it("passes name update to repository", async () => {
+    const { updateCampaign } = setupSuccessPath();
+
+    await handleCampaignUpdate(1, { name: "New Name" });
+
+    expect(updateCampaign).toHaveBeenCalledWith(1, { name: "New Name" });
+  });
+
+  it("passes description update to repository", async () => {
+    const { updateCampaign } = setupSuccessPath();
+
+    await handleCampaignUpdate(1, { description: "New desc" });
+
+    expect(updateCampaign).toHaveBeenCalledWith(1, {
+      description: "New desc",
+    });
+  });
+
+  it("passes null description when --clear-description", async () => {
+    const { updateCampaign } = setupSuccessPath();
+
+    await handleCampaignUpdate(1, { clearDescription: true });
+
+    expect(updateCampaign).toHaveBeenCalledWith(1, { description: null });
+  });
+
+  it("sets exitCode 1 when no update options provided", async () => {
+    await handleCampaignUpdate(1, {});
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "At least one of --name, --description, or --clear-description is required.\n",
+    );
+  });
+
+  it("sets exitCode 1 when campaign not found", async () => {
+    mockResolveAccount();
+    mockWithDatabase();
+    vi.mocked(CampaignRepository).mockImplementation(function () {
+      return {
+        updateCampaign: vi.fn().mockImplementation(() => {
+          throw new CampaignNotFoundError(999);
+        }),
+      } as unknown as CampaignRepository;
+    });
+
+    await handleCampaignUpdate(999, { name: "x" });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("Campaign 999 not found.\n");
+  });
+
+  it("sets exitCode 1 when resolveAccount fails", async () => {
+    vi.mocked(resolveAccount).mockRejectedValue(new Error("timeout"));
+
+    await handleCampaignUpdate(1, { name: "x" });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("timeout\n");
+  });
+});

--- a/packages/cli/src/handlers/find-app.test.ts
+++ b/packages/cli/src/handlers/find-app.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return {
+    ...actual,
+    findApp: vi.fn(),
+  };
+});
+
+import { type DiscoveredApp, findApp } from "@lhremote/core";
+
+import { handleFindApp } from "./find-app.js";
+
+describe("handleFindApp", () => {
+  const originalExitCode = process.exitCode;
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    process.exitCode = undefined;
+    vi.clearAllMocks();
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    process.exitCode = originalExitCode;
+    vi.restoreAllMocks();
+  });
+
+  function getStdout(): string {
+    return stdoutSpy.mock.calls
+      .map((call: unknown[]) => String(call[0]))
+      .join("");
+  }
+
+  it("prints JSON with --json", async () => {
+    const apps: DiscoveredApp[] = [
+      { pid: 1234, cdpPort: 9222, connectable: true },
+    ];
+    vi.mocked(findApp).mockResolvedValue(apps);
+
+    await handleFindApp({ json: true });
+
+    expect(process.exitCode).toBeUndefined();
+    const parsed = JSON.parse(getStdout());
+    expect(parsed).toEqual(apps);
+  });
+
+  it("prints human-readable output for connectable instance", async () => {
+    vi.mocked(findApp).mockResolvedValue([
+      { pid: 1234, cdpPort: 9222, connectable: true },
+    ]);
+
+    await handleFindApp({});
+
+    expect(process.exitCode).toBeUndefined();
+    expect(getStdout()).toContain("PID 1234");
+    expect(getStdout()).toContain("CDP port 9222");
+    expect(getStdout()).toContain("connectable");
+  });
+
+  it("prints 'not connectable' for non-connectable instance", async () => {
+    vi.mocked(findApp).mockResolvedValue([
+      { pid: 5678, cdpPort: 9222, connectable: false },
+    ]);
+
+    await handleFindApp({});
+
+    expect(getStdout()).toContain("not connectable");
+  });
+
+  it("prints 'no CDP port' when cdpPort is null", async () => {
+    vi.mocked(findApp).mockResolvedValue([
+      { pid: 5678, cdpPort: null, connectable: false },
+    ]);
+
+    await handleFindApp({});
+
+    expect(getStdout()).toContain("no CDP port");
+  });
+
+  it("prints message when no instances found", async () => {
+    vi.mocked(findApp).mockResolvedValue([]);
+
+    await handleFindApp({});
+
+    expect(process.exitCode).toBeUndefined();
+    expect(getStdout()).toContain("No running LinkedHelper instances found");
+  });
+
+  it("sets exitCode 1 on error", async () => {
+    vi.mocked(findApp).mockRejectedValue(new Error("scan failed"));
+
+    await handleFindApp({});
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("scan failed\n");
+  });
+});

--- a/packages/cli/src/handlers/import-people-from-urls.test.ts
+++ b/packages/cli/src/handlers/import-people-from-urls.test.ts
@@ -1,0 +1,274 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return {
+    ...actual,
+    resolveAccount: vi.fn(),
+    withInstanceDatabase: vi.fn(),
+    CampaignService: vi.fn(),
+  };
+});
+
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    readFileSync: vi.fn(),
+  };
+});
+
+import {
+  CampaignExecutionError,
+  CampaignNotFoundError,
+  CampaignService,
+  InstanceNotRunningError,
+  resolveAccount,
+  withInstanceDatabase,
+} from "@lhremote/core";
+import { readFileSync } from "node:fs";
+
+import { handleImportPeopleFromUrls } from "./import-people-from-urls.js";
+import {
+  mockResolveAccount,
+  mockWithInstanceDatabase,
+} from "./testing/mock-helpers.js";
+
+const MOCK_RESULT = {
+  actionId: 10,
+  successful: 3,
+  alreadyInQueue: 1,
+  alreadyProcessed: 0,
+  failed: 0,
+};
+
+function mockCampaignService(result = MOCK_RESULT) {
+  vi.mocked(CampaignService).mockImplementation(function () {
+    return {
+      importPeopleFromUrls: vi.fn().mockResolvedValue(result),
+    } as unknown as CampaignService;
+  });
+}
+
+function setupSuccessPath() {
+  mockResolveAccount();
+  mockWithInstanceDatabase();
+  mockCampaignService();
+}
+
+describe("handleImportPeopleFromUrls", () => {
+  const originalExitCode = process.exitCode;
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    process.exitCode = undefined;
+    vi.clearAllMocks();
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    process.exitCode = originalExitCode;
+    vi.restoreAllMocks();
+  });
+
+  function getStdout(): string {
+    return stdoutSpy.mock.calls
+      .map((call: unknown[]) => String(call[0]))
+      .join("");
+  }
+
+  it("imports people from --urls and prints result", async () => {
+    setupSuccessPath();
+
+    await handleImportPeopleFromUrls(1, {
+      urls: "https://linkedin.com/in/alice,https://linkedin.com/in/bob",
+    });
+
+    expect(process.exitCode).toBeUndefined();
+    const output = getStdout();
+    expect(output).toContain("Imported 3 people into campaign 1 action 10.");
+    expect(output).toContain("1 already in queue.");
+  });
+
+  it("imports from --urls-file", async () => {
+    setupSuccessPath();
+    vi.mocked(readFileSync).mockReturnValue(
+      "https://linkedin.com/in/alice\nhttps://linkedin.com/in/bob",
+    );
+
+    await handleImportPeopleFromUrls(1, { urlsFile: "urls.txt" });
+
+    expect(process.exitCode).toBeUndefined();
+    expect(getStdout()).toContain("Imported 3 people");
+  });
+
+  it("prints JSON with --json", async () => {
+    setupSuccessPath();
+
+    await handleImportPeopleFromUrls(1, {
+      urls: "https://linkedin.com/in/alice",
+      json: true,
+    });
+
+    expect(process.exitCode).toBeUndefined();
+    const parsed = JSON.parse(getStdout());
+    expect(parsed.success).toBe(true);
+    expect(parsed.campaignId).toBe(1);
+    expect(parsed.actionId).toBe(10);
+    expect(parsed.imported).toBe(3);
+    expect(parsed.alreadyInQueue).toBe(1);
+  });
+
+  it("shows already-processed and failed counts when non-zero", async () => {
+    mockResolveAccount();
+    mockWithInstanceDatabase();
+    mockCampaignService({
+      actionId: 10,
+      successful: 1,
+      alreadyInQueue: 0,
+      alreadyProcessed: 2,
+      failed: 1,
+    });
+
+    await handleImportPeopleFromUrls(1, {
+      urls: "https://linkedin.com/in/alice",
+    });
+
+    const output = getStdout();
+    expect(output).toContain("2 already processed.");
+    expect(output).toContain("1 failed.");
+  });
+
+  it("omits zero counts from human output", async () => {
+    mockResolveAccount();
+    mockWithInstanceDatabase();
+    mockCampaignService({
+      actionId: 10,
+      successful: 3,
+      alreadyInQueue: 0,
+      alreadyProcessed: 0,
+      failed: 0,
+    });
+
+    await handleImportPeopleFromUrls(1, {
+      urls: "https://linkedin.com/in/alice",
+    });
+
+    const output = getStdout();
+    expect(output).not.toContain("already in queue");
+    expect(output).not.toContain("already processed");
+    expect(output).not.toContain("failed");
+  });
+
+  it("sets exitCode 1 when both url options provided", async () => {
+    await handleImportPeopleFromUrls(1, {
+      urls: "https://linkedin.com/in/alice",
+      urlsFile: "urls.txt",
+    });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "Use only one of --urls or --urls-file.\n",
+    );
+  });
+
+  it("sets exitCode 1 when no url option provided", async () => {
+    await handleImportPeopleFromUrls(1, {});
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "Either --urls or --urls-file is required.\n",
+    );
+  });
+
+  it("sets exitCode 1 when URLs are empty", async () => {
+    vi.mocked(readFileSync).mockReturnValue("");
+
+    await handleImportPeopleFromUrls(1, { urlsFile: "empty.txt" });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("No URLs provided.\n");
+  });
+
+  it("sets exitCode 1 when campaign not found", async () => {
+    mockResolveAccount();
+    mockWithInstanceDatabase();
+    vi.mocked(CampaignService).mockImplementation(function () {
+      return {
+        importPeopleFromUrls: vi
+          .fn()
+          .mockRejectedValue(new CampaignNotFoundError(999)),
+      } as unknown as CampaignService;
+    });
+
+    await handleImportPeopleFromUrls(999, {
+      urls: "https://linkedin.com/in/alice",
+    });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("Campaign 999 not found.\n");
+  });
+
+  it("sets exitCode 1 on CampaignExecutionError", async () => {
+    mockResolveAccount();
+    mockWithInstanceDatabase();
+    vi.mocked(CampaignService).mockImplementation(function () {
+      return {
+        importPeopleFromUrls: vi
+          .fn()
+          .mockRejectedValue(new CampaignExecutionError("import failed")),
+      } as unknown as CampaignService;
+    });
+
+    await handleImportPeopleFromUrls(1, {
+      urls: "https://linkedin.com/in/alice",
+    });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "Failed to import people: import failed\n",
+    );
+  });
+
+  it("sets exitCode 1 on InstanceNotRunningError", async () => {
+    mockResolveAccount();
+    vi.mocked(withInstanceDatabase).mockRejectedValue(
+      new InstanceNotRunningError("No LinkedHelper instance is running."),
+    );
+
+    await handleImportPeopleFromUrls(1, {
+      urls: "https://linkedin.com/in/alice",
+    });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "No LinkedHelper instance is running.\n",
+    );
+  });
+
+  it("sets exitCode 1 when resolveAccount fails", async () => {
+    vi.mocked(resolveAccount).mockRejectedValue(new Error("timeout"));
+
+    await handleImportPeopleFromUrls(1, {
+      urls: "https://linkedin.com/in/alice",
+    });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("timeout\n");
+  });
+
+  it("sets exitCode 1 when urls-file read fails", async () => {
+    vi.mocked(readFileSync).mockImplementation(() => {
+      throw new Error("ENOENT: no such file");
+    });
+
+    await handleImportPeopleFromUrls(1, { urlsFile: "missing.txt" });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      expect.stringContaining("ENOENT"),
+    );
+  });
+});

--- a/packages/cli/src/handlers/scrape-messaging-history.test.ts
+++ b/packages/cli/src/handlers/scrape-messaging-history.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return {
+    ...actual,
+    resolveAccount: vi.fn(),
+    withInstanceDatabase: vi.fn(),
+    MessageRepository: vi.fn(),
+  };
+});
+
+import {
+  InstanceNotRunningError,
+  MessageRepository,
+  resolveAccount,
+  withInstanceDatabase,
+} from "@lhremote/core";
+
+import { handleScrapeMessagingHistory } from "./scrape-messaging-history.js";
+import {
+  mockResolveAccount,
+  mockWithInstanceDatabase,
+} from "./testing/mock-helpers.js";
+
+const MOCK_STATS = {
+  totalChats: 42,
+  totalMessages: 256,
+  earliestMessage: "2024-06-01T10:00:00Z",
+  latestMessage: "2025-01-15T14:00:00Z",
+};
+
+function mockRepo(stats = MOCK_STATS) {
+  vi.mocked(MessageRepository).mockImplementation(function () {
+    return {
+      getMessageStats: vi.fn().mockReturnValue(stats),
+    } as unknown as MessageRepository;
+  });
+}
+
+function setupSuccessPath() {
+  mockResolveAccount();
+  mockRepo();
+  mockWithInstanceDatabase();
+}
+
+describe("handleScrapeMessagingHistory", () => {
+  const originalExitCode = process.exitCode;
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    process.exitCode = undefined;
+    vi.clearAllMocks();
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    process.exitCode = originalExitCode;
+    vi.restoreAllMocks();
+  });
+
+  function getStdout(): string {
+    return stdoutSpy.mock.calls
+      .map((call: unknown[]) => String(call[0]))
+      .join("");
+  }
+
+  function getStderr(): string {
+    return stderrSpy.mock.calls
+      .map((call: unknown[]) => String(call[0]))
+      .join("");
+  }
+
+  it("prints JSON with --json", async () => {
+    setupSuccessPath();
+
+    await handleScrapeMessagingHistory({ json: true });
+
+    expect(process.exitCode).toBeUndefined();
+    const output = JSON.parse(getStdout());
+    expect(output.success).toBe(true);
+    expect(output.actionType).toBe("ScrapeMessagingHistory");
+    expect(output.stats).toEqual(MOCK_STATS);
+  });
+
+  it("prints human-readable output by default", async () => {
+    setupSuccessPath();
+
+    await handleScrapeMessagingHistory({});
+
+    expect(process.exitCode).toBeUndefined();
+    const output = getStdout();
+    expect(output).toContain("42 conversations");
+    expect(output).toContain("256 messages");
+    expect(output).toContain("2024-06-01");
+    expect(output).toContain("2025-01-15");
+  });
+
+  it("prints progress to stderr", async () => {
+    setupSuccessPath();
+
+    await handleScrapeMessagingHistory({});
+
+    const stderr = getStderr();
+    expect(stderr).toContain("Scraping messaging history");
+    expect(stderr).toContain("Done.");
+  });
+
+  it("omits date range when no messages", async () => {
+    mockResolveAccount();
+    mockRepo({
+      totalChats: 0,
+      totalMessages: 0,
+      earliestMessage: null as unknown as string,
+      latestMessage: null as unknown as string,
+    });
+    mockWithInstanceDatabase();
+
+    await handleScrapeMessagingHistory({});
+
+    expect(process.exitCode).toBeUndefined();
+    const output = getStdout();
+    expect(output).toContain("0 conversations");
+    expect(output).not.toContain("Date range");
+  });
+
+  it("sets exitCode 1 when resolveAccount fails", async () => {
+    vi.mocked(resolveAccount).mockRejectedValue(
+      new Error("No accounts found."),
+    );
+
+    await handleScrapeMessagingHistory({});
+
+    expect(process.exitCode).toBe(1);
+    expect(getStderr()).toContain("No accounts found.");
+  });
+
+  it("sets exitCode 1 when instance not running", async () => {
+    mockResolveAccount();
+    vi.mocked(withInstanceDatabase).mockRejectedValue(
+      new InstanceNotRunningError(
+        "No LinkedHelper instance is running. Use start-instance first.",
+      ),
+    );
+
+    await handleScrapeMessagingHistory({});
+
+    expect(process.exitCode).toBe(1);
+    expect(getStderr()).toContain("No LinkedHelper instance is running.");
+  });
+
+  it("sets exitCode 1 on unexpected error", async () => {
+    mockResolveAccount();
+    vi.mocked(withInstanceDatabase).mockRejectedValue(
+      new Error("connection reset"),
+    );
+
+    await handleScrapeMessagingHistory({});
+
+    expect(process.exitCode).toBe(1);
+    expect(getStderr()).toContain("connection reset");
+  });
+});

--- a/packages/cli/src/handlers/testing/mock-helpers.ts
+++ b/packages/cli/src/handlers/testing/mock-helpers.ts
@@ -2,6 +2,7 @@ import { vi } from "vitest";
 
 import type {
   DatabaseClient,
+  DatabaseContext,
   InstanceDatabaseContext,
   LauncherService,
 } from "@lhremote/core";
@@ -10,6 +11,7 @@ import {
   LauncherService as LauncherServiceCtor,
   discoverAllDatabases,
   resolveAccount,
+  withDatabase,
   withInstanceDatabase,
 } from "@lhremote/core";
 
@@ -86,4 +88,23 @@ export function mockWithInstanceDatabase(): {
     },
   );
   return { executeAction };
+}
+
+/**
+ * Mock {@link withDatabase} so the callback receives a
+ * synthetic {@link DatabaseContext}.
+ *
+ * Returns a mock `db` object for further stubbing.
+ */
+export function mockWithDatabase(): { db: Record<string, unknown> } {
+  const db = {};
+  vi.mocked(withDatabase).mockImplementation(
+    async (_accountId, callback) => {
+      return callback({
+        accountId: _accountId,
+        db,
+      } as unknown as DatabaseContext);
+    },
+  );
+  return { db };
 }


### PR DESCRIPTION
## Summary

- Add unit tests for all 22 previously untested CLI handlers, achieving 100% handler test coverage
- Add `mockWithDatabase` helper to shared test utilities for handlers using the database-only context path
- Handlers covered: campaign CRUD, campaign lifecycle, campaign actions, campaign exclusions, import-people-from-urls, find-app, scrape-messaging-history

## Test plan

- [x] All 287 CLI tests pass (`pnpm --filter cli test`)
- [x] Full test suite passes (477 tests across all packages)
- [x] Lint and build pass (`pnpm lint`)
- [ ] CI passes on all platforms (ubuntu/macos/windows)

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)