### PR TITLE
(chore) ci: add npm provenance attestation to release publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,4 +64,4 @@ jobs:
         run: pnpm -r publish --dry-run --access public --no-git-checks
 
       - name: Publish packages
-        run: pnpm -r publish --access public --no-git-checks --report-summary
+        run: pnpm -r publish --access public --no-git-checks --report-summary --provenance


### PR DESCRIPTION
## Summary

- Add `--provenance` flag to the `pnpm -r publish` command in the release workflow
- Generates Sigstore-signed SLSA provenance attestation linking each npm package to its source commit and build
- The `id-token: write` permission prerequisite is already granted

Closes #222

## Test plan

- [ ] Verify CI passes on this PR (no runtime impact — flag only takes effect during actual npm publish)
- [ ] On next release, verify provenance attestation is generated
- [ ] Verify npm package pages show provenance badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)