### PR TITLE
Fix Windows CI test timeout in polling tests

### DIFF
--- a/packages/core/src/services/instance-lifecycle.test.ts
+++ b/packages/core/src/services/instance-lifecycle.test.ts
@@ -156,7 +156,9 @@ describe("waitForInstancePort", () => {
       .mockResolvedValueOnce(null)
       .mockResolvedValue(55123);
 
-    const result = await waitForInstancePort(9222);
+    const resultPromise = waitForInstancePort(9222);
+    await vi.advanceTimersByTimeAsync(3_000);
+    const result = await resultPromise;
 
     expect(result).toBe(55123);
     expect(discoverInstancePort).toHaveBeenCalledTimes(3);
@@ -198,7 +200,9 @@ describe("waitForInstanceShutdown", () => {
       .mockResolvedValueOnce(55123)
       .mockResolvedValue(null);
 
-    await waitForInstanceShutdown(9222);
+    const promise = waitForInstanceShutdown(9222);
+    await vi.advanceTimersByTimeAsync(3_000);
+    await promise;
 
     expect(discoverInstancePort).toHaveBeenCalledTimes(3);
   });


### PR DESCRIPTION
## Summary
- Polling tests (`waitForInstancePort`, `waitForInstanceShutdown`) relied on `shouldAdvanceTime: true` to auto-advance fake timers, which is too slow on Windows CI runners and causes the default 5s test timeout to be exceeded
- Replaced with explicit `vi.advanceTimersByTimeAsync()` calls, matching the pattern already used by the timeout tests in the same file

## Test plan
- [x] All 477 tests pass locally
- [ ] CI passes on all platforms (ubuntu, macos, **windows**)

🤖 Generated with [Claude Code](https://claude.com/claude-code)