### PR TITLE
(refactor) core: extract shared operation layer for CLI/MCP

### DIFF
--- a/packages/cli/src/handlers/campaign-status.ts
+++ b/packages/cli/src/handlers/campaign-status.ts
@@ -4,12 +4,11 @@
 import {
   CampaignExecutionError,
   CampaignNotFoundError,
-  CampaignService,
   DEFAULT_CDP_PORT,
   errorMessage,
   InstanceNotRunningError,
-  resolveAccount,
-  withInstanceDatabase,
+  campaignStatus,
+  type CampaignStatusOutput,
 } from "@lhremote/core";
 
 /** Handle the {@link https://github.com/alexey-pelykh/lhremote#campaigns | campaign-status} CLI command. */
@@ -24,65 +23,15 @@ export async function handleCampaignStatus(
     json?: boolean;
   },
 ): Promise<void> {
-  const cdpPort = options.cdpPort ?? DEFAULT_CDP_PORT;
-
-  let accountId: number;
+  let result: CampaignStatusOutput;
   try {
-    accountId = await resolveAccount(cdpPort, {
-      ...(options.cdpHost !== undefined && { host: options.cdpHost }),
-      ...(options.allowRemote !== undefined && { allowRemote: options.allowRemote }),
-    });
-  } catch (error) {
-    const message = errorMessage(error);
-    process.stderr.write(`${message}\n`);
-    process.exitCode = 1;
-    return;
-  }
-
-  try {
-    await withInstanceDatabase(cdpPort, accountId, async ({ instance, db }) => {
-      const campaignService = new CampaignService(instance, db);
-      const status = await campaignService.getStatus(campaignId);
-
-      const limit = options.limit ?? 20;
-
-      if (options.json) {
-        const response: Record<string, unknown> = { campaignId, ...status };
-        if (options.includeResults) {
-          const runResult = await campaignService.getResults(campaignId);
-          response.results = runResult.results.slice(0, limit);
-        }
-        process.stdout.write(JSON.stringify(response, null, 2) + "\n");
-      } else {
-        process.stdout.write(`Campaign #${String(campaignId)} Status\n`);
-        process.stdout.write(`State: ${status.campaignState}\n`);
-        process.stdout.write(`Paused: ${status.isPaused ? "yes" : "no"}\n`);
-        process.stdout.write(`Runner: ${status.runnerState}\n`);
-
-        if (status.actionCounts.length > 0) {
-          process.stdout.write("\nAction Counts:\n");
-          for (const ac of status.actionCounts) {
-            process.stdout.write(
-              `  Action #${String(ac.actionId)}: ${String(ac.queued)} queued, ${String(ac.processed)} processed, ${String(ac.successful)} successful, ${String(ac.failed)} failed\n`,
-            );
-          }
-        }
-
-        if (options.includeResults) {
-          const runResult = await campaignService.getResults(campaignId);
-          const results = runResult.results.slice(0, limit);
-          if (results.length > 0) {
-            process.stdout.write(`\nResults (${String(results.length)}):\n`);
-            for (const r of results) {
-              process.stdout.write(
-                `  Person ${String(r.personId)}: result=${String(r.result)} (action version #${String(r.actionVersionId)})\n`,
-              );
-            }
-          } else {
-            process.stdout.write("\nNo results yet.\n");
-          }
-        }
-      }
+    result = await campaignStatus({
+      campaignId,
+      includeResults: options.includeResults,
+      limit: options.limit,
+      cdpPort: options.cdpPort ?? DEFAULT_CDP_PORT,
+      cdpHost: options.cdpHost,
+      allowRemote: options.allowRemote,
     });
   } catch (error) {
     if (error instanceof CampaignNotFoundError) {
@@ -98,5 +47,38 @@ export async function handleCampaignStatus(
       process.stderr.write(`${message}\n`);
     }
     process.exitCode = 1;
+    return;
+  }
+
+  if (options.json) {
+    process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+  } else {
+    process.stdout.write(`Campaign #${String(campaignId)} Status\n`);
+    process.stdout.write(`State: ${result.campaignState}\n`);
+    process.stdout.write(`Paused: ${result.isPaused ? "yes" : "no"}\n`);
+    process.stdout.write(`Runner: ${result.runnerState}\n`);
+
+    if (result.actionCounts.length > 0) {
+      process.stdout.write("\nAction Counts:\n");
+      for (const ac of result.actionCounts) {
+        process.stdout.write(
+          `  Action #${String(ac.actionId)}: ${String(ac.queued)} queued, ${String(ac.processed)} processed, ${String(ac.successful)} successful, ${String(ac.failed)} failed\n`,
+        );
+      }
+    }
+
+    if (options.includeResults) {
+      const results = result.results ?? [];
+      if (results.length > 0) {
+        process.stdout.write(`\nResults (${String(results.length)}):\n`);
+        for (const r of results) {
+          process.stdout.write(
+            `  Person ${String(r.personId)}: result=${String(r.result)} (action version #${String(r.actionVersionId)})\n`,
+          );
+        }
+      } else {
+        process.stdout.write("\nNo results yet.\n");
+      }
+    }
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -142,6 +142,14 @@ export {
   killInstanceProcesses,
 } from "./cdp/index.js";
 
+// Operations (shared business logic for CLI + MCP)
+export {
+  campaignStatus,
+  type CampaignStatusInput,
+  type CampaignStatusOutput,
+  type ConnectionOptions,
+} from "./operations/index.js";
+
 // Constants
 export { DEFAULT_CDP_PORT } from "./constants.js";
 

--- a/packages/core/src/operations/campaign-status.test.ts
+++ b/packages/core/src/operations/campaign-status.test.ts
@@ -1,0 +1,192 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../services/account-resolution.js", () => ({
+  resolveAccount: vi.fn(),
+}));
+
+vi.mock("../services/instance-context.js", () => ({
+  withInstanceDatabase: vi.fn(),
+}));
+
+vi.mock("../services/campaign.js", () => ({
+  CampaignService: vi.fn(),
+}));
+
+import type { InstanceDatabaseContext } from "../services/instance-context.js";
+import { resolveAccount } from "../services/account-resolution.js";
+import { withInstanceDatabase } from "../services/instance-context.js";
+import { CampaignService } from "../services/campaign.js";
+import { campaignStatus } from "./campaign-status.js";
+
+const MOCK_STATUS = {
+  campaignState: "active" as const,
+  isPaused: false,
+  runnerState: "campaigns" as const,
+  actionCounts: [
+    { actionId: 1, queued: 10, processed: 5, successful: 4, failed: 1 },
+  ],
+};
+
+const MOCK_RESULTS = {
+  campaignId: 42,
+  results: [
+    { id: 1, actionVersionId: 1, personId: 100, result: 3, platform: "linkedin", createdAt: "2026-01-01T00:00:00Z" },
+    { id: 2, actionVersionId: 1, personId: 101, result: 3, platform: "linkedin", createdAt: "2026-01-01T00:01:00Z" },
+    { id: 3, actionVersionId: 1, personId: 102, result: 3, platform: "linkedin", createdAt: "2026-01-01T00:02:00Z" },
+  ],
+  actionCounts: MOCK_STATUS.actionCounts,
+};
+
+function setupMocks() {
+  vi.mocked(resolveAccount).mockResolvedValue(1);
+
+  vi.mocked(withInstanceDatabase).mockImplementation(
+    async (_cdpPort, _accountId, callback) =>
+      callback({
+        accountId: 1,
+        instance: {},
+        db: {},
+      } as unknown as InstanceDatabaseContext),
+  );
+
+  vi.mocked(CampaignService).mockImplementation(function () {
+    return {
+      getStatus: vi.fn().mockResolvedValue(MOCK_STATUS),
+      getResults: vi.fn().mockResolvedValue(MOCK_RESULTS),
+    } as unknown as CampaignService;
+  });
+}
+
+describe("campaignStatus", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns campaign status with campaignId", async () => {
+    setupMocks();
+
+    const result = await campaignStatus({
+      campaignId: 42,
+      cdpPort: 9222,
+    });
+
+    expect(result.campaignId).toBe(42);
+    expect(result.campaignState).toBe("active");
+    expect(result.isPaused).toBe(false);
+    expect(result.runnerState).toBe("campaigns");
+    expect(result.actionCounts).toHaveLength(1);
+    expect(result.results).toBeUndefined();
+  });
+
+  it("includes results when includeResults is true", async () => {
+    setupMocks();
+
+    const result = await campaignStatus({
+      campaignId: 42,
+      cdpPort: 9222,
+      includeResults: true,
+    });
+
+    expect(result.results).toHaveLength(3);
+  });
+
+  it("limits results to specified limit", async () => {
+    setupMocks();
+
+    const result = await campaignStatus({
+      campaignId: 42,
+      cdpPort: 9222,
+      includeResults: true,
+      limit: 1,
+    });
+
+    expect(result.results).toHaveLength(1);
+  });
+
+  it("defaults limit to 20", async () => {
+    setupMocks();
+
+    const result = await campaignStatus({
+      campaignId: 42,
+      cdpPort: 9222,
+      includeResults: true,
+    });
+
+    // All 3 results returned since 3 < default limit of 20
+    expect(result.results).toHaveLength(3);
+  });
+
+  it("passes connection options to resolveAccount", async () => {
+    setupMocks();
+
+    await campaignStatus({
+      campaignId: 42,
+      cdpPort: 1234,
+      cdpHost: "192.168.1.1",
+      allowRemote: true,
+    });
+
+    expect(resolveAccount).toHaveBeenCalledWith(1234, {
+      host: "192.168.1.1",
+      allowRemote: true,
+    });
+  });
+
+  it("omits undefined connection options", async () => {
+    setupMocks();
+
+    await campaignStatus({
+      campaignId: 42,
+      cdpPort: 9222,
+    });
+
+    expect(resolveAccount).toHaveBeenCalledWith(9222, {});
+  });
+
+  it("propagates resolveAccount errors", async () => {
+    vi.mocked(resolveAccount).mockRejectedValue(new Error("connection refused"));
+
+    await expect(
+      campaignStatus({ campaignId: 42, cdpPort: 9222 }),
+    ).rejects.toThrow("connection refused");
+  });
+
+  it("propagates withInstanceDatabase errors", async () => {
+    vi.mocked(resolveAccount).mockResolvedValue(1);
+    vi.mocked(withInstanceDatabase).mockRejectedValue(
+      new Error("instance not running"),
+    );
+
+    await expect(
+      campaignStatus({ campaignId: 42, cdpPort: 9222 }),
+    ).rejects.toThrow("instance not running");
+  });
+
+  it("propagates CampaignService errors", async () => {
+    vi.mocked(resolveAccount).mockResolvedValue(1);
+    vi.mocked(withInstanceDatabase).mockImplementation(
+      async (_cdpPort, _accountId, callback) =>
+        callback({
+          accountId: 1,
+          instance: {},
+          db: {},
+        } as unknown as InstanceDatabaseContext),
+    );
+    vi.mocked(CampaignService).mockImplementation(function () {
+      return {
+        getStatus: vi.fn().mockRejectedValue(new Error("campaign not found")),
+      } as unknown as CampaignService;
+    });
+
+    await expect(
+      campaignStatus({ campaignId: 42, cdpPort: 9222 }),
+    ).rejects.toThrow("campaign not found");
+  });
+});

