### PR TITLE
(test) mcp: add tool registration completeness guard

### DIFF
--- a/packages/mcp/src/tools/index.test.ts
+++ b/packages/mcp/src/tools/index.test.ts
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2025 Alexey Pelykh
+
+import { describe, expect, it } from "vitest";
+
+import * as toolExports from "./index.js";
+import { registerAllTools } from "./index.js";
+import { createMockServer } from "./testing/mock-server.js";
+
+describe("registerAllTools", () => {
+  it("calls every exported register* function", () => {
+    const registerExports = Object.keys(toolExports).filter(
+      (key) => key.startsWith("register") && key !== "registerAllTools",
+    );
+
+    const { server } = createMockServer();
+    registerAllTools(server);
+
+    expect(server.tool).toHaveBeenCalledTimes(registerExports.length);
+  });
+
+  it("registers tools with unique names", () => {
+    const { server } = createMockServer();
+    registerAllTools(server);
+
+    const toolNames = (server.tool as ReturnType<typeof import("vitest").vi.fn>).mock.calls.map(
+      (call: unknown[]) => call[0],
+    );
+    const uniqueNames = new Set(toolNames);
+    expect(uniqueNames.size).toBe(toolNames.length);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `packages/mcp/src/tools/index.test.ts` with two completeness guard tests
- Verifies `registerAllTools()` calls `server.tool` exactly N times (N = number of exported `register*` functions, excluding `registerAllTools` itself)
- Verifies all registered tool names are unique (no duplicates)
- Catches silent omissions: if a developer exports a new `register*` function but forgets to call it in `registerAllTools()`, the count test fails

Closes #273

## Test plan

- [x] New test passes (`pnpm test` — 243 tests in `@lhremote/mcp`, all green)
- [x] Temporarily commenting out one `register*` call causes the count test to fail (verified: "expected 32 times, but got 31 times")
- [x] Full suite passes with no regressions (559 core + 243 mcp tests)
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)