### PR TITLE
(chore) github: add issue templates for bug reports and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,69 @@
+name: Bug Report
+description: Report a bug or unexpected behavior
+labels: ["bug"]
+body:
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating System
+      options:
+        - Windows
+        - macOS
+        - Linux
+    validations:
+      required: true
+
+  - type: input
+    id: node-version
+    attributes:
+      label: Node.js Version
+      description: "Output of `node --version`"
+      placeholder: "e.g. v24.0.0"
+    validations:
+      required: true
+
+  - type: input
+    id: lh-version
+    attributes:
+      label: LinkedHelper Version
+      description: The version of the LinkedHelper desktop app
+      placeholder: "e.g. 2024.12.1"
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to Reproduce
+      description: Minimal steps to reproduce the issue
+      placeholder: |
+        1. Start LinkedHelper
+        2. Run `lhremote ...`
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: What you expected to happen
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: What actually happened
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Error Output / Logs
+      description: Paste any relevant error messages or log output
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,39 @@
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Description / Use Case
+      description: What problem does this feature solve? Why is it needed?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the solution you'd like
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any alternative solutions or workarounds you've considered
+    validations:
+      required: false
+
+  - type: dropdown
+    id: interface
+    attributes:
+      label: Interface Preference
+      description: Which interface should this feature target?
+      options:
+        - CLI
+        - MCP
+        - Both
+    validations:
+      required: true


### PR DESCRIPTION
## Summary
- Add GitHub issue form templates for structured bug reports and feature requests
- Bug report template collects OS, Node.js version, LinkedHelper version, repro steps, expected/actual behavior, and logs
- Feature request template collects problem/use case, proposed solution, alternatives, and interface preference (CLI/MCP/Both)
- Add `config.yml` to allow blank issues alongside templates

Closes #219

## Test plan
- [ ] Verify templates render correctly on the "New Issue" page
- [ ] Confirm form fields match acceptance criteria (dropdowns, required fields, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)