### PR TITLE
(refactor) core: move raw SQL in checkStatus to ProfileRepository

### DIFF
--- a/packages/core/src/db/repositories/profile.test.ts
+++ b/packages/core/src/db/repositories/profile.test.ts
@@ -24,6 +24,19 @@ describe("ProfileRepository", () => {
     db.close();
   });
 
+  describe("getProfileCount", () => {
+    it("returns the total number of profiles", () => {
+      expect(repo.getProfileCount()).toBe(4);
+    });
+
+    it("returns 0 for an empty database", () => {
+      db.exec("PRAGMA foreign_keys = OFF");
+      db.exec("DELETE FROM people");
+      db.exec("PRAGMA foreign_keys = ON");
+      expect(repo.getProfileCount()).toBe(0);
+    });
+  });
+
   describe("findById", () => {
     it("returns a fully assembled profile", () => {
       const profile = repo.findById(1);

--- a/packages/core/src/db/repositories/profile.ts
+++ b/packages/core/src/db/repositories/profile.ts
@@ -96,6 +96,7 @@ export class ProfileRepository {
   private readonly stmtSkills;
   private readonly stmtEmails;
   private readonly stmtSearch;
+  private readonly stmtProfileCount;
 
   constructor(client: DatabaseClient) {
     const { db } = client;
@@ -148,6 +149,10 @@ export class ProfileRepository {
       `SELECT email FROM person_email WHERE person_id = ?`,
     );
 
+    this.stmtProfileCount = db.prepare(
+      "SELECT COUNT(*) AS cnt FROM people",
+    );
+
     this.stmtSearch = db.prepare(
       `SELECT
          p.id,
@@ -165,6 +170,14 @@ export class ProfileRepository {
        ORDER BY mp.first_name, mp.last_name
        LIMIT ? OFFSET ?`,
     );
+  }
+
+  /**
+   * Returns the total number of profiles in the database.
+   */
+  getProfileCount(): number {
+    const row = this.stmtProfileCount.get() as { cnt: number } | undefined;
+    return row?.cnt ?? 0;
   }
 
   /**

--- a/packages/core/src/services/status.ts
+++ b/packages/core/src/services/status.ts
@@ -4,6 +4,7 @@
 import { discoverInstancePort } from "../cdp/index.js";
 import { DEFAULT_CDP_PORT } from "../constants.js";
 import { DatabaseClient, discoverAllDatabases } from "../db/index.js";
+import { ProfileRepository } from "../db/repositories/profile.js";
 import { LauncherService } from "./launcher.js";
 
 /** Status of the LinkedHelper launcher process. */
@@ -89,10 +90,8 @@ export async function checkStatus(
       try {
         const client = new DatabaseClient(dbPath);
         try {
-          const row = client.db
-            .prepare("SELECT COUNT(*) AS cnt FROM people")
-            .get() as { cnt: number } | undefined;
-          profileCount = row?.cnt ?? 0;
+          const repo = new ProfileRepository(client);
+          profileCount = repo.getProfileCount();
         } finally {
           client.close();
         }


### PR DESCRIPTION
## Summary

- Add `getProfileCount()` method to `ProfileRepository` to encapsulate the `SELECT COUNT(*) FROM people` query
- Replace direct `client.db.prepare(...)` raw SQL in `checkStatus()` with `ProfileRepository.getProfileCount()`
- Add unit tests for the new method (populated and empty database cases)

Closes #288

## Test plan

- [x] `ProfileRepository.getProfileCount()` returns correct count (4 profiles in fixture)
- [x] `ProfileRepository.getProfileCount()` returns 0 for empty database
- [x] `status.ts` no longer contains `client.db.prepare` or raw SQL strings
- [x] `pnpm build` succeeds
- [x] `pnpm lint` succeeds
- [x] All existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)