### PR TITLE
(refactor) mcp: migrate infrastructure tools to use helpers.ts

### DIFF
--- a/packages/mcp/src/tools/check-status.ts
+++ b/packages/mcp/src/tools/check-status.ts
@@ -2,8 +2,9 @@
 // Copyright (C) 2025 Alexey Pelykh
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { checkStatus, DEFAULT_CDP_PORT, errorMessage } from "@lhremote/core";
+import { checkStatus, DEFAULT_CDP_PORT } from "@lhremote/core";
 import { z } from "zod";
+import { mcpCatchAll, mcpSuccess } from "../helpers.js";
 
 /** Register the {@link https://github.com/alexey-pelykh/lhremote#check-status | check-status} MCP tool. */
 export function registerCheckStatus(server: McpServer): void {
@@ -31,22 +32,9 @@ export function registerCheckStatus(server: McpServer): void {
       try {
         const report = await checkStatus(cdpPort, { ...(cdpHost !== undefined && { host: cdpHost }), ...(allowRemote !== undefined && { allowRemote }) });
 
-        return {
-          content: [
-            { type: "text" as const, text: JSON.stringify(report, null, 2) },
-          ],
-        };
+        return mcpSuccess(JSON.stringify(report, null, 2));
       } catch (error) {
-        const message = errorMessage(error);
-        return {
-          isError: true,
-          content: [
-            {
-              type: "text" as const,
-              text: `Failed to check status: ${message}`,
-            },
-          ],
-        };
+        return mcpCatchAll(error, "Failed to check status");
       }
     },
   );

--- a/packages/mcp/src/tools/describe-actions.ts
+++ b/packages/mcp/src/tools/describe-actions.ts
@@ -4,6 +4,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { getActionTypeCatalog, getActionTypeInfo } from "@lhremote/core";
 import { z } from "zod";
+import { mcpError, mcpSuccess } from "../helpers.js";
 
 /** Register the {@link https://github.com/alexey-pelykh/lhremote#describe-actions | describe-actions} MCP tool. */
 export function registerDescribeActions(server: McpServer): void {
@@ -25,32 +26,16 @@ export function registerDescribeActions(server: McpServer): void {
       if (actionType !== undefined) {
         const info = getActionTypeInfo(actionType);
         if (info === undefined) {
-          return {
-            isError: true,
-            content: [
-              {
-                type: "text" as const,
-                text: `Unknown action type: ${actionType}`,
-              },
-            ],
-          };
+          return mcpError(`Unknown action type: ${actionType}`);
         }
-        return {
-          content: [
-            { type: "text" as const, text: JSON.stringify(info, null, 2) },
-          ],
-        };
+        return mcpSuccess(JSON.stringify(info, null, 2));
       }
 
       const catalog = getActionTypeCatalog(
         category === "all" ? undefined : category,
       );
 
-      return {
-        content: [
-          { type: "text" as const, text: JSON.stringify(catalog, null, 2) },
-        ],
-      };
+      return mcpSuccess(JSON.stringify(catalog, null, 2));
     },
   );
 }

--- a/packages/mcp/src/tools/find-app.ts
+++ b/packages/mcp/src/tools/find-app.ts
@@ -2,7 +2,8 @@
 // Copyright (C) 2025 Alexey Pelykh
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { errorMessage, findApp } from "@lhremote/core";
+import { findApp } from "@lhremote/core";
+import { mcpCatchAll, mcpSuccess } from "../helpers.js";
 
 /** Register the {@link https://github.com/alexey-pelykh/lhremote#find-app | find-app} MCP tool. */
 export function registerFindApp(server: McpServer): void {
@@ -15,32 +16,12 @@ export function registerFindApp(server: McpServer): void {
         const apps = await findApp();
 
         if (apps.length === 0) {
-          return {
-            content: [
-              {
-                type: "text" as const,
-                text: "No running LinkedHelper instances found",
-              },
-            ],
-          };
+          return mcpSuccess("No running LinkedHelper instances found");
         }
 
-        return {
-          content: [
-            { type: "text" as const, text: JSON.stringify(apps, null, 2) },
-          ],
-        };
+        return mcpSuccess(JSON.stringify(apps, null, 2));
       } catch (error) {
-        const message = errorMessage(error);
-        return {
-          isError: true,
-          content: [
-            {
-              type: "text" as const,
-              text: `Failed to find LinkedHelper: ${message}`,
-            },
-          ],
-        };
+        return mcpCatchAll(error, "Failed to find LinkedHelper");
       }
     },
   );

--- a/packages/mcp/src/tools/launch-app.ts
+++ b/packages/mcp/src/tools/launch-app.ts
@@ -2,8 +2,9 @@
 // Copyright (C) 2025 Alexey Pelykh
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { AppLaunchError, AppNotFoundError, AppService, errorMessage } from "@lhremote/core";
+import { AppLaunchError, AppNotFoundError, AppService } from "@lhremote/core";
 import { z } from "zod";
