### PR TITLE
(chore) ci: add Dependabot configuration for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+# Dependabot configuration — https://docs.github.com/en/code-security/dependabot
+
+version: 2
+
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      npm-minor-patch:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` to enable automated dependency updates
- Configure weekly scanning for both `github-actions` and `npm` ecosystems
- Group minor/patch updates per ecosystem to reduce PR noise; major bumps remain individual PRs

## Test plan
- [ ] Verify Dependabot starts creating PRs for outdated dependencies after merge
- [ ] Confirm grouped PRs contain only minor/patch updates
- [ ] Confirm major version bumps arrive as separate PRs

Closes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)