### PR TITLE
(docs) update ADR-005 and create ADR-006 for operations layer

### DIFF
--- a/docs/adr/001-monorepo-package-structure.md
+++ b/docs/adr/001-monorepo-package-structure.md
@@ -17,13 +17,18 @@ The project needs to:
 
 ## Decision
 
-Organize as a pnpm workspace monorepo with four packages in a layered dependency graph:
+Organize as a pnpm workspace monorepo with five packages in a layered dependency graph:
 
 ```
 lhremote (distribution package)
 ├── @lhremote/cli   (CLI interface)
 └── @lhremote/mcp   (MCP server interface)
     └── @lhremote/core (shared foundation)
+
+@lhremote/e2e (private, not published)
+├── @lhremote/cli
+├── @lhremote/mcp
+└── @lhremote/core
 ```
 
 **Package responsibilities:**
@@ -34,6 +39,7 @@ lhremote (distribution package)
 | `@lhremote/mcp` | MCP server with tool definitions and Zod validation | `@lhremote/core`, `@modelcontextprotocol/sdk`, `zod` |
 | `@lhremote/cli` | Commander.js CLI with command handlers | `@lhremote/core`, `commander` |
 | `lhremote` | Published npm package, combines CLI + MCP binaries | `@lhremote/cli`, `@lhremote/mcp` |
+| `@lhremote/e2e` | E2E tests against real LinkedHelper (private, not published) | `@lhremote/core`, `@lhremote/mcp`, `@lhremote/cli` |
 
 **Key constraints:**
 
@@ -68,7 +74,7 @@ Merge CLI and MCP into a single "app" package. Reduces package count but couples
 
 **Negative:**
 
-- Four `package.json` files and `tsconfig.json` files to maintain
+- Five `package.json` files and `tsconfig.json` files to maintain
 - pnpm workspace and Turbo configuration add infrastructure complexity
 - Developers must understand the dependency graph to know where code belongs
 - Cross-package TypeScript changes require rebuilding downstream packages

--- a/docs/adr/005-error-hierarchy-design.md
+++ b/docs/adr/005-error-hierarchy-design.md
@@ -41,7 +41,8 @@ Error (built-in)
     ├── InvalidProfileUrlError      Profile URL validation failed
     ├── ExtractionTimeoutError      Profile data didn't appear in DB in time
     ├── CampaignExecutionError      Campaign operation failed (carries campaignId)
-    └── CampaignTimeoutError        Campaign state transition timeout (carries campaignId)
+    ├── CampaignTimeoutError        Campaign state transition timeout (carries campaignId)
+    └── AccountResolutionError      Account resolution ambiguous (carries reason: "no-accounts" | "multiple-accounts")
 ```
 
 **Key design choices:**

--- a/docs/adr/006-operations-layer.md
+++ b/docs/adr/006-operations-layer.md
@@ -1,0 +1,53 @@
+# ADR-006: Operations Layer
+
+## Status
+
+Accepted
+
+## Context
+
+lhremote exposes automation capabilities through two user-facing interfaces — a CLI (`@lhremote/cli`) and an MCP server (`@lhremote/mcp`). Both interfaces need to perform the same business flows: resolve an account, open a database/instance context, call one or more services, and return a typed result.
+
+Before the operations layer, this orchestration logic was duplicated across MCP tool handlers and CLI command handlers. With 30+ tool/command pairs, the duplication created divergence risk — a bug fix in one handler might not be applied to its counterpart — and made it harder to test business flows in isolation from interface concerns.
+
+Services (e.g., `CampaignService`) encapsulate single-domain logic but do not handle cross-cutting concerns like account resolution or resource lifecycle management. A layer was needed between services and interface adapters to centralize this orchestration.
+
+## Decision
+
+Introduce `packages/core/src/operations/` as a layer between services and interface adapters (MCP tools / CLI handlers). Each operation:
+
+- Accepts a typed input interface extending `ConnectionOptions` (from `operations/types.ts`), which carries CDP connection parameters (`cdpPort`, `cdpHost`, `allowRemote`)
+- Resolves the target account via `resolveAccount()`
+- Manages resource lifecycle via `withInstanceDatabase()` or `withDatabase()`
+- Delegates domain logic to the appropriate service(s)
+- Returns a typed output interface
+
+The first exemplar is `campaignStatus` (introduced in commit `688117a`), which retrieves campaign execution status and optionally includes action results.
+
+**Boundary with services:** Services encapsulate a single domain (e.g., `CampaignService` for campaign CRUD). Operations orchestrate across domains and infrastructure concerns (account resolution, database lifecycle). MCP tools and CLI handlers become thin adapters that parse input and format output.
+
+**When to create a new operation vs. adding to a service:** Create an operation when both MCP and CLI need the same business flow that involves account resolution and service calls. Pure service calls that do not need cross-cutting orchestration stay in services.
+
+## Alternatives Considered
+
+### Keep duplication in handlers
+
+Leave the orchestration logic in each MCP tool and CLI command handler. This avoids the additional layer but violates DRY — the same account-resolution and database-lifecycle boilerplate is repeated in every handler. Divergence risk grows with the number of tools. Rejected.
+
+### Put orchestration in services
+
+Move the orchestration into service classes themselves. This would eliminate duplication but mix domain logic (campaign CRUD, profile lookup) with infrastructure concerns (CDP port/host options, account resolution, database lifecycle). Services would need to know about connection parameters that are irrelevant to their domain responsibility. Rejected.
+
+## Consequences
+
+**Positive:**
+
+- Single source of truth for business flows — a bug fix in an operation applies to both CLI and MCP
+- Thinner interface adapters — MCP tools and CLI handlers focus on input parsing and output formatting
+- Easier to test orchestration in isolation from interface-specific concerns
+- Clear layering: interface adapters → operations → services → database/CDP
+
+**Negative:**
+
+- Additional layer to navigate when tracing a request from interface to database
+- Operations must be kept in sync with service API changes (e.g., if `CampaignService.getStatus()` signature changes)


### PR DESCRIPTION
## Summary

- **ADR-005**: Add `AccountResolutionError` to the ServiceError hierarchy diagram, with its `reason` discriminant (`"no-accounts" | "multiple-accounts"`)
- **ADR-006**: Create new ADR documenting the operations layer (`packages/core/src/operations/`) — the boundary between services and interface adapters, introduced in commit `688117a`
- **ADR-001**: Amend package count from four to five and add `@lhremote/e2e` (private test package) to the dependency graph and package table

Closes #278

## Test plan

- [ ] Verify ADR-005 ServiceError section includes `AccountResolutionError` with description
- [ ] Verify ADR-006 file paths match actual directory structure (`packages/core/src/operations/`)
- [ ] Verify ADR-001 states five packages and `@lhremote/e2e` appears in the table
- [ ] Verify CI passes (docs-only change, no code impact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)