### PR TITLE
(chore) ci: harden release and CI pipeline

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -17,7 +17,7 @@ runs:
         cache: pnpm
         registry-url: ${{ inputs.registry-url }}
 
-    - run: pnpm install --frozen-lockfile
+    - run: pnpm install --frozen-lockfile --ignore-scripts
       shell: bash
 
     - name: Install Playwright Chromium

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,9 @@ updates:
         update-types:
           - minor
           - patch
+      actions-major:
+        update-types:
+          - major
 
   - package-ecosystem: npm
     directory: /
@@ -22,3 +25,6 @@ updates:
         update-types:
           - minor
           - patch
+      npm-major:
+        update-types:
+          - major

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,7 +44,7 @@ jobs:
 
       # Trusted publishing requires npm 11.5.1+ for OIDC token exchange
       - name: Upgrade npm
-        run: npm install -g "npm@^11.5.1"
+        run: npm install -g "npm@11.5.1"
 
       - name: Stamp version
         env:


### PR DESCRIPTION
## Summary

- Pin npm to exact version (`11.5.1`) in release workflow — removes caret range that allowed non-deterministic installs
- Add `--ignore-scripts` to `pnpm install` in CI setup action — prevents compromised dependencies from executing arbitrary code during install
- Add major version update groups to Dependabot config for both `npm` and `github-actions` ecosystems — surfaces major bumps that may contain security fixes

Closes #284

## Test plan

- [ ] CI passes (build, lint, test) — confirms `--ignore-scripts` doesn't break dependency setup
- [ ] Verify release workflow YAML is valid (npm pin syntax correct)
- [ ] Verify dependabot.yml is valid YAML with correct group structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)