### PR TITLE
(chore) ci: optimize Playwright Chromium installation in CI

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -5,6 +5,10 @@ inputs:
   registry-url:
     description: Registry URL for publishing
     required: false
+  skip-playwright:
+    description: Skip Playwright Chromium installation
+    required: false
+    default: 'false'
 
 runs:
   using: composite
@@ -20,8 +24,39 @@ runs:
     - run: pnpm install --frozen-lockfile
       shell: bash
 
+    - name: Get Playwright version
+      if: inputs.skip-playwright != 'true'
+      id: pw-version
+      run: echo "version=$(npx playwright-core --version)" >> "$GITHUB_OUTPUT"
+      shell: bash
+
+    - name: Resolve Playwright cache path
+      if: inputs.skip-playwright != 'true'
+      id: pw-cache-path
+      shell: bash
+      run: |
+        case "${{ runner.os }}" in
+          Linux)   echo "path=${XDG_CACHE_HOME:-$HOME/.cache}/ms-playwright" >> "$GITHUB_OUTPUT" ;;
+          macOS)   echo "path=$HOME/Library/Caches/ms-playwright" >> "$GITHUB_OUTPUT" ;;
+          Windows) echo "path=$LOCALAPPDATA/ms-playwright" >> "$GITHUB_OUTPUT" ;;
+        esac
+
+    - name: Cache Playwright browsers
+      if: inputs.skip-playwright != 'true'
+      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+      id: pw-cache
+      with:
+        path: ${{ steps.pw-cache-path.outputs.path }}
+        key: pw-${{ runner.os }}-${{ steps.pw-version.outputs.version }}
+
     - name: Install Playwright Chromium
+      if: inputs.skip-playwright != 'true' && steps.pw-cache.outputs.cache-hit != 'true'
       run: npx playwright-core install chromium --with-deps
+      shell: bash
+
+    - name: Install Playwright OS deps (cache hit)
+      if: inputs.skip-playwright != 'true' && steps.pw-cache.outputs.cache-hit == 'true'
+      run: npx playwright-core install-deps chromium
       shell: bash
 
     - uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,8 @@ jobs:
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
 
       - uses: ./.github/actions/setup
+        with:
+          skip-playwright: 'true'
 
       - name: Build packages
         run: pnpm build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,7 @@ jobs:
       - uses: ./.github/actions/setup
         with:
           registry-url: https://registry.npmjs.org
+          skip-playwright: 'true'
 
       # Trusted publishing requires npm 11.5.1+ for OIDC token exchange
       - name: Upgrade npm


### PR DESCRIPTION
## Summary

- Add `skip-playwright` input to the composite setup action so non-test jobs (`package`, `publish-npm`) skip Playwright Chromium installation entirely
- Cache Playwright browser binaries by OS and version across the 3-OS CI matrix; on cache hit only OS-level dependencies are reinstalled
- Resolve the correct Playwright cache path per platform (Linux `XDG_CACHE_HOME`, macOS `~/Library/Caches`, Windows `LOCALAPPDATA`)

Closes #283

## Test plan

- [ ] `ci` job (3-OS matrix): Playwright installs normally on first run, uses cache on subsequent runs
- [ ] `package` job: Playwright Chromium is not installed (verify step is skipped in logs)
- [ ] `validate` job in release: Playwright Chromium is installed (tests require it)
- [ ] `publish-npm` job in release: Playwright Chromium is not installed (verify step is skipped in logs)
- [ ] All CI jobs pass on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)