### PR TITLE
(chore) infra: add composite: true to lhremote tsconfig

### DIFF
--- a/packages/lhremote/tsconfig.json
+++ b/packages/lhremote/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "composite": true,
     "outDir": "dist",
     "rootDir": "src"
   },


### PR DESCRIPTION
## Summary

- Add `"composite": true` to `packages/lhremote/tsconfig.json` compilerOptions for consistency with `core`, `mcp`, and `cli` packages
- Enables `tsc --build` mode for the lhremote wrapper package

Closes #224

## Test plan

- [x] `pnpm build` succeeds without errors
- [ ] CI passes (build, lint, test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)