### PR TITLE
(chore) core: replace inline delay patterns with delay() utility

### DIFF
--- a/packages/core/src/cdp/client.ts
+++ b/packages/core/src/cdp/client.ts
@@ -3,6 +3,7 @@
 
 import type { Protocol } from "devtools-protocol";
 import type { CdpTarget } from "../types/cdp.js";
+import { delay } from "../utils/delay.js";
 import { isLoopbackAddress } from "../utils/loopback.js";
 import {
   CDPConnectionError,
@@ -357,8 +358,8 @@ export class CDPClient {
     this.reconnecting = true;
 
     for (let attempt = 0; attempt < MAX_RECONNECT_ATTEMPTS; attempt++) {
-      const delay = RECONNECT_BASE_DELAY * 2 ** attempt;
-      await new Promise<void>((r) => setTimeout(r, delay));
+      const backoff = RECONNECT_BASE_DELAY * 2 ** attempt;
+      await delay(backoff);
 
       try {
         await this.connect(this.targetId ?? undefined);

--- a/packages/core/src/cdp/testing/launch-chromium.ts
+++ b/packages/core/src/cdp/testing/launch-chromium.ts
@@ -7,6 +7,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { chromium } from "playwright-core";
 import { discoverTargets } from "../discovery.js";
+import { delay } from "../../utils/delay.js";
 
 /** Result of launching a test Chromium instance. */
 export interface ChromiumInstance {
@@ -88,7 +89,7 @@ export async function launchChromium(options?: {
     } catch {
       // Not ready yet
     }
-    await new Promise<void>((r) => setTimeout(r, 100));
+    await delay(100);
   }
 
   if (!ready) {

--- a/packages/core/src/testing/e2e-helpers.ts
+++ b/packages/core/src/testing/e2e-helpers.ts
@@ -6,6 +6,7 @@ import { AppService, type AppServiceOptions } from "../services/app.js";
 import { AppNotFoundError } from "../services/errors.js";
 import { discoverTargets } from "../cdp/discovery.js";
 import { LauncherService } from "../services/launcher.js";
+import { delay } from "../utils/delay.js";
 
 const linkedHelperAvailable = (() => {
   try {
@@ -66,7 +67,7 @@ export async function launchApp(options?: {
     } catch {
       // Not ready yet
     }
-    await new Promise<void>((r) => setTimeout(r, 250));
+    await delay(250);
   }
 
   // Phase 2: Wait for full launcher readiness (WebSocket + renderer loaded)
@@ -80,7 +81,7 @@ export async function launchApp(options?: {
     } catch {
       launcher.disconnect();
     }
-    await new Promise<void>((r) => setTimeout(r, 500));
+    await delay(500);
   }
 
   // Clean up on timeout
@@ -117,7 +118,7 @@ export async function retryAsync<T>(
   options?: { retries?: number; delay?: number },
 ): Promise<T> {
   const retries = options?.retries ?? 3;
-  const delay = options?.delay ?? 500;
+  const interval = options?.delay ?? 500;
   let lastError: unknown;
 
   for (let i = 0; i <= retries; i++) {
@@ -126,7 +127,7 @@ export async function retryAsync<T>(
     } catch (error) {
       lastError = error;
       if (i < retries) {
-        await new Promise<void>((r) => setTimeout(r, delay));
+        await delay(interval);
       }
     }
   }


### PR DESCRIPTION
## Summary

- Replace 5 inline `new Promise<void>((r) => setTimeout(r, ms))` patterns with the existing `delay()` utility across 3 files
- Rename local variables that shadowed the imported `delay` name (`delay` → `backoff` in `client.ts`, `delay` → `interval` in `e2e-helpers.ts`)

## Changes

| File | Changes |
|------|---------|
| `packages/core/src/testing/e2e-helpers.ts` | Import `delay`, replace 3 inline patterns, rename local `delay` → `interval` |
| `packages/core/src/cdp/client.ts` | Import `delay`, replace 1 inline pattern, rename local `delay` → `backoff` |
| `packages/core/src/cdp/testing/launch-chromium.ts` | Import `delay`, replace 1 inline pattern |

## Test plan

- [x] `pnpm build` succeeds (tsc compiles without errors)
- [x] All unit tests pass (`pnpm --filter @lhremote/core test`)
- [x] No remaining inline delay patterns (`grep` confirms zero matches)

Closes #287

🤖 Generated with [Claude Code](https://claude.com/claude-code)