### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -9,9 +9,9 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: pnpm/action-setup@v4
+    - uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4.2.0
 
-    - uses: actions/setup-node@v4
+    - uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
       with:
         node-version: 24
         cache: pnpm
@@ -24,7 +24,7 @@ runs:
       run: npx playwright-core install chromium --with-deps
       shell: bash
 
-    - uses: actions/cache@v4
+    - uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
       with:
         path: .turbo
         key: turbo-${{ runner.os }}-node24-${{ hashFiles('**/pnpm-lock.yaml') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,14 +22,14 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup
       - run: pnpm build
       - run: pnpm lint
       - run: pnpm test ${{ matrix.os == 'ubuntu-latest' && '-- -- --coverage' || '' }}
       - name: Upload coverage to Codecov
         if: matrix.os == 'ubuntu-latest' && env.CODECOV_TOKEN != ''
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -46,10 +46,10 @@ jobs:
       - ci
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Set up GitHub Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
 
       - name: Build docs
         run: |
@@ -61,7 +61,7 @@ jobs:
             -o build/gh-pages/index.html gh-pages/metadata.md README.md
 
       - name: Upload GitHub Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
           path: build/gh-pages
 
@@ -85,8 +85,8 @@ jobs:
 
     steps:
       - name: Set up GitHub Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
 
       - name: Publish GitHub Pages
         id: publish-github-pages
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup
       - run: pnpm build
       - run: pnpm lint
@@ -37,7 +37,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup
         with:
           registry-url: https://registry.npmjs.org


### PR DESCRIPTION
## Summary
- Pin all third-party GitHub Actions to full commit SHAs to prevent tag mutation attacks
- Upgrade actions to latest available versions:
  - `actions/checkout` v4 → v6.0.2
  - `actions/setup-node` v4 → v6.2.0
  - `actions/cache` v4 → v5.0.3
  - `actions/upload-pages-artifact` v3 → v4.0.0
  - `actions/configure-pages` v5 → v5.0.0 (SHA-pinned, same major)
  - `actions/deploy-pages` v4 → v4.0.5 (SHA-pinned, same major)
  - `codecov/codecov-action` v5 → v5.5.2 (SHA-pinned, same major)
  - `pnpm/action-setup` v4 → v4.2.0 (SHA-pinned, same major)
- All SHA pins include version comments for maintainability

Closes #148

## Test plan
- [ ] CI passes on all three OS matrix entries (ubuntu, macos, windows)
- [ ] GH Pages build succeeds (package job)

🤖 Generated with [Claude Code](https://claude.com/claude-code)