### PR TITLE
Add SPDX license headers to all source files

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import eslint from "@eslint/js";
 import tseslint from "typescript-eslint";
 import eslintConfigPrettier from "eslint-config-prettier";

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
 
 import { createProgram } from "./program.js";
 

--- a/packages/cli/src/handlers/campaign-add-action.test.ts
+++ b/packages/cli/src/handlers/campaign-add-action.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/cli/src/handlers/campaign-add-action.ts
+++ b/packages/cli/src/handlers/campaign-add-action.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import {
   CampaignNotFoundError,
   CampaignRepository,

--- a/packages/cli/src/handlers/campaign-create.test.ts
+++ b/packages/cli/src/handlers/campaign-create.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/cli/src/handlers/campaign-create.ts
+++ b/packages/cli/src/handlers/campaign-create.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { readFileSync } from "node:fs";
 
 import {

--- a/packages/cli/src/handlers/campaign-delete.test.ts
+++ b/packages/cli/src/handlers/campaign-delete.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/cli/src/handlers/campaign-delete.ts
+++ b/packages/cli/src/handlers/campaign-delete.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import {
   CampaignExecutionError,
   CampaignNotFoundError,

--- a/packages/cli/src/handlers/campaign-exclude-add.test.ts
+++ b/packages/cli/src/handlers/campaign-exclude-add.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/cli/src/handlers/campaign-exclude-add.ts
+++ b/packages/cli/src/handlers/campaign-exclude-add.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { readFileSync } from "node:fs";
 
 import {

--- a/packages/cli/src/handlers/campaign-exclude-list.test.ts
+++ b/packages/cli/src/handlers/campaign-exclude-list.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/cli/src/handlers/campaign-exclude-list.ts
+++ b/packages/cli/src/handlers/campaign-exclude-list.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import {
   ActionNotFoundError,
   CampaignNotFoundError,

--- a/packages/cli/src/handlers/campaign-exclude-remove.test.ts
+++ b/packages/cli/src/handlers/campaign-exclude-remove.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/cli/src/handlers/campaign-exclude-remove.ts
+++ b/packages/cli/src/handlers/campaign-exclude-remove.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { readFileSync } from "node:fs";
 
 import {

--- a/packages/cli/src/handlers/campaign-export.test.ts
+++ b/packages/cli/src/handlers/campaign-export.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/cli/src/handlers/campaign-export.ts
+++ b/packages/cli/src/handlers/campaign-export.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { writeFileSync } from "node:fs";
 
 import {

--- a/packages/cli/src/handlers/campaign-get.test.ts
+++ b/packages/cli/src/handlers/campaign-get.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/cli/src/handlers/campaign-get.ts
+++ b/packages/cli/src/handlers/campaign-get.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import {
   CampaignNotFoundError,
   CampaignRepository,

--- a/packages/cli/src/handlers/campaign-list.test.ts
+++ b/packages/cli/src/handlers/campaign-list.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/cli/src/handlers/campaign-list.ts
+++ b/packages/cli/src/handlers/campaign-list.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import {
   CampaignRepository,
   type CampaignSummary,

--- a/packages/cli/src/handlers/campaign-move-next.test.ts
+++ b/packages/cli/src/handlers/campaign-move-next.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/cli/src/handlers/campaign-move-next.ts
+++ b/packages/cli/src/handlers/campaign-move-next.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { readFileSync } from "node:fs";
 
 import {

--- a/packages/cli/src/handlers/campaign-remove-action.test.ts
+++ b/packages/cli/src/handlers/campaign-remove-action.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/cli/src/handlers/campaign-remove-action.ts
+++ b/packages/cli/src/handlers/campaign-remove-action.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import {
   ActionNotFoundError,
   CampaignExecutionError,

--- a/packages/cli/src/handlers/campaign-reorder-actions.test.ts
+++ b/packages/cli/src/handlers/campaign-reorder-actions.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/cli/src/handlers/campaign-reorder-actions.ts
+++ b/packages/cli/src/handlers/campaign-reorder-actions.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import {
   ActionNotFoundError,
   CampaignExecutionError,

--- a/packages/cli/src/handlers/campaign-retry.test.ts
+++ b/packages/cli/src/handlers/campaign-retry.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/cli/src/handlers/campaign-retry.ts
+++ b/packages/cli/src/handlers/campaign-retry.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { readFileSync } from "node:fs";
 
 import {

--- a/packages/cli/src/handlers/campaign-start.test.ts
+++ b/packages/cli/src/handlers/campaign-start.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/cli/src/handlers/campaign-start.ts
+++ b/packages/cli/src/handlers/campaign-start.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { readFileSync } from "node:fs";
 
 import {

--- a/packages/cli/src/handlers/campaign-statistics.test.ts
+++ b/packages/cli/src/handlers/campaign-statistics.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/cli/src/handlers/campaign-statistics.ts
+++ b/packages/cli/src/handlers/campaign-statistics.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import {
   ActionNotFoundError,
   CampaignNotFoundError,

--- a/packages/cli/src/handlers/campaign-status.test.ts
+++ b/packages/cli/src/handlers/campaign-status.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/cli/src/handlers/campaign-status.ts
+++ b/packages/cli/src/handlers/campaign-status.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import {
   CampaignExecutionError,
   CampaignNotFoundError,

--- a/packages/cli/src/handlers/campaign-stop.test.ts
+++ b/packages/cli/src/handlers/campaign-stop.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/cli/src/handlers/campaign-stop.ts
+++ b/packages/cli/src/handlers/campaign-stop.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import {
   CampaignExecutionError,
   CampaignNotFoundError,

--- a/packages/cli/src/handlers/campaign-update.test.ts
+++ b/packages/cli/src/handlers/campaign-update.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/cli/src/handlers/campaign-update.ts
+++ b/packages/cli/src/handlers/campaign-update.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import {
   CampaignNotFoundError,
   CampaignRepository,

--- a/packages/cli/src/handlers/check-replies.test.ts
+++ b/packages/cli/src/handlers/check-replies.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/cli/src/handlers/check-replies.ts
+++ b/packages/cli/src/handlers/check-replies.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import {
   type ConversationMessages,
   errorMessage,

--- a/packages/cli/src/handlers/check-status.test.ts
+++ b/packages/cli/src/handlers/check-status.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/cli/src/handlers/check-status.ts
+++ b/packages/cli/src/handlers/check-status.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { checkStatus, errorMessage } from "@lhremote/core";
 
 /** Handle the {@link https://github.com/alexey-pelykh/lhremote#account--instance | check-status} CLI command. */

--- a/packages/cli/src/handlers/describe-actions.test.ts
+++ b/packages/cli/src/handlers/describe-actions.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { handleDescribeActions } from "./describe-actions.js";

--- a/packages/cli/src/handlers/describe-actions.ts
+++ b/packages/cli/src/handlers/describe-actions.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import {
   type ActionTypeInfo,
   getActionTypeCatalog,

--- a/packages/cli/src/handlers/find-app.test.ts
+++ b/packages/cli/src/handlers/find-app.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/cli/src/handlers/find-app.ts
+++ b/packages/cli/src/handlers/find-app.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { errorMessage, findApp } from "@lhremote/core";
 
 /** Handle the {@link https://github.com/alexey-pelykh/lhremote#app-management | find-app} CLI command. */

--- a/packages/cli/src/handlers/import-people-from-urls.test.ts
+++ b/packages/cli/src/handlers/import-people-from-urls.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/cli/src/handlers/import-people-from-urls.ts
+++ b/packages/cli/src/handlers/import-people-from-urls.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { readFileSync } from "node:fs";
 
 import {

--- a/packages/cli/src/handlers/index.ts
+++ b/packages/cli/src/handlers/index.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 export { handleCampaignAddAction } from "./campaign-add-action.js";
 export { handleCampaignCreate } from "./campaign-create.js";
 export { handleCampaignDelete } from "./campaign-delete.js";

--- a/packages/cli/src/handlers/launch-app.test.ts
+++ b/packages/cli/src/handlers/launch-app.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/cli/src/handlers/launch-app.ts
+++ b/packages/cli/src/handlers/launch-app.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { AppService, errorMessage } from "@lhremote/core";
 
 /** Handle the {@link https://github.com/alexey-pelykh/lhremote#app-management | launch-app} CLI command. */

--- a/packages/cli/src/handlers/list-accounts.test.ts
+++ b/packages/cli/src/handlers/list-accounts.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/cli/src/handlers/list-accounts.ts
+++ b/packages/cli/src/handlers/list-accounts.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { errorMessage, LauncherService } from "@lhremote/core";
 
 /** Handle the {@link https://github.com/alexey-pelykh/lhremote#account--instance | list-accounts} CLI command. */

--- a/packages/cli/src/handlers/query-messages.integration.test.ts
+++ b/packages/cli/src/handlers/query-messages.integration.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 

--- a/packages/cli/src/handlers/query-messages.test.ts
+++ b/packages/cli/src/handlers/query-messages.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/cli/src/handlers/query-messages.ts
+++ b/packages/cli/src/handlers/query-messages.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import {
   type Chat,
   type ConversationThread,

--- a/packages/cli/src/handlers/query-profile.test.ts
+++ b/packages/cli/src/handlers/query-profile.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/cli/src/handlers/query-profile.ts
+++ b/packages/cli/src/handlers/query-profile.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import {
   type Profile,
   DatabaseClient,

--- a/packages/cli/src/handlers/query-profiles.test.ts
+++ b/packages/cli/src/handlers/query-profiles.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/cli/src/handlers/query-profiles.ts
+++ b/packages/cli/src/handlers/query-profiles.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import {
   DatabaseClient,
   discoverAllDatabases,

--- a/packages/cli/src/handlers/quit-app.test.ts
+++ b/packages/cli/src/handlers/quit-app.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/cli/src/handlers/quit-app.ts
+++ b/packages/cli/src/handlers/quit-app.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { AppService, errorMessage } from "@lhremote/core";
 
 /** Handle the {@link https://github.com/alexey-pelykh/lhremote#app-management | quit-app} CLI command. */

--- a/packages/cli/src/handlers/scrape-messaging-history.test.ts
+++ b/packages/cli/src/handlers/scrape-messaging-history.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/cli/src/handlers/scrape-messaging-history.ts
+++ b/packages/cli/src/handlers/scrape-messaging-history.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import {
   type MessageStats,
   errorMessage,

--- a/packages/cli/src/handlers/start-instance.test.ts
+++ b/packages/cli/src/handlers/start-instance.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/cli/src/handlers/start-instance.ts
+++ b/packages/cli/src/handlers/start-instance.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import {
   errorMessage,
   LauncherService,

--- a/packages/cli/src/handlers/stop-instance.test.ts
+++ b/packages/cli/src/handlers/stop-instance.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/cli/src/handlers/stop-instance.ts
+++ b/packages/cli/src/handlers/stop-instance.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { errorMessage, LauncherService } from "@lhremote/core";
 
 /** Handle the {@link https://github.com/alexey-pelykh/lhremote#account--instance | stop-instance} CLI command. */

--- a/packages/cli/src/handlers/testing/mock-helpers.ts
+++ b/packages/cli/src/handlers/testing/mock-helpers.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { vi } from "vitest";
 
 import type {

--- a/packages/cli/src/program.test.ts
+++ b/packages/cli/src/program.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { createRequire } from "node:module";
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { createRequire } from "node:module";
 
 import { Command, InvalidArgumentError, Option } from "commander";

--- a/packages/core/src/cdp/app-discovery.test.ts
+++ b/packages/core/src/cdp/app-discovery.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { findApp } from "./app-discovery.js";
 

--- a/packages/core/src/cdp/app-discovery.ts
+++ b/packages/core/src/cdp/app-discovery.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { pidToPorts } from "pid-port";
 import psList from "ps-list";
 import { isCdpPort } from "../utils/cdp-port.js";

--- a/packages/core/src/cdp/client.integration.test.ts
+++ b/packages/core/src/cdp/client.integration.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
 import { CDPClient } from "./client.js";
 import { CDPEvaluationError } from "./errors.js";

--- a/packages/core/src/cdp/client.test.ts
+++ b/packages/core/src/cdp/client.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   CDPConnectionError,

--- a/packages/core/src/cdp/client.ts
+++ b/packages/core/src/cdp/client.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import type { Protocol } from "devtools-protocol";
 import type { CdpTarget } from "../types/cdp.js";
 import {

--- a/packages/core/src/cdp/discovery.integration.test.ts
+++ b/packages/core/src/cdp/discovery.integration.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { discoverTargets } from "./discovery.js";
 import {

--- a/packages/core/src/cdp/discovery.test.ts
+++ b/packages/core/src/cdp/discovery.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { CdpTarget } from "../types/cdp.js";
 import { CDPConnectionError } from "./errors.js";

--- a/packages/core/src/cdp/discovery.ts
+++ b/packages/core/src/cdp/discovery.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import type { CdpTarget } from "../types/cdp.js";
 import { CDPConnectionError } from "./errors.js";
 

--- a/packages/core/src/cdp/errors.test.ts
+++ b/packages/core/src/cdp/errors.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { describe, expect, it } from "vitest";
 import {
   CDPConnectionError,

--- a/packages/core/src/cdp/errors.ts
+++ b/packages/core/src/cdp/errors.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 /**
  * Base class for all CDP-related errors.
  */

--- a/packages/core/src/cdp/index.ts
+++ b/packages/core/src/cdp/index.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 export { CDPClient } from "./client.js";
 export { discoverTargets } from "./discovery.js";
 export {

--- a/packages/core/src/cdp/instance-discovery.integration.test.ts
+++ b/packages/core/src/cdp/instance-discovery.integration.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { pidToPorts, portToPid } from "pid-port";
 import psList from "ps-list";

--- a/packages/core/src/cdp/instance-discovery.test.ts
+++ b/packages/core/src/cdp/instance-discovery.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { discoverInstancePort } from "./instance-discovery.js";
 

--- a/packages/core/src/cdp/instance-discovery.ts
+++ b/packages/core/src/cdp/instance-discovery.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { pidToPorts, portToPid } from "pid-port";
 import psList from "ps-list";
 import { isCdpPort } from "../utils/cdp-port.js";

--- a/packages/core/src/cdp/testing/launch-chromium.ts
+++ b/packages/core/src/cdp/testing/launch-chromium.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { type ChildProcess, spawn } from "node:child_process";
 import { createServer } from "node:net";
 import { tmpdir } from "node:os";

--- a/packages/core/src/data/action-types.test.ts
+++ b/packages/core/src/data/action-types.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { describe, it, expect } from "vitest";
 
 import {

--- a/packages/core/src/data/action-types.ts
+++ b/packages/core/src/data/action-types.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 /**
  * LinkedHelper action type identifiers.
  *

--- a/packages/core/src/data/index.ts
+++ b/packages/core/src/data/index.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 export type {
   ActionCategory,
   ActionType,

--- a/packages/core/src/db/client.integration.test.ts
+++ b/packages/core/src/db/client.integration.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, describe, expect, it } from "vitest";
 
 import { DatabaseClient } from "./client.js";

--- a/packages/core/src/db/client.test.ts
+++ b/packages/core/src/db/client.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { DatabaseClient } from "./client.js";

--- a/packages/core/src/db/client.ts
+++ b/packages/core/src/db/client.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { DatabaseSync } from "node:sqlite";
 
 /**

--- a/packages/core/src/db/discovery.integration.test.ts
+++ b/packages/core/src/db/discovery.integration.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { copyFileSync, mkdirSync, rmSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";

--- a/packages/core/src/db/discovery.test.ts
+++ b/packages/core/src/db/discovery.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { existsSync, readdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";

--- a/packages/core/src/db/discovery.ts
+++ b/packages/core/src/db/discovery.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { existsSync, readdirSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";

--- a/packages/core/src/db/errors.test.ts
+++ b/packages/core/src/db/errors.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { describe, expect, it } from "vitest";
 
 import {

--- a/packages/core/src/db/errors.ts
+++ b/packages/core/src/db/errors.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 /**
  * Base class for all database-related errors.
  */

--- a/packages/core/src/db/index.ts
+++ b/packages/core/src/db/index.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 export { DatabaseClient, type DatabaseClientOptions } from "./client.js";
 export { discoverAllDatabases, discoverDatabase } from "./discovery.js";
 export {

--- a/packages/core/src/db/repositories/campaign.test.ts
+++ b/packages/core/src/db/repositories/campaign.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import type { DatabaseSync } from "node:sqlite";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 

--- a/packages/core/src/db/repositories/campaign.ts
+++ b/packages/core/src/db/repositories/campaign.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import type {
   ActionConfig,
   ActionErrorSummary,

--- a/packages/core/src/db/repositories/index.ts
+++ b/packages/core/src/db/repositories/index.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 export { CampaignRepository } from "./campaign.js";
 export { MessageRepository } from "./message.js";
 export { ProfileRepository } from "./profile.js";

--- a/packages/core/src/db/repositories/message.integration.test.ts
+++ b/packages/core/src/db/repositories/message.integration.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import { DatabaseClient } from "../client.js";

--- a/packages/core/src/db/repositories/message.test.ts
+++ b/packages/core/src/db/repositories/message.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import type { DatabaseSync } from "node:sqlite";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 

--- a/packages/core/src/db/repositories/message.ts
+++ b/packages/core/src/db/repositories/message.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import type {
   Chat,
   ChatParticipant,

--- a/packages/core/src/db/repositories/profile.integration.test.ts
+++ b/packages/core/src/db/repositories/profile.integration.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
 import { DatabaseClient } from "../client.js";

--- a/packages/core/src/db/repositories/profile.test.ts
+++ b/packages/core/src/db/repositories/profile.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import type { DatabaseSync } from "node:sqlite";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 

--- a/packages/core/src/db/repositories/profile.ts
+++ b/packages/core/src/db/repositories/profile.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import type {
   CurrentPosition,
   Education,

--- a/packages/core/src/db/testing/create-fixture.ts
+++ b/packages/core/src/db/testing/create-fixture.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 /**
  * Generates a test fixture SQLite database with the real LinkedHelper
  * schema populated with synthetic (non-personal) mock data.

--- a/packages/core/src/db/testing/open-fixture.ts
+++ b/packages/core/src/db/testing/open-fixture.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { copyFileSync, unlinkSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { randomUUID } from "node:crypto";

--- a/packages/core/src/formats/campaign-format.test.ts
+++ b/packages/core/src/formats/campaign-format.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { describe, expect, it } from "vitest";
 
 import type { Campaign, CampaignAction } from "../types/index.js";

--- a/packages/core/src/formats/campaign-format.ts
+++ b/packages/core/src/formats/campaign-format.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
 
 import { errorMessage } from "../utils/error-message.js";

--- a/packages/core/src/formats/index.ts
+++ b/packages/core/src/formats/index.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 export {
   CampaignFormatError,
   parseCampaignJson,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 // Types (profile, messaging, instance, account, campaign — CDP types are internal)
 export type {
   Account,

--- a/packages/core/src/services/account-resolution.ts
+++ b/packages/core/src/services/account-resolution.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import type { Account } from "../types/index.js";
 import { LauncherService } from "./launcher.js";
 import { ServiceError } from "./errors.js";

--- a/packages/core/src/services/app.e2e.test.ts
+++ b/packages/core/src/services/app.e2e.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { describeE2E, launchApp, quitApp, retryAsync } from "../testing/e2e-helpers.js";
 import { findApp, type DiscoveredApp } from "../cdp/app-discovery.js";

--- a/packages/core/src/services/app.test.ts
+++ b/packages/core/src/services/app.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { type ChildProcess, spawn } from "node:child_process";
 import { accessSync } from "node:fs";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/packages/core/src/services/app.ts
+++ b/packages/core/src/services/app.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { type ChildProcess, spawn } from "node:child_process";
 import { accessSync, constants } from "node:fs";
 import { join } from "node:path";

--- a/packages/core/src/services/campaign.test.ts
+++ b/packages/core/src/services/campaign.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type {

--- a/packages/core/src/services/campaign.ts
+++ b/packages/core/src/services/campaign.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import type {
   ActionPeopleCounts,
   Campaign,

--- a/packages/core/src/services/errors.test.ts
+++ b/packages/core/src/services/errors.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { describe, expect, it } from "vitest";
 import {
   ActionExecutionError,

--- a/packages/core/src/services/errors.ts
+++ b/packages/core/src/services/errors.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 /**
  * Base class for all service-layer errors.
  */

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 export { AppService, type AppServiceOptions } from "./app.js";
 export { InstanceService, type ActionResult } from "./instance.js";
 export {

--- a/packages/core/src/services/instance-context.ts
+++ b/packages/core/src/services/instance-context.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { DatabaseClient, type DatabaseClientOptions, discoverDatabase } from "../db/index.js";
 import { discoverInstancePort } from "../cdp/index.js";
 import { InstanceService } from "./instance.js";

--- a/packages/core/src/services/instance-lifecycle.test.ts
+++ b/packages/core/src/services/instance-lifecycle.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../cdp/index.js", async (importOriginal) => {

--- a/packages/core/src/services/instance-lifecycle.ts
+++ b/packages/core/src/services/instance-lifecycle.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { discoverInstancePort } from "../cdp/index.js";
 import { delay } from "../utils/delay.js";
 import type { LauncherService } from "./launcher.js";

--- a/packages/core/src/services/instance.test.ts
+++ b/packages/core/src/services/instance.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { CdpTarget } from "../types/cdp.js";

--- a/packages/core/src/services/instance.ts
+++ b/packages/core/src/services/instance.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { CDPClient, discoverTargets } from "../cdp/index.js";
 import type { CdpTarget } from "../types/cdp.js";
 import { delay } from "../utils/delay.js";

--- a/packages/core/src/services/launcher.test.ts
+++ b/packages/core/src/services/launcher.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {

--- a/packages/core/src/services/launcher.ts
+++ b/packages/core/src/services/launcher.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { CDPClient, CDPConnectionError, CDPEvaluationError } from "../cdp/index.js";
 import type {
   Account,

--- a/packages/core/src/services/mcp-claude.e2e.test.ts
+++ b/packages/core/src/services/mcp-claude.e2e.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { execFileSync } from "node:child_process";
 import { resolve } from "node:path";
 

--- a/packages/core/src/services/status.test.ts
+++ b/packages/core/src/services/status.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("../cdp/index.js", () => ({

--- a/packages/core/src/services/status.ts
+++ b/packages/core/src/services/status.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { discoverInstancePort } from "../cdp/index.js";
 import { DatabaseClient, discoverAllDatabases } from "../db/index.js";
 import { LauncherService } from "./launcher.js";

--- a/packages/core/src/testing/e2e-helpers.ts
+++ b/packages/core/src/testing/e2e-helpers.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { describe } from "vitest";
 import { AppService, type AppServiceOptions } from "../services/app.js";
 import { AppNotFoundError } from "../services/errors.js";

--- a/packages/core/src/types/account.test.ts
+++ b/packages/core/src/types/account.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { describe, expect, it } from "vitest";
 import type { Account } from "./account.js";
 

--- a/packages/core/src/types/account.ts
+++ b/packages/core/src/types/account.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 /**
  * A LinkedHelper account as stored in the Electron store.
  *

--- a/packages/core/src/types/campaign.ts
+++ b/packages/core/src/types/campaign.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 /**
  * Campaign state enumeration.
  */

--- a/packages/core/src/types/cdp.test.ts
+++ b/packages/core/src/types/cdp.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { describe, expect, it } from "vitest";
 import type { CdpTarget } from "./cdp.js";
 

--- a/packages/core/src/types/cdp.ts
+++ b/packages/core/src/types/cdp.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 /**
  * Entry returned by Chrome's HTTP `/json/list` debugging endpoint.
  *

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 export type {
   CurrentPosition,
   Education,

--- a/packages/core/src/types/instance.test.ts
+++ b/packages/core/src/types/instance.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { describe, expect, it } from "vitest";
 import type {
   InstanceInfo,

--- a/packages/core/src/types/instance.ts
+++ b/packages/core/src/types/instance.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 /**
  * LinkedHelper instance lifecycle types.
  *

--- a/packages/core/src/types/messaging.ts
+++ b/packages/core/src/types/messaging.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 /**
  * Messaging types derived from LinkedHelper's SQLite schema.
  *

--- a/packages/core/src/types/profile.test.ts
+++ b/packages/core/src/types/profile.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { describe, expect, it } from "vitest";
 import type {
   CurrentPosition,

--- a/packages/core/src/types/profile.ts
+++ b/packages/core/src/types/profile.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 /**
  * Core people/profile types derived from LinkedHelper's SQLite schema.
  *

--- a/packages/core/src/utils/cdp-port.test.ts
+++ b/packages/core/src/utils/cdp-port.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { isCdpPort } from "./cdp-port.js";
 

--- a/packages/core/src/utils/cdp-port.ts
+++ b/packages/core/src/utils/cdp-port.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 /**
  * Check whether a port exposes a CDP `/json/list` endpoint.
  */

--- a/packages/core/src/utils/delay.test.ts
+++ b/packages/core/src/utils/delay.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { describe, expect, it } from "vitest";
 import { delay } from "./delay.js";
 

--- a/packages/core/src/utils/delay.ts
+++ b/packages/core/src/utils/delay.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 /**
  * Return a promise that resolves after the given number of milliseconds.
  */

--- a/packages/core/src/utils/error-message.test.ts
+++ b/packages/core/src/utils/error-message.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { describe, expect, it } from "vitest";
 import { errorMessage } from "./error-message.js";
 

--- a/packages/core/src/utils/error-message.ts
+++ b/packages/core/src/utils/error-message.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 /**
  * Extract a human-readable message from an unknown caught value.
  */

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 export { isCdpPort } from "./cdp-port.js";
 export { delay } from "./delay.js";
 export { errorMessage } from "./error-message.js";

--- a/packages/lhremote/src/cli.test.ts
+++ b/packages/lhremote/src/cli.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { describe, expect, it } from "vitest";
 
 import { createProgram } from "@lhremote/cli";

--- a/packages/lhremote/src/cli.ts
+++ b/packages/lhremote/src/cli.ts
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
 
 import { createProgram } from "@lhremote/cli";
 import { runStdioServer } from "@lhremote/mcp/stdio";

--- a/packages/mcp/src/helpers.ts
+++ b/packages/mcp/src/helpers.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import {
   AccountResolutionError,
   errorMessage,

--- a/packages/mcp/src/index.ts
+++ b/packages/mcp/src/index.ts
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
 
 import { runStdioServer } from "./stdio.js";
 

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { createRequire } from "node:module";
 
 import type { Client } from "@modelcontextprotocol/sdk/client/index.js";

--- a/packages/mcp/src/server.ts
+++ b/packages/mcp/src/server.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { createRequire } from "node:module";
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";

--- a/packages/mcp/src/stdio.ts
+++ b/packages/mcp/src/stdio.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { errorMessage } from "@lhremote/core";
 

--- a/packages/mcp/src/tools/campaign-add-action.test.ts
+++ b/packages/mcp/src/tools/campaign-add-action.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/mcp/src/tools/campaign-add-action.ts
+++ b/packages/mcp/src/tools/campaign-add-action.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   CampaignNotFoundError,

--- a/packages/mcp/src/tools/campaign-create.test.ts
+++ b/packages/mcp/src/tools/campaign-create.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/mcp/src/tools/campaign-create.ts
+++ b/packages/mcp/src/tools/campaign-create.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   CampaignExecutionError,

--- a/packages/mcp/src/tools/campaign-delete.test.ts
+++ b/packages/mcp/src/tools/campaign-delete.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/mcp/src/tools/campaign-delete.ts
+++ b/packages/mcp/src/tools/campaign-delete.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   CampaignExecutionError,

--- a/packages/mcp/src/tools/campaign-exclude-add.test.ts
+++ b/packages/mcp/src/tools/campaign-exclude-add.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/mcp/src/tools/campaign-exclude-add.ts
+++ b/packages/mcp/src/tools/campaign-exclude-add.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   ActionNotFoundError,

--- a/packages/mcp/src/tools/campaign-exclude-list.test.ts
+++ b/packages/mcp/src/tools/campaign-exclude-list.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/mcp/src/tools/campaign-exclude-list.ts
+++ b/packages/mcp/src/tools/campaign-exclude-list.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   ActionNotFoundError,

--- a/packages/mcp/src/tools/campaign-exclude-remove.test.ts
+++ b/packages/mcp/src/tools/campaign-exclude-remove.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/mcp/src/tools/campaign-exclude-remove.ts
+++ b/packages/mcp/src/tools/campaign-exclude-remove.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   ActionNotFoundError,

--- a/packages/mcp/src/tools/campaign-export.test.ts
+++ b/packages/mcp/src/tools/campaign-export.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/mcp/src/tools/campaign-export.ts
+++ b/packages/mcp/src/tools/campaign-export.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   CampaignNotFoundError,

--- a/packages/mcp/src/tools/campaign-get.test.ts
+++ b/packages/mcp/src/tools/campaign-get.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/mcp/src/tools/campaign-get.ts
+++ b/packages/mcp/src/tools/campaign-get.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   CampaignNotFoundError,

--- a/packages/mcp/src/tools/campaign-list.test.ts
+++ b/packages/mcp/src/tools/campaign-list.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/mcp/src/tools/campaign-list.ts
+++ b/packages/mcp/src/tools/campaign-list.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   CampaignRepository,

--- a/packages/mcp/src/tools/campaign-move-next.test.ts
+++ b/packages/mcp/src/tools/campaign-move-next.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/mcp/src/tools/campaign-move-next.ts
+++ b/packages/mcp/src/tools/campaign-move-next.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   ActionNotFoundError,

--- a/packages/mcp/src/tools/campaign-remove-action.test.ts
+++ b/packages/mcp/src/tools/campaign-remove-action.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/mcp/src/tools/campaign-remove-action.ts
+++ b/packages/mcp/src/tools/campaign-remove-action.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   ActionNotFoundError,

--- a/packages/mcp/src/tools/campaign-reorder-actions.test.ts
+++ b/packages/mcp/src/tools/campaign-reorder-actions.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/mcp/src/tools/campaign-reorder-actions.ts
+++ b/packages/mcp/src/tools/campaign-reorder-actions.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   ActionNotFoundError,

--- a/packages/mcp/src/tools/campaign-retry.test.ts
+++ b/packages/mcp/src/tools/campaign-retry.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/mcp/src/tools/campaign-retry.ts
+++ b/packages/mcp/src/tools/campaign-retry.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   CampaignNotFoundError,

--- a/packages/mcp/src/tools/campaign-start.test.ts
+++ b/packages/mcp/src/tools/campaign-start.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/mcp/src/tools/campaign-start.ts
+++ b/packages/mcp/src/tools/campaign-start.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   CampaignExecutionError,

--- a/packages/mcp/src/tools/campaign-statistics.test.ts
+++ b/packages/mcp/src/tools/campaign-statistics.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/mcp/src/tools/campaign-statistics.ts
+++ b/packages/mcp/src/tools/campaign-statistics.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   ActionNotFoundError,

--- a/packages/mcp/src/tools/campaign-status.test.ts
+++ b/packages/mcp/src/tools/campaign-status.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/mcp/src/tools/campaign-status.ts
+++ b/packages/mcp/src/tools/campaign-status.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   CampaignExecutionError,

--- a/packages/mcp/src/tools/campaign-stop.test.ts
+++ b/packages/mcp/src/tools/campaign-stop.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/mcp/src/tools/campaign-stop.ts
+++ b/packages/mcp/src/tools/campaign-stop.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   CampaignExecutionError,

--- a/packages/mcp/src/tools/campaign-update.test.ts
+++ b/packages/mcp/src/tools/campaign-update.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/mcp/src/tools/campaign-update.ts
+++ b/packages/mcp/src/tools/campaign-update.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   CampaignNotFoundError,

--- a/packages/mcp/src/tools/check-replies.test.ts
+++ b/packages/mcp/src/tools/check-replies.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/mcp/src/tools/check-replies.ts
+++ b/packages/mcp/src/tools/check-replies.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   MessageRepository,

--- a/packages/mcp/src/tools/check-status.test.ts
+++ b/packages/mcp/src/tools/check-status.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/mcp/src/tools/check-status.ts
+++ b/packages/mcp/src/tools/check-status.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { checkStatus, errorMessage } from "@lhremote/core";
 import { z } from "zod";

--- a/packages/mcp/src/tools/describe-actions.test.ts
+++ b/packages/mcp/src/tools/describe-actions.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/mcp/src/tools/describe-actions.ts
+++ b/packages/mcp/src/tools/describe-actions.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { getActionTypeCatalog, getActionTypeInfo } from "@lhremote/core";
 import { z } from "zod";

--- a/packages/mcp/src/tools/find-app.ts
+++ b/packages/mcp/src/tools/find-app.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { errorMessage, findApp } from "@lhremote/core";
 

--- a/packages/mcp/src/tools/import-people-from-urls.test.ts
+++ b/packages/mcp/src/tools/import-people-from-urls.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/mcp/src/tools/import-people-from-urls.ts
+++ b/packages/mcp/src/tools/import-people-from-urls.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   CampaignExecutionError,

--- a/packages/mcp/src/tools/index.ts
+++ b/packages/mcp/src/tools/index.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 
 import { registerCampaignAddAction } from "./campaign-add-action.js";

--- a/packages/mcp/src/tools/launch-app.test.ts
+++ b/packages/mcp/src/tools/launch-app.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/mcp/src/tools/launch-app.ts
+++ b/packages/mcp/src/tools/launch-app.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { AppLaunchError, AppNotFoundError, AppService, errorMessage } from "@lhremote/core";
 import { z } from "zod";

--- a/packages/mcp/src/tools/list-accounts.test.ts
+++ b/packages/mcp/src/tools/list-accounts.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/mcp/src/tools/list-accounts.ts
+++ b/packages/mcp/src/tools/list-accounts.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { errorMessage, LauncherService, LinkedHelperNotRunningError } from "@lhremote/core";
 import { z } from "zod";

--- a/packages/mcp/src/tools/query-messages.integration.test.ts
+++ b/packages/mcp/src/tools/query-messages.integration.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 

--- a/packages/mcp/src/tools/query-messages.test.ts
+++ b/packages/mcp/src/tools/query-messages.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/mcp/src/tools/query-messages.ts
+++ b/packages/mcp/src/tools/query-messages.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   ChatNotFoundError,

--- a/packages/mcp/src/tools/query-profile.test.ts
+++ b/packages/mcp/src/tools/query-profile.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/mcp/src/tools/query-profile.ts
+++ b/packages/mcp/src/tools/query-profile.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   DatabaseClient,

--- a/packages/mcp/src/tools/query-profiles.test.ts
+++ b/packages/mcp/src/tools/query-profiles.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/mcp/src/tools/query-profiles.ts
+++ b/packages/mcp/src/tools/query-profiles.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   DatabaseClient,

--- a/packages/mcp/src/tools/quit-app.test.ts
+++ b/packages/mcp/src/tools/quit-app.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/mcp/src/tools/quit-app.ts
+++ b/packages/mcp/src/tools/quit-app.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { AppService, errorMessage } from "@lhremote/core";
 import { z } from "zod";

--- a/packages/mcp/src/tools/scrape-messaging-history.test.ts
+++ b/packages/mcp/src/tools/scrape-messaging-history.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/mcp/src/tools/scrape-messaging-history.ts
+++ b/packages/mcp/src/tools/scrape-messaging-history.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   MessageRepository,

--- a/packages/mcp/src/tools/start-instance.test.ts
+++ b/packages/mcp/src/tools/start-instance.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/mcp/src/tools/start-instance.ts
+++ b/packages/mcp/src/tools/start-instance.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   type Account,

--- a/packages/mcp/src/tools/stop-instance.test.ts
+++ b/packages/mcp/src/tools/stop-instance.test.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@lhremote/core", async (importOriginal) => {

--- a/packages/mcp/src/tools/stop-instance.ts
+++ b/packages/mcp/src/tools/stop-instance.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   type Account,

--- a/packages/mcp/src/tools/testing/mock-server.ts
+++ b/packages/mcp/src/tools/testing/mock-server.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { vi } from "vitest";
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({


### PR DESCRIPTION
## Summary

- Adds `SPDX-License-Identifier: AGPL-3.0-only` and `Copyright (C) 2025 Alexey Pelykh` headers to all 226 source files
- Covers 119 non-test `.ts` files, 104 test `.ts` files, and 3 root config files (`eslint.config.js`, `vitest.config.ts`, `vitest.e2e.config.ts`)
- Preserves shebang lines above the header in 3 entry-point files (`packages/cli/src/cli.ts`, `packages/lhremote/src/cli.ts`, `packages/mcp/src/index.ts`)

## Test plan

- [x] Build passes (`pnpm build`)
- [x] All tests pass (`pnpm test`)
- [x] Lint passes (`pnpm lint`)
- [x] Shebang files verified to keep `#!/usr/bin/env node` as first line

Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)