+import { mcpCatchAll, mcpError, mcpSuccess } from "../helpers.js";
 
 /** Register the {@link https://github.com/alexey-pelykh/lhremote#launch-app | launch-app} MCP tool. */
 export function registerLaunchApp(server: McpServer): void {
@@ -28,28 +29,14 @@ export function registerLaunchApp(server: McpServer): void {
           error instanceof AppNotFoundError ||
           error instanceof AppLaunchError
         ) {
-          return {
-            isError: true,
-            content: [{ type: "text", text: error.message }],
-          };
+          return mcpError(error.message);
         }
-        const message = errorMessage(error);
-        return {
-          isError: true,
-          content: [
-            { type: "text", text: `Failed to launch LinkedHelper: ${message}` },
-          ],
-        };
+        return mcpCatchAll(error, "Failed to launch LinkedHelper");
       }
 
-      return {
-        content: [
-          {
-            type: "text",
-            text: `LinkedHelper launched on CDP port ${String(app.cdpPort)}`,
-          },
-        ],
-      };
+      return mcpSuccess(
+        `LinkedHelper launched on CDP port ${String(app.cdpPort)}`,
+      );
     },
   );
 }

--- a/packages/mcp/src/tools/list-accounts.ts
+++ b/packages/mcp/src/tools/list-accounts.ts
@@ -4,11 +4,10 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   DEFAULT_CDP_PORT,
-  errorMessage,
   LauncherService,
-  LinkedHelperNotRunningError,
 } from "@lhremote/core";
 import { z } from "zod";
+import { mcpCatchAll, mcpSuccess } from "../helpers.js";
 
 /** Register the {@link https://github.com/alexey-pelykh/lhremote#list-accounts | list-accounts} MCP tool. */
 export function registerListAccounts(server: McpServer): void {
@@ -38,44 +37,14 @@ export function registerListAccounts(server: McpServer): void {
       try {
         await launcher.connect();
       } catch (error) {
-        if (error instanceof LinkedHelperNotRunningError) {
-          return {
-            isError: true,
-            content: [
-              {
-                type: "text",
-                text: "LinkedHelper is not running. Use launch-app first.",
-              },
-            ],
-          };
-        }
-        const message = errorMessage(error);
-        return {
-          isError: true,
-          content: [
-            {
-              type: "text",
-              text: `Failed to connect to LinkedHelper: ${message}`,
-            },
-          ],
-        };
+        return mcpCatchAll(error, "Failed to connect to LinkedHelper");
       }
 
       try {
         const accounts = await launcher.listAccounts();
-        return {
-          content: [
-            { type: "text", text: JSON.stringify(accounts, null, 2) },
-          ],
-        };
+        return mcpSuccess(JSON.stringify(accounts, null, 2));
       } catch (error) {
-        const message = errorMessage(error);
-        return {
-          isError: true,
-          content: [
-            { type: "text", text: `Failed to list accounts: ${message}` },
-          ],
-        };
+        return mcpCatchAll(error, "Failed to list accounts");
       } finally {
         launcher.disconnect();
       }

--- a/packages/mcp/src/tools/quit-app.ts
+++ b/packages/mcp/src/tools/quit-app.ts
@@ -2,8 +2,9 @@
 // Copyright (C) 2025 Alexey Pelykh
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { AppService, DEFAULT_CDP_PORT, errorMessage } from "@lhremote/core";
+import { AppService, DEFAULT_CDP_PORT } from "@lhremote/core";
 import { z } from "zod";
+import { mcpCatchAll, mcpSuccess } from "../helpers.js";
 
 /** Register the {@link https://github.com/alexey-pelykh/lhremote#quit-app | quit-app} MCP tool. */
 export function registerQuitApp(server: McpServer): void {
@@ -25,18 +26,10 @@ export function registerQuitApp(server: McpServer): void {
       try {
         await app.quit();
       } catch (error) {
-        const message = errorMessage(error);
-        return {
-          isError: true,
-          content: [
-            { type: "text", text: `Failed to quit LinkedHelper: ${message}` },
-          ],
-        };
+        return mcpCatchAll(error, "Failed to quit LinkedHelper");
       }
 
-      return {
-        content: [{ type: "text", text: "LinkedHelper quit successfully" }],
-      };
+      return mcpSuccess("LinkedHelper quit successfully");
     },
   );
 }


### PR DESCRIPTION
## Summary

- Migrates all 10 infrastructure MCP tools to use `mcpSuccess()`, `mcpError()`, and `mcpCatchAll()` from `helpers.ts` instead of inline `{ content: [{ type: "text", text: ... }] }` response construction
- Removes ~260 lines of repetitive response formatting boilerplate (63 insertions, 326 deletions)
- No behavioral changes — all existing tests pass without modification since helpers produce identical response structures

Closes #218

## Test plan

- [x] `pnpm run build` — all 5 packages build successfully
- [x] `pnpm run lint` — no lint errors
- [x] `pnpm test` — all 1,077 tests pass (core: 548, mcp: 241, cli: 288)
- [x] Verified no inline `{ content: [{ type: "text" ... }] }` patterns remain in the 10 migrated files

🤖 Generated with [Claude Code](https://claude.com/claude-code)