### PR TITLE
(docs) core: update README with missing public API exports

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -23,6 +23,8 @@ npm install @lhremote/core
 | `resolveAccount` | Resolve the active account ID from a running instance |
 | `checkStatus` | Check launcher, instance, and database health |
 | `startInstanceWithRecovery` | Start an instance with automatic retry on failure |
+| `waitForInstancePort` | Wait for an instance CDP port to become available |
+| `waitForInstanceShutdown` | Wait for an instance to shut down |
 | `withDatabase` / `withInstanceDatabase` | Scoped database access helpers |
 
 ### Data Access
@@ -41,6 +43,7 @@ npm install @lhremote/core
 |--------|-------------|
 | `parseCampaignYaml` / `parseCampaignJson` | Parse campaign configuration |
 | `serializeCampaignYaml` / `serializeCampaignJson` | Serialize campaign configuration |
+| `CampaignFormatError` | Error thrown on invalid campaign format input |
 
 ### Action Catalog
 
@@ -55,10 +58,54 @@ npm install @lhremote/core
 |--------|-------------|
 | `findApp` | Detect running LinkedHelper instances via process inspection |
 | `discoverInstancePort` | Find the CDP port for a running instance |
+| `discoverTargets` | Discover CDP targets on a given port |
+| `killInstanceProcesses` | Kill processes associated with a LinkedHelper instance |
+
+### Operations
+
+| Export | Description |
+|--------|-------------|
+| `campaignStatus` | Retrieve campaign status with statistics and action details |
+
+### Constants & Utilities
+
+| Export | Description |
+|--------|-------------|
+| `DEFAULT_CDP_PORT` | Default CDP port used by LinkedHelper |
+| `delay` | Promise-based delay helper |
+| `errorMessage` | Extract a human-readable message from an unknown error |
+| `isCdpPort` | Check whether a value is a valid CDP port number |
+| `isLoopbackAddress` | Check whether a string is a loopback IP address |
 
 ### Error Types
 
-The library exports domain-specific error classes (`CampaignNotFoundError`, `CDPConnectionError`, `DatabaseNotFoundError`, etc.) that consumers can use for fine-grained error handling.
+| Export | Description |
+|--------|-------------|
+| `ServiceError` | Base class for service-layer errors |
+| `AccountResolutionError` | Failed to resolve the active account |
+| `ActionExecutionError` | Action execution failed |
+| `AppLaunchError` | LinkedHelper application failed to launch |
+| `AppNotFoundError` | LinkedHelper application not found |
+| `CampaignExecutionError` | Campaign execution failed |
+| `CampaignTimeoutError` | Campaign operation timed out |
+| `ExtractionTimeoutError` | Data extraction timed out |
+| `InstanceNotRunningError` | Target instance is not running |
+| `InvalidProfileUrlError` | Invalid LinkedIn profile URL |
+| `LinkedHelperNotRunningError` | LinkedHelper is not running |
+| `StartInstanceError` | Instance failed to start |
+| `WrongPortError` | Connected to wrong port / unexpected endpoint |
+| `CampaignNotFoundError` | Campaign not found in the database |
+| `ActionNotFoundError` | Action not found in the database |
+| `ChatNotFoundError` | Chat not found in the database |
+| `DatabaseError` | General database error |
+| `DatabaseNotFoundError` | Database file not found on disk |
+| `ExcludeListNotFoundError` | Exclude list not found in the database |
+| `NoNextActionError` | No next action available in the campaign |
+| `ProfileNotFoundError` | Profile not found in the database |
+| `CDPConnectionError` | CDP connection failed |
+| `CDPError` | General CDP protocol error |
+| `CDPEvaluationError` | CDP JavaScript evaluation failed |
+| `CDPTimeoutError` | CDP operation timed out |
 
 ## Usage
 


### PR DESCRIPTION
## Summary

- Add `waitForInstancePort`, `waitForInstanceShutdown` to Services table
- Add `discoverTargets`, `killInstanceProcesses` to CDP table
- Add `CampaignFormatError` to Campaign Formats table
- Add new Operations section with `campaignStatus`
- Add new Constants & Utilities section with `DEFAULT_CDP_PORT`, `delay`, `errorMessage`, `isCdpPort`, `isLoopbackAddress`
- Replace vague Error Types paragraph with explicit table listing all 24 error classes

Closes #276

## Test plan

- [x] `pnpm build` succeeds
- [x] All non-type exports from `packages/core/src/index.ts` are represented in README tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)