### PR TITLE
(fix) docs: CLI README installation instructions contradict root README

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -8,14 +8,18 @@ Built on [`@lhremote/core`](../core).
 
 ## Installation
 
+End users should install the [`lhremote`](https://www.npmjs.com/package/lhremote) meta-package, which includes both the CLI and MCP server:
+
 ```bash
-npm install -g @lhremote/cli
+npm install -g lhremote
 ```
 
-Or run directly with npx:
+This provides the `lhremote` binary. See the [root README](https://github.com/alexey-pelykh/lhremote#installation) for full details.
+
+Installing `@lhremote/cli` directly is possible but provides the `lhremote-cli` binary instead:
 
 ```bash
-npx @lhremote/cli --help
+npm install -g @lhremote/cli    # binary: lhremote-cli
 ```
 
 ## Usage


### PR DESCRIPTION
## Summary

- Updated `packages/cli/README.md` installation section to recommend `lhremote` meta-package as the primary install path (consistent with root README)
- Clarified that installing `@lhremote/cli` directly is possible but provides the `lhremote-cli` binary instead of `lhremote`

Closes #211

## Test plan

- [ ] Verify `packages/cli/README.md` installation instructions now recommend `npm install -g lhremote`
- [ ] Verify no contradiction between root README and CLI README

🤖 Generated with [Claude Code](https://claude.com/claude-code)