### PR TITLE
(refactor) cli: extract person-ID parsing/resolution utilities

### DIFF
--- a/packages/cli/src/handlers/campaign-exclude-add.ts
+++ b/packages/cli/src/handlers/campaign-exclude-add.ts
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2025 Alexey Pelykh
 
-import { readFileSync } from "node:fs";
-
 import {
   ActionNotFoundError,
   CampaignNotFoundError,
@@ -14,34 +12,7 @@ import {
   withDatabase,
 } from "@lhremote/core";
 
-function parsePersonIds(raw: string): number[] {
-  return raw
-    .split(",")
-    .map((s) => s.trim())
-    .filter((s) => s.length > 0)
-    .map((s) => {
-      const n = Number(s);
-      if (!Number.isInteger(n) || n <= 0) {
-        throw new Error(`Invalid person ID: "${s}"`);
-      }
-      return n;
-    });
-}
-
-function readPersonIdsFile(filePath: string): number[] {
-  const content = readFileSync(filePath, "utf-8");
-  return content
-    .split(/[\n,]/)
-    .map((s) => s.trim())
-    .filter((s) => s.length > 0)
-    .map((s) => {
-      const n = Number(s);
-      if (!Number.isInteger(n) || n <= 0) {
-        throw new Error(`Invalid person ID in file: "${s}"`);
-      }
-      return n;
-    });
-}
+import { resolvePersonIds } from "./person-ids.js";
 
 /** Handle the {@link https://github.com/alexey-pelykh/lhremote#campaign-targeting | campaign-exclude-add} CLI command. */
 export async function handleCampaignExcludeAdd(
@@ -58,45 +29,12 @@ export async function handleCampaignExcludeAdd(
 ): Promise<void> {
   const cdpPort = options.cdpPort ?? DEFAULT_CDP_PORT;
 
-  // Reject conflicting options
-  if (options.personIds && options.personIdsFile) {
-    process.stderr.write(
-      "Use only one of --person-ids or --person-ids-file.\n",
-    );
-    process.exitCode = 1;
-    return;
-  }
-
-  // Parse person IDs from options
   let personIds: number[];
-  if (options.personIds) {
-    try {
-      personIds = parsePersonIds(options.personIds);
-    } catch (error) {
-      const message = errorMessage(error);
-      process.stderr.write(`${message}\n`);
-      process.exitCode = 1;
-      return;
-    }
-  } else if (options.personIdsFile) {
-    try {
-      personIds = readPersonIdsFile(options.personIdsFile);
-    } catch (error) {
-      const message = errorMessage(error);
-      process.stderr.write(`${message}\n`);
-      process.exitCode = 1;
-      return;
-    }
-  } else {
-    process.stderr.write(
-      "Either --person-ids or --person-ids-file is required.\n",
-    );
-    process.exitCode = 1;
-    return;
-  }
-
-  if (personIds.length === 0) {
-    process.stderr.write("No person IDs provided.\n");
+  try {
+    personIds = resolvePersonIds(options);
+  } catch (error) {
+    const message = errorMessage(error);
+    process.stderr.write(`${message}\n`);
     process.exitCode = 1;
     return;
   }

--- a/packages/cli/src/handlers/campaign-move-next.ts
+++ b/packages/cli/src/handlers/campaign-move-next.ts
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2025 Alexey Pelykh
 
-import { readFileSync } from "node:fs";
-
 import {
   ActionNotFoundError,
   CampaignNotFoundError,
@@ -14,34 +12,7 @@ import {
   withDatabase,
 } from "@lhremote/core";
 
-function parsePersonIds(raw: string): number[] {
-  return raw
-    .split(",")
-    .map((s) => s.trim())
-    .filter((s) => s.length > 0)
-    .map((s) => {
-      const n = Number(s);
-      if (!Number.isInteger(n) || n <= 0) {
-        throw new Error(`Invalid person ID: "${s}"`);
-      }
-      return n;
-    });
-}
-
-function readPersonIdsFile(filePath: string): number[] {
-  const content = readFileSync(filePath, "utf-8");
-  return content
-    .split(/[\n,]/)
-    .map((s) => s.trim())
-    .filter((s) => s.length > 0)
-    .map((s) => {
-      const n = Number(s);
-      if (!Number.isInteger(n) || n <= 0) {
-        throw new Error(`Invalid person ID in file: "${s}"`);
-      }
-      return n;
-    });
-}
+import { resolvePersonIds } from "./person-ids.js";
 
 /** Handle the {@link https://github.com/alexey-pelykh/lhremote#campaign-actions | campaign-move-next} CLI command. */
 export async function handleCampaignMoveNext(
@@ -58,45 +29,12 @@ export async function handleCampaignMoveNext(
 ): Promise<void> {
   const cdpPort = options.cdpPort ?? DEFAULT_CDP_PORT;
 
-  // Reject conflicting options
-  if (options.personIds && options.personIdsFile) {
-    process.stderr.write(
-      "Use only one of --person-ids or --person-ids-file.\n",
-    );
-    process.exitCode = 1;
-    return;
-  }
-
-  // Parse person IDs from options
   let personIds: number[];
-  if (options.personIds) {
-    try {
-      personIds = parsePersonIds(options.personIds);
-    } catch (error) {
-      const message = errorMessage(error);
-      process.stderr.write(`${message}\n`);
-      process.exitCode = 1;
-      return;
-    }
-  } else if (options.personIdsFile) {
-    try {
-      personIds = readPersonIdsFile(options.personIdsFile);
-    } catch (error) {
-      const message = errorMessage(error);
-      process.stderr.write(`${message}\n`);
-      process.exitCode = 1;
-      return;
-    }
-  } else {
-    process.stderr.write(
-      "Either --person-ids or --person-ids-file is required.\n",
-    );
-    process.exitCode = 1;
-    return;
-  }
-
-  if (personIds.length === 0) {
-    process.stderr.write("No person IDs provided.\n");
+  try {
+    personIds = resolvePersonIds(options);
+  } catch (error) {
+    const message = errorMessage(error);
+    process.stderr.write(`${message}\n`);
     process.exitCode = 1;
     return;
   }

--- a/packages/cli/src/handlers/campaign-retry.ts
+++ b/packages/cli/src/handlers/campaign-retry.ts
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2025 Alexey Pelykh
 
-import { readFileSync } from "node:fs";
-
 import {
   CampaignNotFoundError,
   CampaignRepository,
@@ -12,34 +10,7 @@ import {
   withDatabase,
 } from "@lhremote/core";
 
-function parsePersonIds(raw: string): number[] {
-  return raw
-    .split(",")
-    .map((s) => s.trim())
-    .filter((s) => s.length > 0)
-    .map((s) => {
-      const n = Number(s);
-      if (!Number.isInteger(n) || n <= 0) {
-        throw new Error(`Invalid person ID: "${s}"`);
-      }
-      return n;
-    });
-}
-
-function readPersonIdsFile(filePath: string): number[] {
-  const content = readFileSync(filePath, "utf-8");
-  return content
-    .split(/[\n,]/)
-    .map((s) => s.trim())
-    .filter((s) => s.length > 0)
-    .map((s) => {
-      const n = Number(s);
-      if (!Number.isInteger(n) || n <= 0) {
-        throw new Error(`Invalid person ID in file: "${s}"`);
-      }
-      return n;
-    });
-}
+import { resolvePersonIds } from "./person-ids.js";
 
 /** Handle the {@link https://github.com/alexey-pelykh/lhremote#campaigns | campaign-retry} CLI command. */
 export async function handleCampaignRetry(
@@ -55,45 +26,12 @@ export async function handleCampaignRetry(
 ): Promise<void> {
   const cdpPort = options.cdpPort ?? DEFAULT_CDP_PORT;
 
-  // Reject conflicting options
-  if (options.personIds && options.personIdsFile) {
-    process.stderr.write(
-      "Use only one of --person-ids or --person-ids-file.\n",
-    );
-    process.exitCode = 1;
-    return;
-  }
-
-  // Parse person IDs from options
   let personIds: number[];
-  if (options.personIds) {
-    try {
-      personIds = parsePersonIds(options.personIds);
-    } catch (error) {
-      const message = errorMessage(error);
-      process.stderr.write(`${message}\n`);
-      process.exitCode = 1;
-      return;
-    }
-  } else if (options.personIdsFile) {
-    try {
-      personIds = readPersonIdsFile(options.personIdsFile);
-    } catch (error) {
-      const message = errorMessage(error);
-      process.stderr.write(`${message}\n`);
-      process.exitCode = 1;
-      return;
-    }
-  } else {
-    process.stderr.write(
-      "Either --person-ids or --person-ids-file is required.\n",
-    );
-    process.exitCode = 1;
-    return;
-  }
-
-  if (personIds.length === 0) {
-    process.stderr.write("No person IDs provided.\n");
+  try {
+    personIds = resolvePersonIds(options);
+  } catch (error) {
+    const message = errorMessage(error);
+    process.stderr.write(`${message}\n`);
     process.exitCode = 1;
     return;
   }

--- a/packages/cli/src/handlers/campaign-start.ts
+++ b/packages/cli/src/handlers/campaign-start.ts
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2025 Alexey Pelykh
 
-import { readFileSync } from "node:fs";
-
 import {
   CampaignExecutionError,
   CampaignNotFoundError,
@@ -15,34 +13,7 @@ import {
   withInstanceDatabase,
 } from "@lhremote/core";
 
-function parsePersonIds(raw: string): number[] {
-  return raw
-    .split(",")
-    .map((s) => s.trim())
-    .filter((s) => s.length > 0)
-    .map((s) => {
-      const n = Number(s);
-      if (!Number.isInteger(n) || n <= 0) {
-        throw new Error(`Invalid person ID: "${s}"`);
-      }
-      return n;
-    });
-}
-
-function readPersonIdsFile(filePath: string): number[] {
-  const content = readFileSync(filePath, "utf-8");
-  return content
-    .split(/[\n,]/)
-    .map((s) => s.trim())
-    .filter((s) => s.length > 0)
-    .map((s) => {
-      const n = Number(s);
-      if (!Number.isInteger(n) || n <= 0) {
-        throw new Error(`Invalid person ID in file: "${s}"`);
-      }
-      return n;
-    });
-}
+import { resolvePersonIds } from "./person-ids.js";
 
 /** Handle the {@link https://github.com/alexey-pelykh/lhremote#campaigns | campaign-start} CLI command. */
 export async function handleCampaignStart(
@@ -58,45 +29,12 @@ export async function handleCampaignStart(
 ): Promise<void> {
   const cdpPort = options.cdpPort ?? DEFAULT_CDP_PORT;
 
-  // Reject conflicting options
-  if (options.personIds && options.personIdsFile) {
-    process.stderr.write(
-      "Use only one of --person-ids or --person-ids-file.\n",
-    );
-    process.exitCode = 1;
-    return;
-  }
-
-  // Parse person IDs from options
   let personIds: number[];
-  if (options.personIds) {
-    try {
-      personIds = parsePersonIds(options.personIds);
-    } catch (error) {
-      const message = errorMessage(error);
-      process.stderr.write(`${message}\n`);
-      process.exitCode = 1;
-      return;
-    }
-  } else if (options.personIdsFile) {
-    try {
-      personIds = readPersonIdsFile(options.personIdsFile);
-    } catch (error) {
-      const message = errorMessage(error);
-      process.stderr.write(`${message}\n`);
-      process.exitCode = 1;
-      return;
-    }
-  } else {
-    process.stderr.write(
-      "Either --person-ids or --person-ids-file is required.\n",
-    );
-    process.exitCode = 1;
-    return;
-  }
-
-  if (personIds.length === 0) {
-    process.stderr.write("No person IDs provided.\n");
+  try {
+    personIds = resolvePersonIds(options);
+  } catch (error) {
+    const message = errorMessage(error);
+    process.stderr.write(`${message}\n`);
     process.exitCode = 1;
     return;
   }

--- a/packages/cli/src/handlers/person-ids.ts
+++ b/packages/cli/src/handlers/person-ids.ts
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
+import { readFileSync } from "node:fs";
+
+export function parsePersonIds(raw: string): number[] {
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+    .map((s) => {
+      const n = Number(s);
+      if (!Number.isInteger(n) || n <= 0) {
+        throw new Error(`Invalid person ID: "${s}"`);
+      }
+      return n;
+    });
+}
+
+export function readPersonIdsFile(filePath: string): number[] {
+  const content = readFileSync(filePath, "utf-8");
+  return content
+    .split(/[\n,]/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+    .map((s) => {
+      const n = Number(s);
+      if (!Number.isInteger(n) || n <= 0) {
+        throw new Error(`Invalid person ID in file: "${s}"`);
+      }
+      return n;
+    });
+}
+
+export function resolvePersonIds(options: {
+  personIds?: string;
+  personIdsFile?: string;
+}): number[] {
+  if (options.personIds && options.personIdsFile) {
+    throw new Error("Use only one of --person-ids or --person-ids-file.");
+  }
+
+  let personIds: number[];
+  if (options.personIds) {
+    personIds = parsePersonIds(options.personIds);
+  } else if (options.personIdsFile) {
+    personIds = readPersonIdsFile(options.personIdsFile);
+  } else {
+    throw new Error("Either --person-ids or --person-ids-file is required.");
+  }
+
+  if (personIds.length === 0) {
+    throw new Error("No person IDs provided.");
+  }
+
+  return personIds;
+}


### PR DESCRIPTION
## Summary

- Extract duplicated `parsePersonIds`, `readPersonIdsFile`, and resolution boilerplate (~320 lines) from 5 CLI handler files into a shared `packages/cli/src/handlers/person-ids.ts` module
- Introduce `resolvePersonIds()` that encapsulates mutual exclusivity checks, dispatch to parse/read, and empty-set validation
- Replace inline implementations in `campaign-exclude-add`, `campaign-exclude-remove`, `campaign-move-next`, `campaign-retry`, and `campaign-start` handlers with imports from the shared module

Closes #261

## Test plan

- [x] `pnpm build` succeeds
- [x] `pnpm lint` passes
- [x] `pnpm test` — all 288 CLI tests pass; 241 MCP tests pass; 1 pre-existing flaky core integration test (psList timeout, unrelated)
- [ ] CI passes on all platforms (ubuntu/macos/windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)