### PR TITLE
Add CODEOWNERS for security-sensitive files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Require owner review for CI/CD and security-sensitive files
+.github/ @alexey-pelykh
+.npmrc @alexey-pelykh
+pnpm-workspace.yaml @alexey-pelykh
+scripts/ @alexey-pelykh
+SECURITY.md @alexey-pelykh


### PR DESCRIPTION
## Summary
- Add `.github/CODEOWNERS` requiring `@alexey-pelykh` review for CI/CD workflows, package configs, scripts, and security policy
- Closes security gap where write-access contributors could modify sensitive files without mandatory owner review

Closes #282

## Test plan
- [ ] Verify CODEOWNERS syntax is accepted by GitHub (no errors in repo settings)
- [ ] Verify PRs touching `.github/` files show required review from `@alexey-pelykh`
- [ ] Verify `pnpm build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)