### PR TITLE
(fix) cli: fix --max-results parser and unused options on launch-app/quit-app

### DIFF
--- a/packages/cli/src/handlers/launch-app.test.ts
+++ b/packages/cli/src/handlers/launch-app.test.ts
@@ -40,7 +40,7 @@ describe("handleLaunchApp", () => {
       } as unknown as AppService;
     });
 
-    await handleLaunchApp({});
+    await handleLaunchApp();
 
     expect(stdoutSpy).toHaveBeenCalledWith(
       "LinkedHelper launched on CDP port 9222\n",
@@ -48,19 +48,19 @@ describe("handleLaunchApp", () => {
     expect(process.exitCode).toBeUndefined();
   });
 
-  it("passes cdpPort option to AppService", async () => {
+  it("creates AppService without explicit port", async () => {
     vi.spyOn(process.stdout, "write").mockReturnValue(true);
 
     vi.mocked(AppService).mockImplementation(function () {
       return {
         launch: vi.fn().mockResolvedValue(undefined),
-        cdpPort: 4567,
+        cdpPort: 9222,
       } as unknown as AppService;
     });
 
-    await handleLaunchApp({ cdpPort: 4567 });
+    await handleLaunchApp();
 
-    expect(AppService).toHaveBeenCalledWith(4567);
+    expect(AppService).toHaveBeenCalledWith();
   });
 
   it("sets exitCode 1 on error", async () => {
@@ -78,7 +78,7 @@ describe("handleLaunchApp", () => {
       } as unknown as AppService;
     });
 
-    await handleLaunchApp({});
+    await handleLaunchApp();
 
     expect(process.exitCode).toBe(1);
     expect(stderrSpy).toHaveBeenCalledWith(

--- a/packages/cli/src/handlers/launch-app.ts
+++ b/packages/cli/src/handlers/launch-app.ts
@@ -4,10 +4,8 @@
 import { AppService, errorMessage } from "@lhremote/core";
 
 /** Handle the {@link https://github.com/alexey-pelykh/lhremote#app-management | launch-app} CLI command. */
-export async function handleLaunchApp(options: {
-  cdpPort?: number;
-}): Promise<void> {
-  const app = new AppService(options.cdpPort);
+export async function handleLaunchApp(): Promise<void> {
+  const app = new AppService();
 
   try {
     await app.launch();

--- a/packages/cli/src/handlers/quit-app.test.ts
+++ b/packages/cli/src/handlers/quit-app.test.ts
@@ -39,13 +39,13 @@ describe("handleQuitApp", () => {
       } as unknown as AppService;
     });
 
-    await handleQuitApp({});
+    await handleQuitApp();
 
     expect(stdoutSpy).toHaveBeenCalledWith("LinkedHelper quit\n");
     expect(process.exitCode).toBeUndefined();
   });
 
-  it("passes cdpPort to AppService", async () => {
+  it("creates AppService with DEFAULT_CDP_PORT", async () => {
     vi.spyOn(process.stdout, "write").mockReturnValue(true);
 
     vi.mocked(AppService).mockImplementation(function () {
@@ -54,21 +54,7 @@ describe("handleQuitApp", () => {
       } as unknown as AppService;
     });
 
-    await handleQuitApp({ cdpPort: 4567 });
-
-    expect(AppService).toHaveBeenCalledWith(4567);
-  });
-
-  it("defaults cdpPort to 9222", async () => {
-    vi.spyOn(process.stdout, "write").mockReturnValue(true);
-
-    vi.mocked(AppService).mockImplementation(function () {
-      return {
-        quit: vi.fn().mockResolvedValue(undefined),
-      } as unknown as AppService;
-    });
-
-    await handleQuitApp({});
+    await handleQuitApp();
 
     expect(AppService).toHaveBeenCalledWith(9222);
   });
@@ -84,7 +70,7 @@ describe("handleQuitApp", () => {
       } as unknown as AppService;
     });
 
-    await handleQuitApp({});
+    await handleQuitApp();
 
     expect(process.exitCode).toBe(1);
     expect(stderrSpy).toHaveBeenCalledWith("SIGTERM failed\n");

--- a/packages/cli/src/handlers/quit-app.ts
+++ b/packages/cli/src/handlers/quit-app.ts
@@ -4,10 +4,8 @@
 import { AppService, DEFAULT_CDP_PORT, errorMessage } from "@lhremote/core";
 
 /** Handle the {@link https://github.com/alexey-pelykh/lhremote#app-management | quit-app} CLI command. */
-export async function handleQuitApp(options: {
-  cdpPort?: number;
-}): Promise<void> {
-  const app = new AppService(options.cdpPort ?? DEFAULT_CDP_PORT);
+export async function handleQuitApp(): Promise<void> {
+  const app = new AppService(DEFAULT_CDP_PORT);
 
   try {
     await app.quit();

--- a/packages/cli/src/program.test.ts
+++ b/packages/cli/src/program.test.ts
@@ -72,12 +72,22 @@ describe("createProgram", () => {
   });
 
   describe("launch-app", () => {
-    it("accepts --cdp-port option", () => {
+    it("does not have --cdp-port option", () => {
       const program = createProgram();
       const cmd = program.commands.find((c) => c.name() === "launch-app");
       const portOption = cmd?.options.find((o) => o.long === "--cdp-port");
 
-      expect(portOption).toBeDefined();
+      expect(portOption).toBeUndefined();
+    });
+  });
+
+  describe("quit-app", () => {
+    it("does not have --cdp-port option", () => {
+      const program = createProgram();
+      const cmd = program.commands.find((c) => c.name() === "quit-app");
+      const portOption = cmd?.options.find((o) => o.long === "--cdp-port");
+
+      expect(portOption).toBeUndefined();
     });
   });
 
@@ -109,6 +119,60 @@ describe("createProgram", () => {
 
       await expect(
         program.parseAsync(["node", "lhremote", "start-instance", "abc"]),
+      ).rejects.toThrow();
+    });
+  });
+
+  describe("campaign-add-action --max-results", () => {
+    it("rejects non-numeric value", async () => {
+      const program = createProgram();
+      program.exitOverride().configureOutput({ writeErr: () => {} });
+
+      await expect(
+        program.parseAsync([
+          "node", "lhremote", "campaign-add-action", "1",
+          "--name", "test", "--action-type", "VisitAndExtract",
+          "--max-results", "abc",
+        ]),
+      ).rejects.toThrow();
+    });
+
+    it("rejects fractional value", async () => {
+      const program = createProgram();
+      program.exitOverride().configureOutput({ writeErr: () => {} });
+
+      await expect(
+        program.parseAsync([
+          "node", "lhremote", "campaign-add-action", "1",
+          "--name", "test", "--action-type", "VisitAndExtract",
+          "--max-results", "3.7",
+        ]),
+      ).rejects.toThrow();
+    });
+
+    it("rejects zero", async () => {
+      const program = createProgram();
+      program.exitOverride().configureOutput({ writeErr: () => {} });
+
+      await expect(
+        program.parseAsync([
+          "node", "lhremote", "campaign-add-action", "1",
+          "--name", "test", "--action-type", "VisitAndExtract",
+          "--max-results", "0",
+        ]),
+      ).rejects.toThrow();
+    });
+
+    it("rejects values less than -1", async () => {
+      const program = createProgram();
+      program.exitOverride().configureOutput({ writeErr: () => {} });
+
+      await expect(
+        program.parseAsync([
+          "node", "lhremote", "campaign-add-action", "1",
+          "--name", "test", "--action-type", "VisitAndExtract",
+          "--max-results", "-2",
+        ]),
       ).rejects.toThrow();
     });
   });

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -52,6 +52,17 @@ function parsePositiveInt(value: string): number {
   return n;
 }
 
+/** Parse a string as a max-results value: positive integer or -1 for unlimited. */
+function parseMaxResults(value: string): number {
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < -1 || n === 0) {
+    throw new InvalidArgumentError(
+      `Expected a positive integer or -1 for unlimited, got "${value}".`,
+    );
+  }
+  return n;
+}
+
 /** Parse a string as a non-negative integer, throwing on invalid input. */
 function parseNonNegativeInt(value: string): number {
   const n = Number(value);
@@ -81,17 +92,11 @@ export function createProgram(): Command {
   program
     .command("launch-app")
     .description("Launch the LinkedHelper application")
-    .option("--cdp-port <port>", "CDP debugging port", parsePositiveInt)
-    .option("--cdp-host <host>", "CDP host (default: 127.0.0.1)")
-    .option("--allow-remote", "Allow non-loopback CDP connections")
     .action(handleLaunchApp);
 
   program
     .command("quit-app")
     .description("Quit the LinkedHelper application")
-    .option("--cdp-port <port>", "CDP debugging port", parsePositiveInt)
-    .option("--cdp-host <host>", "CDP host (default: 127.0.0.1)")
-    .option("--allow-remote", "Allow non-loopback CDP connections")
     .action(handleQuitApp);
 
   program
@@ -326,7 +331,7 @@ export function createProgram(): Command {
     .option(
       "--max-results <n>",
       "Maximum results per iteration (-1 for unlimited)",
-      parseInt,
+      parseMaxResults,
     )
     .option("--action-settings <json>", "Action-specific settings as JSON")
     .option("--cdp-port <port>", "CDP debugging port", parsePositiveInt)


### PR DESCRIPTION
## Summary

- Replace bare `parseInt` on `--max-results` with `parseMaxResults` that rejects `NaN`, fractional, zero, and out-of-range inputs (accepts positive integers and `-1` for unlimited)
- Remove unused `--cdp-port`, `--cdp-host`, and `--allow-remote` options from `launch-app` and `quit-app` commands
- Simplify `handleLaunchApp` and `handleQuitApp` handlers to no longer accept CDP options

Closes #268

## Test plan

- [x] `--max-results abc` throws `InvalidArgumentError`
- [x] `--max-results 3.7` throws `InvalidArgumentError`
- [x] `--max-results 0` throws `InvalidArgumentError`
- [x] `--max-results -2` throws `InvalidArgumentError`
- [x] `launch-app` does not have `--cdp-port` option
- [x] `quit-app` does not have `--cdp-port` option
- [x] `pnpm build` succeeds
- [x] `pnpm lint` succeeds
- [x] `pnpm test` — all 292 CLI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)