### PR TITLE
(test) mcp: add find-app tool handler tests

### DIFF
--- a/packages/mcp/src/tools/find-app.test.ts
+++ b/packages/mcp/src/tools/find-app.test.ts
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return {
+    ...actual,
+    findApp: vi.fn(),
+  };
+});
+
+import { type DiscoveredApp, findApp } from "@lhremote/core";
+
+import { registerFindApp } from "./find-app.js";
+import { createMockServer } from "./testing/mock-server.js";
+
+const mockedFindApp = vi.mocked(findApp);
+
+describe("registerFindApp", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("registers a tool named find-app", () => {
+    const { server } = createMockServer();
+    registerFindApp(server);
+
+    expect(server.tool).toHaveBeenCalledOnce();
+    expect(server.tool).toHaveBeenCalledWith(
+      "find-app",
+      expect.any(String),
+      expect.any(Object),
+      expect.any(Function),
+    );
+  });
+
+  it("returns apps as JSON when found", async () => {
+    const { server, getHandler } = createMockServer();
+    registerFindApp(server);
+
+    const apps: DiscoveredApp[] = [
+      { pid: 1234, cdpPort: 9222, connectable: true },
+    ];
+    mockedFindApp.mockResolvedValue(apps);
+
+    const handler = getHandler("find-app");
+    const result = (await handler({})) as { content: [{ text: string }] };
+
+    expect(JSON.parse(result.content[0].text)).toEqual(apps);
+  });
+
+  it("returns friendly message when no apps found", async () => {
+    const { server, getHandler } = createMockServer();
+    registerFindApp(server);
+
+    mockedFindApp.mockResolvedValue([]);
+
+    const handler = getHandler("find-app");
+    const result = await handler({});
+
+    expect(result).toEqual({
+      content: [
+        { type: "text", text: "No running LinkedHelper instances found" },
+      ],
+    });
+  });
+
+  it("returns error on unexpected failure", async () => {
+    const { server, getHandler } = createMockServer();
+    registerFindApp(server);
+
+    mockedFindApp.mockRejectedValue(new Error("scan failed"));
+
+    const handler = getHandler("find-app");
+    const result = await handler({});
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        { type: "text", text: "Failed to find LinkedHelper: scan failed" },
+      ],
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add unit tests for the `find-app` MCP tool handler covering all three code paths: apps found (JSON response), no apps found (friendly message), and error catch-all
- Follows the established plain-function mock pattern used by `check-status.test.ts`

Closes #271

## Test plan
- [x] `pnpm test` passes with no regressions (all 10 tasks, 806 tests)
- [x] New `find-app.test.ts` passes all 4 test cases:
  - Registration test
  - Apps found → JSON response
  - No apps found → friendly message
  - Error catch-all → `isError: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)