### PR TITLE
Add license-check to release validation pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,7 @@ jobs:
       - uses: ./.github/actions/setup
       - run: pnpm build
       - run: pnpm lint
+      - run: pnpm license-check
       - run: pnpm test
 
   publish-npm:


### PR DESCRIPTION
## Summary

- Adds `pnpm license-check` step to the release `validate` job, between lint and test — mirroring the existing CI workflow order

Closes #281

## Test plan

- [ ] CI passes on this PR (build, lint, license-check, test)
- [ ] Verify `.github/workflows/release.yml` validate job now includes `pnpm license-check` between lint and test

🤖 Generated with [Claude Code](https://claude.com/claude-code)