### PR TITLE
(chore) ci: add fail-fast: false to CI matrix strategy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
     name: Build, Lint & Test (${{ matrix.os }})
     timeout-minutes: 15
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Summary
- Add `fail-fast: false` to the CI matrix strategy so all three OS jobs (Ubuntu, macOS, Windows) run to completion regardless of individual failures

Closes #209

## Test plan
- [ ] CI runs on all three OS platforms complete independently (no cancellation on failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)