### PR TITLE
Add ESLint rule to enforce SPDX license headers

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,6 +4,13 @@
 import eslint from "@eslint/js";
 import tseslint from "typescript-eslint";
 import eslintConfigPrettier from "eslint-config-prettier";
+import headerPlugin from "eslint-plugin-header";
+
+// Workaround: eslint-plugin-header lacks meta.schema, which ESLint >=9.4
+// treats as "no options allowed". Setting schema to false disables validation.
+// See https://github.com/Stuk/eslint-plugin-header/issues/57
+headerPlugin.rules.header.meta ??= {};
+headerPlugin.rules.header.meta.schema = false;
 
 export default tseslint.config(
   eslint.configs.recommended,
@@ -11,5 +18,20 @@ export default tseslint.config(
   eslintConfigPrettier,
   {
     ignores: ["**/dist/"],
+  },
+  {
+    plugins: {
+      header: headerPlugin,
+    },
+    rules: {
+      "header/header": [
+        "error",
+        "line",
+        [
+          " SPDX-License-Identifier: AGPL-3.0-only",
+          " Copyright (C) 2025 Alexey Pelykh",
+        ],
+      ],
+    },
   },
 );

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@vitest/coverage-v8": "catalog:",
     "eslint": "^9.39.2",
     "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-header": "catalog:",
     "prettier": "^3.8.1",
     "turbo": "^2.3.4",
     "typescript": "^5.9.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ catalogs:
     eslint:
       specifier: ^9.39.2
       version: 9.39.2
+    eslint-plugin-header:
+      specifier: ^3.1.1
+      version: 3.1.1
     get-port:
       specifier: ^7.1.0
       version: 7.1.0
@@ -68,6 +71,9 @@ importers:
       eslint-config-prettier:
         specifier: ^10.1.8
         version: 10.1.8(eslint@9.39.2)
+      eslint-plugin-header:
+        specifier: 'catalog:'
+        version: 3.1.1(eslint@9.39.2)
       prettier:
         specifier: ^3.8.1
         version: 3.8.1
@@ -903,6 +909,11 @@ packages:
     hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
+
+  eslint-plugin-header@3.1.1:
+    resolution: {integrity: sha512-9vlKxuJ4qf793CmeeSrZUvVClw6amtpghq3CuWcB5cUNnWHQhgcqy5eF8oVKFk1G3Y/CbchGfEaw3wiIJaNmVg==}
+    peerDependencies:
+      eslint: '>=7.7.0'
 
   eslint-scope@8.4.0:
     resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
@@ -2353,6 +2364,10 @@ snapshots:
   escape-string-regexp@4.0.0: {}
 
   eslint-config-prettier@10.1.8(eslint@9.39.2):
+    dependencies:
+      eslint: 9.39.2
+
+  eslint-plugin-header@3.1.1(eslint@9.39.2):
     dependencies:
       eslint: 9.39.2
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,6 +11,7 @@ catalog:
   prettier: "^3.8.1"
   typescript-eslint: "^8.54.0"
   eslint-config-prettier: "^10.1.8"
+  eslint-plugin-header: "^3.1.1"
   playwright-core: "^1.52.0"
   pid-port: "^2.0.1"
   ps-list: "^9.0.0"


### PR DESCRIPTION
## Summary

- Add `eslint-plugin-header` to enforce the standard SPDX license header (`AGPL-3.0-only` + copyright) on all linted files
- Include a workaround for the plugin's missing `meta.schema` (upstream [issue #57](https://github.com/Stuk/eslint-plugin-header/issues/57)) to support ESLint >=9.4
- The rule supports `--fix` to auto-insert missing headers

Closes #195

## Test plan

- [x] `pnpm lint` passes on all existing files (all already have headers)
- [x] New `.ts` file without header causes lint failure (`missing header`)
- [x] `eslint --fix` auto-inserts the correct header
- [x] `pnpm test` passes (477 tests)
- [x] `pnpm build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)