### PR TITLE
Add exports field to lhremote facade package

### DIFF
--- a/packages/lhremote/package.json
+++ b/packages/lhremote/package.json
@@ -16,6 +16,12 @@
     "url": "https://github.com/alexey-pelykh/lhremote.git",
     "directory": "packages/lhremote"
   },
+  "exports": {
+    ".": {
+      "types": "./dist/cli.d.ts",
+      "import": "./dist/cli.js"
+    }
+  },
   "bin": {
     "lhremote": "./dist/cli.js"
   },


### PR DESCRIPTION
## Summary
- Add `exports` field to `packages/lhremote/package.json` for consistency with sibling packages (`core`, `mcp`, `cli`)
- Maps `"."` entry to `./dist/cli.d.ts` (types) and `./dist/cli.js` (import)

Closes #291

## Test plan
- [x] `pnpm build` succeeds
- [x] `pnpm test` passes (all 800 tests across all packages)
- [x] All 4 non-e2e packages now have `exports` fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)