### PR TITLE
(chore) test: remove passWithNoTests from vitest config

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,7 +5,6 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
-    passWithNoTests: true,
     exclude: ["**/node_modules/**", "**/dist/**", "**/*.e2e.test.ts"],
     coverage: {
       provider: "v8",


### PR DESCRIPTION
## Summary

- Remove `passWithNoTests: true` from root `vitest.config.ts` so CI fails when a package has no test files, preventing silent coverage gaps
- The E2E config (`vitest.e2e.config.ts`) retains `passWithNoTests` since E2E tests are local-only

Closes #208

## Test plan

- [x] All unit tests pass locally (`pnpm test` — 8/8 turbo tasks successful)
- [ ] CI matrix (ubuntu/macos/windows) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)