### PR TITLE
(chore) ci: pin npm version in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
 
       # Trusted publishing requires npm 11.5.1+ for OIDC token exchange
       - name: Upgrade npm
-        run: npm install -g npm@latest
+        run: npm install -g "npm@^11.5.1"
 
       - name: Stamp version
         env:


### PR DESCRIPTION
## Summary
- Pin npm to `^11.5.1` instead of `@latest` in the release workflow to prevent floating versions across releases and reduce supply chain risk
- OIDC trusted publishing still works since `^11.5.1` satisfies the minimum requirement

Closes #210

## Test plan
- [ ] CI passes on this PR
- [ ] Next release publish succeeds with pinned npm version

🤖 Generated with [Claude Code](https://claude.com/claude-code)