### PR TITLE
Consolidate CDP round-trips in getActionPeopleCounts

### DIFF
--- a/packages/core/src/services/campaign.test.ts
+++ b/packages/core/src/services/campaign.test.ts
@@ -453,14 +453,11 @@ describe("CampaignService", () => {
       mockGetCampaign.mockReturnValue(MOCK_CAMPAIGN);
       mockGetCampaignActions.mockReturnValue(MOCK_ACTIONS);
 
-      // CDP calls: runnerState, isPaused, then 4 action counts
+      // CDP calls: runnerState, isPaused, then 1 batched action counts call
       mockEvaluateUI
         .mockResolvedValueOnce("idle")   // runnerState
         .mockResolvedValueOnce(true)     // isPaused
-        .mockResolvedValueOnce(5)        // queued
-        .mockResolvedValueOnce(3)        // processed
-        .mockResolvedValueOnce(2)        // successful
-        .mockResolvedValueOnce(1);       // failed
+        .mockResolvedValueOnce({ queued: 5, processed: 3, successful: 2, failed: 1 });
 
       const status = await service.getStatus(1);
 
@@ -493,12 +490,9 @@ describe("CampaignService", () => {
       mockGetResults.mockReturnValue(MOCK_RESULTS);
       mockGetCampaignActions.mockReturnValue(MOCK_ACTIONS);
 
-      // 4 action count CDP calls
+      // 1 batched action counts CDP call
       mockEvaluateUI
-        .mockResolvedValueOnce(0)  // queued
-        .mockResolvedValueOnce(0)  // processed
-        .mockResolvedValueOnce(1)  // successful
-        .mockResolvedValueOnce(0); // failed
+        .mockResolvedValueOnce({ queued: 0, processed: 0, successful: 1, failed: 0 });
 
       const result = await service.getResults(1);
 


### PR DESCRIPTION
## Summary

- Replace 4 separate `evaluateUI` CDP calls per action with a single batched call that retrieves all people-state counts (`queued`, `processed`, `successful`, `failed`) in one round-trip
- Update test mocks to expect 1 CDP call per action instead of 4

Closes #266

## Test plan

- [x] `pnpm build` succeeds
- [x] `pnpm test` — all campaign service tests pass (38/38)
- [x] `pnpm lint` passes
- [x] Operation-level `campaign-status` tests pass (9/9)

🤖 Generated with [Claude Code](https://claude.com/claude-code)