### PR TITLE
(chore) deps: convert root devDependencies to catalog refs

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,13 +19,13 @@
   "devDependencies": {
     "@eslint/js": "catalog:",
     "@vitest/coverage-v8": "catalog:",
-    "eslint": "^9.39.2",
-    "eslint-config-prettier": "^10.1.8",
+    "eslint": "catalog:",
+    "eslint-config-prettier": "catalog:",
     "eslint-plugin-header": "catalog:",
-    "prettier": "^3.8.1",
-    "turbo": "^2.3.4",
-    "typescript": "^5.9.3",
-    "typescript-eslint": "^8.54.0",
-    "vitest": "^4.0.18"
+    "prettier": "catalog:",
+    "turbo": "catalog:",
+    "typescript": "catalog:",
+    "typescript-eslint": "catalog:",
+    "vitest": "catalog:"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ catalogs:
     eslint:
       specifier: ^9.39.2
       version: 9.39.2
+    eslint-config-prettier:
+      specifier: ^10.1.8
+      version: 10.1.8
     eslint-plugin-header:
       specifier: ^3.1.1
       version: 3.1.1
@@ -36,15 +39,24 @@ catalogs:
     playwright-core:
       specifier: ^1.52.0
       version: 1.58.2
+    prettier:
+      specifier: ^3.8.1
+      version: 3.8.1
     ps-list:
       specifier: ^9.0.0
       version: 9.0.0
+    turbo:
+      specifier: ^2.3.4
+      version: 2.8.4
     typedoc:
       specifier: ^0.28.16
       version: 0.28.16
     typescript:
       specifier: ^5.9.3
       version: 5.9.3
+    typescript-eslint:
+      specifier: ^8.54.0
+      version: 8.55.0
     vitest:
       specifier: ^4.0.18
       version: 4.0.18
@@ -66,28 +78,28 @@ importers:
         specifier: 'catalog:'
         version: 4.0.18(vitest@4.0.18(@types/node@22.19.11)(yaml@2.8.2))
       eslint:
-        specifier: ^9.39.2
+        specifier: 'catalog:'
         version: 9.39.2
       eslint-config-prettier:
-        specifier: ^10.1.8
+        specifier: 'catalog:'
         version: 10.1.8(eslint@9.39.2)
       eslint-plugin-header:
         specifier: 'catalog:'
         version: 3.1.1(eslint@9.39.2)
       prettier:
-        specifier: ^3.8.1
+        specifier: 'catalog:'
         version: 3.8.1
       turbo:
-        specifier: ^2.3.4
+        specifier: 'catalog:'
         version: 2.8.4
       typescript:
-        specifier: ^5.9.3
+        specifier: 'catalog:'
         version: 5.9.3
       typescript-eslint:
-        specifier: ^8.54.0
+        specifier: 'catalog:'
         version: 8.55.0(eslint@9.39.2)(typescript@5.9.3)
       vitest:
-        specifier: ^4.0.18
+        specifier: 'catalog:'
         version: 4.0.18(@types/node@22.19.11)(yaml@2.8.2)
 
   packages/cli:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,4 +20,5 @@ catalog:
   zod: "^4.3.6"
   commander: "^14.0.3"
   typedoc: "^0.28.16"
+  turbo: "^2.3.4"
   yaml: "^2.7.1"


### PR DESCRIPTION
## Summary

- Convert 6 hardcoded version strings in root `package.json` to `catalog:` references (`eslint`, `eslint-config-prettier`, `prettier`, `typescript`, `typescript-eslint`, `vitest`)
- Add `turbo` to the pnpm catalog in `pnpm-workspace.yaml`
- Convert root `turbo` reference to `catalog:`
- All root devDependencies now use a single source of truth for version management

Closes #207

## Test plan

- [x] `pnpm install` succeeds
- [x] `pnpm build` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` — unit tests pass; 2 pre-existing integration test timeouts unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)