### PR TITLE
(fix) core: export WrongPortError from public API

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -85,6 +85,7 @@ export {
   waitForInstanceShutdown,
   withDatabase,
   withInstanceDatabase,
+  WrongPortError,
 } from "./services/index.js";
 
 // Data access


### PR DESCRIPTION
## Summary

- Add `WrongPortError` to the barrel export in `packages/core/src/index.ts`
- All other service errors were already exported; this was the only omission

Closes #267

## Test plan

- [x] `pnpm build` succeeds
- [x] `pnpm test` passes (557 tests)
- [ ] CI passes on all matrix targets

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>