### PR TITLE
(docs) add same-machine limitation to README Known Limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,6 +473,7 @@ List available LinkedHelper action types with descriptions and configuration sch
 - **Instance startup time**: Starting an instance loads LinkedIn, which may take up to 45 seconds.
 - **Profile data is cached**: `query-profile` and `query-profiles` search the local LinkedHelper database. Profiles must have been visited or imported by LinkedHelper to appear in results.
 - **Messaging scrape is slow**: `scrape-messaging-history` navigates LinkedIn's messaging UI and can take several minutes depending on conversation volume.
+- **Same-machine requirement**: lhremote must run on the same machine as LinkedHelper. CDP connections are localhost-only by default (for security), and database access requires direct file system access to the LinkedHelper SQLite database.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

- Adds a "Same-machine requirement" bullet to the README Known Limitations section, explaining that lhremote must run on the same machine as LinkedHelper due to localhost-only CDP connections and direct SQLite file access

Closes #285

## Test plan

- [x] Verify the new bullet is present in the Known Limitations section
- [x] Verify it mentions both CDP localhost-only and database file access reasons
- [x] Verify no other sections are affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)