--- a/packages/core/src/operations/campaign-status.ts
+++ b/packages/core/src/operations/campaign-status.ts
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
+import type { CampaignActionResult, CampaignStatus } from "../types/index.js";
+import { resolveAccount } from "../services/account-resolution.js";
+import { withInstanceDatabase } from "../services/instance-context.js";
+import { CampaignService } from "../services/campaign.js";
+import { DEFAULT_CDP_PORT } from "../constants.js";
+import type { ConnectionOptions } from "./types.js";
+
+/**
+ * Input for the campaign-status operation.
+ */
+export interface CampaignStatusInput extends ConnectionOptions {
+  readonly campaignId: number;
+  readonly includeResults?: boolean | undefined;
+  readonly limit?: number | undefined;
+}
+
+/**
+ * Output from the campaign-status operation.
+ */
+export interface CampaignStatusOutput extends CampaignStatus {
+  readonly campaignId: number;
+  readonly results?: CampaignActionResult[];
+}
+
+/**
+ * Retrieve the execution status of a campaign, optionally including
+ * action results.
+ *
+ * This is the shared business logic used by both the CLI handler and
+ * the MCP tool.
+ */
+export async function campaignStatus(
+  input: CampaignStatusInput,
+): Promise<CampaignStatusOutput> {
+  const cdpPort = input.cdpPort ?? DEFAULT_CDP_PORT;
+  const limit = input.limit ?? 20;
+
+  const accountId = await resolveAccount(cdpPort, {
+    ...(input.cdpHost !== undefined && { host: input.cdpHost }),
+    ...(input.allowRemote !== undefined && { allowRemote: input.allowRemote }),
+  });
+
+  return withInstanceDatabase(cdpPort, accountId, async ({ instance, db }) => {
+    const campaignService = new CampaignService(instance, db);
+    const status = await campaignService.getStatus(input.campaignId);
+
+    const output: CampaignStatusOutput = { campaignId: input.campaignId, ...status };
+
+    if (input.includeResults) {
+      const runResult = await campaignService.getResults(input.campaignId);
+      return { ...output, results: runResult.results.slice(0, limit) };
+    }
+
+    return output;
+  });
+}

