### PR TITLE
(chore) infra: enforce test coverage thresholds in CI

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -18,6 +18,12 @@ export default defineConfig({
         "**/*.d.ts",
         "**/testing/**",
       ],
+      thresholds: {
+        statements: 85,
+        branches: 69,
+        functions: 80,
+        lines: 85,
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary

- Add `thresholds` block to the existing `coverage` configuration in `vitest.config.ts`
- Thresholds derived from current per-package coverage with ≥5 percentage-point margins:
  - **statements: 85%** (lowest current: 90.15% in core)
  - **branches: 69%** (lowest current: 74.46% in mcp)
  - **functions: 80%** (lowest current: 96.53% in core)
  - **lines: 85%** (lowest current: 90.85% in core)
- `branches` set to 69% (not 80% as originally proposed) because `@lhremote/mcp` currently sits at 74.46%

## Test plan

- [x] `pnpm build` succeeds
- [x] `pnpm test` passes (all 1088 tests)
- [x] `pnpm test -- -- --coverage` passes with thresholds enforced
- [ ] CI passes on all platforms (ubuntu/macos/windows)

Closes #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)