### PR TITLE
Add license field to root package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "lhremote",
   "version": "0.0.0",
   "private": true,
+  "license": "AGPL-3.0-only",
   "type": "module",
   "packageManager": "pnpm@9.15.4",
   "engines": {


### PR DESCRIPTION
## Summary
- Add `"license": "AGPL-3.0-only"` to the root `package.json`, matching all sub-packages and the existing LICENSE file
- Eliminates `UNLICENSED` noise from tooling like `license-checker`

Closes #193

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm lint` passes
- [x] All sub-packages already declare `AGPL-3.0-only`
- [x] LICENSE file exists at repo root

🤖 Generated with [Claude Code](https://claude.com/claude-code)