--- a/packages/core/src/operations/index.ts
+++ b/packages/core/src/operations/index.ts
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
+export type { ConnectionOptions } from "./types.js";
+export {
+  campaignStatus,
+  type CampaignStatusInput,
+  type CampaignStatusOutput,
+} from "./campaign-status.js";

--- a/packages/core/src/operations/types.ts
+++ b/packages/core/src/operations/types.ts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
+/**
+ * Connection options shared by all operations that need to reach a
+ * running LinkedHelper instance via CDP.
+ */
+export interface ConnectionOptions {
+  readonly cdpPort: number;
+  readonly cdpHost?: string | undefined;
+  readonly allowRemote?: boolean | undefined;
+}


### PR DESCRIPTION
## Summary

- Introduces a shared `operations/` layer in `@lhremote/core` that encapsulates business logic (account resolution → service instantiation → operation → result) previously duplicated between CLI handlers and MCP tools
- Refactors the `campaign-status` pair as the first exemplar, making both CLI and MCP thin adapters that only handle input parsing/output formatting
- Adds comprehensive unit tests for the new operation in core, and updates CLI/MCP tests to mock the operation instead of lower-level internals

## Pattern for remaining pairs

The `campaign-status` operation demonstrates the pattern for the remaining 32 pairs:

1. Create `core/src/operations/<name>.ts` with typed `Input`/`Output` interfaces and a single async function
2. The function handles: `resolveAccount` → `withInstanceDatabase` → service call → result construction
3. Export from `core/src/operations/index.ts` and `core/src/index.ts`
4. CLI handler: call the operation, catch errors for stderr, format output (text vs JSON)
5. MCP tool: call the operation, catch errors for MCP error responses, return JSON

## Test plan

- [x] All existing tests continue to pass (557 core + 288 CLI + 241 MCP)
- [x] New operation tests cover: happy path, results inclusion, limit, connection options passthrough, error propagation
- [x] Build passes with `exactOptionalPropertyTypes`
- [x] Lint clean

Closes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)