### PR TITLE
(security) enhance allowRemote parameter descriptions with security warnings

### DIFF
--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -104,7 +104,7 @@ export function createProgram(): Command {
     .description("List LinkedHelper accounts")
     .option("--cdp-port <port>", "CDP debugging port", parsePositiveInt)
     .option("--cdp-host <host>", "CDP host (default: 127.0.0.1)")
-    .option("--allow-remote", "Allow non-loopback CDP connections")
+    .option("--allow-remote", "SECURITY: allow non-loopback CDP connections (enables remote code execution on target)")
     .option("--json", "Output as JSON")
     .action(handleListAccounts);
 
@@ -114,7 +114,7 @@ export function createProgram(): Command {
     .argument("<accountId>", "Account ID to start", parsePositiveInt)
     .option("--cdp-port <port>", "CDP debugging port", parsePositiveInt)
     .option("--cdp-host <host>", "CDP host (default: 127.0.0.1)")
-    .option("--allow-remote", "Allow non-loopback CDP connections")
+    .option("--allow-remote", "SECURITY: allow non-loopback CDP connections (enables remote code execution on target)")
     .action(handleStartInstance);
 
   program
@@ -123,7 +123,7 @@ export function createProgram(): Command {
     .argument("<accountId>", "Account ID to stop", parsePositiveInt)
     .option("--cdp-port <port>", "CDP debugging port", parsePositiveInt)
     .option("--cdp-host <host>", "CDP host (default: 127.0.0.1)")
-    .option("--allow-remote", "Allow non-loopback CDP connections")
+    .option("--allow-remote", "SECURITY: allow non-loopback CDP connections (enables remote code execution on target)")
     .action(handleStopInstance);
 
   program
@@ -141,7 +141,7 @@ export function createProgram(): Command {
     .option("--json-input <config>", "Inline JSON campaign configuration")
     .option("--cdp-port <port>", "CDP debugging port", parsePositiveInt)
     .option("--cdp-host <host>", "CDP host (default: 127.0.0.1)")
-    .option("--allow-remote", "Allow non-loopback CDP connections")
+    .option("--allow-remote", "SECURITY: allow non-loopback CDP connections (enables remote code execution on target)")
     .option("--json", "Output as JSON")
     .action(handleCampaignCreate);
 
@@ -151,7 +151,7 @@ export function createProgram(): Command {
     .argument("<campaignId>", "Campaign ID", parsePositiveInt)
     .option("--cdp-port <port>", "CDP debugging port", parsePositiveInt)
     .option("--cdp-host <host>", "CDP host (default: 127.0.0.1)")
-    .option("--allow-remote", "Allow non-loopback CDP connections")
+    .option("--allow-remote", "SECURITY: allow non-loopback CDP connections (enables remote code execution on target)")
     .option("--json", "Output as JSON")
     .action(handleCampaignGet);
 
@@ -161,7 +161,7 @@ export function createProgram(): Command {
     .argument("<campaignId>", "Campaign ID to delete", parsePositiveInt)
     .option("--cdp-port <port>", "CDP debugging port", parsePositiveInt)
     .option("--cdp-host <host>", "CDP host (default: 127.0.0.1)")
-    .option("--allow-remote", "Allow non-loopback CDP connections")
+    .option("--allow-remote", "SECURITY: allow non-loopback CDP connections (enables remote code execution on target)")
     .option("--json", "Output as JSON")
     .action(handleCampaignDelete);
 
@@ -176,7 +176,7 @@ export function createProgram(): Command {
     )
     .option("--cdp-port <port>", "CDP debugging port", parsePositiveInt)
     .option("--cdp-host <host>", "CDP host (default: 127.0.0.1)")
-    .option("--allow-remote", "Allow non-loopback CDP connections")
+    .option("--allow-remote", "SECURITY: allow non-loopback CDP connections (enables remote code execution on target)")
     .option("--json", "Output as JSON")
     .action(handleCampaignExcludeList);
 
@@ -193,7 +193,7 @@ export function createProgram(): Command {
     )
     .option("--cdp-port <port>", "CDP debugging port", parsePositiveInt)
     .option("--cdp-host <host>", "CDP host (default: 127.0.0.1)")
-    .option("--allow-remote", "Allow non-loopback CDP connections")
+    .option("--allow-remote", "SECURITY: allow non-loopback CDP connections (enables remote code execution on target)")
     .option("--json", "Output as JSON")
     .action(handleCampaignExcludeAdd);
 
@@ -210,7 +210,7 @@ export function createProgram(): Command {
     )
     .option("--cdp-port <port>", "CDP debugging port", parsePositiveInt)
     .option("--cdp-host <host>", "CDP host (default: 127.0.0.1)")
-    .option("--allow-remote", "Allow non-loopback CDP connections")
+    .option("--allow-remote", "SECURITY: allow non-loopback CDP connections (enables remote code execution on target)")
     .option("--json", "Output as JSON")
     .action(handleCampaignExcludeRemove);
 
@@ -226,7 +226,7 @@ export function createProgram(): Command {
     .option("--output <path>", "Output file path (default: stdout)")
     .option("--cdp-port <port>", "CDP debugging port", parsePositiveInt)
     .option("--cdp-host <host>", "CDP host (default: 127.0.0.1)")
-    .option("--allow-remote", "Allow non-loopback CDP connections")
+    .option("--allow-remote", "SECURITY: allow non-loopback CDP connections (enables remote code execution on target)")
     .action(handleCampaignExport);
 
   program
@@ -237,7 +237,7 @@ export function createProgram(): Command {
     .option("--limit <n>", "Max results to show (default: 20)", parsePositiveInt)
     .option("--cdp-port <port>", "CDP debugging port", parsePositiveInt)
     .option("--cdp-host <host>", "CDP host (default: 127.0.0.1)")
-    .option("--allow-remote", "Allow non-loopback CDP connections")
+    .option("--allow-remote", "SECURITY: allow non-loopback CDP connections (enables remote code execution on target)")
     .option("--json", "Output as JSON")
     .action(handleCampaignStatus);
 
@@ -249,7 +249,7 @@ export function createProgram(): Command {
     .option("--max-errors <n>", "Max top errors per action (default: 5)", parsePositiveInt)
     .option("--cdp-port <port>", "CDP debugging port", parsePositiveInt)
     .option("--cdp-host <host>", "CDP host (default: 127.0.0.1)")
-    .option("--allow-remote", "Allow non-loopback CDP connections")
+    .option("--allow-remote", "SECURITY: allow non-loopback CDP connections (enables remote code execution on target)")
     .option("--json", "Output as JSON")
     .action(handleCampaignStatistics);
 
@@ -262,7 +262,7 @@ export function createProgram(): Command {
     .option("--person-ids-file <path>", "File containing person IDs")
     .option("--cdp-port <port>", "CDP debugging port", parsePositiveInt)
     .option("--cdp-host <host>", "CDP host (default: 127.0.0.1)")
-    .option("--allow-remote", "Allow non-loopback CDP connections")
+    .option("--allow-remote", "SECURITY: allow non-loopback CDP connections (enables remote code execution on target)")
     .option("--json", "Output as JSON")
     .action(handleCampaignMoveNext);
 
@@ -274,7 +274,7 @@ export function createProgram(): Command {
     .option("--person-ids-file <path>", "File containing person IDs")
     .option("--cdp-port <port>", "CDP debugging port", parsePositiveInt)
     .option("--cdp-host <host>", "CDP host (default: 127.0.0.1)")
-    .option("--allow-remote", "Allow non-loopback CDP connections")
+    .option("--allow-remote", "SECURITY: allow non-loopback CDP connections (enables remote code execution on target)")
     .option("--json", "Output as JSON")
     .action(handleCampaignRetry);
 
@@ -286,7 +286,7 @@ export function createProgram(): Command {
     .option("--person-ids-file <path>", "File containing person IDs")
     .option("--cdp-port <port>", "CDP debugging port", parsePositiveInt)
     .option("--cdp-host <host>", "CDP host (default: 127.0.0.1)")
-    .option("--allow-remote", "Allow non-loopback CDP connections")
+    .option("--allow-remote", "SECURITY: allow non-loopback CDP connections (enables remote code execution on target)")
     .option("--json", "Output as JSON")
     .action(handleCampaignStart);
 
@@ -296,7 +296,7 @@ export function createProgram(): Command {
     .argument("<campaignId>", "Campaign ID to stop", parsePositiveInt)
     .option("--cdp-port <port>", "CDP debugging port", parsePositiveInt)
     .option("--cdp-host <host>", "CDP host (default: 127.0.0.1)")
-    .option("--allow-remote", "Allow non-loopback CDP connections")
+    .option("--allow-remote", "SECURITY: allow non-loopback CDP connections (enables remote code execution on target)")
     .option("--json", "Output as JSON")
     .action(handleCampaignStop);
 
@@ -309,7 +309,7 @@ export function createProgram(): Command {
     .option("--clear-description", "Clear the campaign description")
     .option("--cdp-port <port>", "CDP debugging port", parsePositiveInt)
     .option("--cdp-host <host>", "CDP host (default: 127.0.0.1)")
-    .option("--allow-remote", "Allow non-loopback CDP connections")
+    .option("--allow-remote", "SECURITY: allow non-loopback CDP connections (enables remote code execution on target)")
     .option("--json", "Output as JSON")
     .action(handleCampaignUpdate);
 
@@ -336,7 +336,7 @@ export function createProgram(): Command {
     .option("--action-settings <json>", "Action-specific settings as JSON")
     .option("--cdp-port <port>", "CDP debugging port", parsePositiveInt)
     .option("--cdp-host <host>", "CDP host (default: 127.0.0.1)")
-    .option("--allow-remote", "Allow non-loopback CDP connections")
+    .option("--allow-remote", "SECURITY: allow non-loopback CDP connections (enables remote code execution on target)")
     .option("--json", "Output as JSON")
     .action(handleCampaignAddAction);
 
@@ -347,7 +347,7 @@ export function createProgram(): Command {
     .argument("<actionId>", "Action ID to remove", parsePositiveInt)
     .option("--cdp-port <port>", "CDP debugging port", parsePositiveInt)
     .option("--cdp-host <host>", "CDP host (default: 127.0.0.1)")
-    .option("--allow-remote", "Allow non-loopback CDP connections")
+    .option("--allow-remote", "SECURITY: allow non-loopback CDP connections (enables remote code execution on target)")
     .option("--json", "Output as JSON")
     .action(handleCampaignRemoveAction);
 
@@ -361,7 +361,7 @@ export function createProgram(): Command {
     )
     .option("--cdp-port <port>", "CDP debugging port", parsePositiveInt)
     .option("--cdp-host <host>", "CDP host (default: 127.0.0.1)")
-    .option("--allow-remote", "Allow non-loopback CDP connections")
+    .option("--allow-remote", "SECURITY: allow non-loopback CDP connections (enables remote code execution on target)")
     .option("--json", "Output as JSON")
     .action(handleCampaignReorderActions);
 
@@ -373,7 +373,7 @@ export function createProgram(): Command {
     .option("--urls-file <path>", "File containing LinkedIn profile URLs")
     .option("--cdp-port <port>", "CDP debugging port", parsePositiveInt)
     .option("--cdp-host <host>", "CDP host (default: 127.0.0.1)")
-    .option("--allow-remote", "Allow non-loopback CDP connections")
+    .option("--allow-remote", "SECURITY: allow non-loopback CDP connections (enables remote code execution on target)")
     .option("--json", "Output as JSON")
     .action(handleImportPeopleFromUrls);
 
@@ -421,7 +421,7 @@ export function createProgram(): Command {
     )
     .option("--cdp-port <port>", "CDP debugging port", parsePositiveInt)
     .option("--cdp-host <host>", "CDP host (default: 127.0.0.1)")
-    .option("--allow-remote", "Allow non-loopback CDP connections")
+    .option("--allow-remote", "SECURITY: allow non-loopback CDP connections (enables remote code execution on target)")
     .option("--json", "Output as JSON")
     .action(handleScrapeMessagingHistory);
 
@@ -431,7 +431,7 @@ export function createProgram(): Command {
     .option("--since <timestamp>", "Only show replies after this ISO timestamp")
     .option("--cdp-port <port>", "CDP debugging port", parsePositiveInt)
     .option("--cdp-host <host>", "CDP host (default: 127.0.0.1)")
-    .option("--allow-remote", "Allow non-loopback CDP connections")
+    .option("--allow-remote", "SECURITY: allow non-loopback CDP connections (enables remote code execution on target)")
     .option("--json", "Output as JSON")
     .action(handleCheckReplies);
 
@@ -440,7 +440,7 @@ export function createProgram(): Command {
     .description("Check LinkedHelper status")
     .option("--cdp-port <port>", "CDP debugging port", parsePositiveInt)
     .option("--cdp-host <host>", "CDP host (default: 127.0.0.1)")
-    .option("--allow-remote", "Allow non-loopback CDP connections")
+    .option("--allow-remote", "SECURITY: allow non-loopback CDP connections (enables remote code execution on target)")
     .option("--json", "Output as JSON")
     .action(handleCheckStatus);
 

--- a/packages/core/src/cdp/client.test.ts
+++ b/packages/core/src/cdp/client.test.ts
@@ -138,7 +138,7 @@ describe("CDPClient", () => {
         CDPConnectionError,
       );
       expect(() => new CDPClient(9222, { host: "example.com" })).toThrow(
-        /Remote CDP connections/,
+        /arbitrary code execution/,
       );
     });
 
@@ -149,6 +149,22 @@ describe("CDPClient", () => {
       expect(
         () => new CDPClient(9222, { host: "example.com", allowRemote: true }),
       ).not.toThrow();
+    });
+
+    it("should warn when allowRemote is used with non-loopback host", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      new CDPClient(9222, { host: "192.168.1.1", allowRemote: true });
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("[SECURITY WARNING]"),
+      );
+      warnSpy.mockRestore();
+    });
+
+    it("should not warn for loopback host with allowRemote", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      new CDPClient(9222, { host: "127.0.0.1", allowRemote: true });
+      expect(warnSpy).not.toHaveBeenCalled();
+      warnSpy.mockRestore();
     });
   });
 

--- a/packages/core/src/cdp/client.ts
+++ b/packages/core/src/cdp/client.ts
@@ -63,7 +63,15 @@ export class CDPClient {
     if (!isLoopbackAddress(this.host) && !options?.allowRemote) {
       throw new CDPConnectionError(
         `Remote CDP connections to "${this.host}" are not allowed. ` +
-          "Use the allowRemote option to connect to non-loopback addresses.",
+          "Remote connections expose the target to arbitrary code execution. " +
+          "Set allowRemote only if the network path is secured.",
+      );
+    }
+
+    if (!isLoopbackAddress(this.host) && options?.allowRemote) {
+      console.warn(
+        `[SECURITY WARNING] Remote CDP connection to ${this.host} enabled. ` +
+          "Any client on the network path can execute arbitrary JavaScript on the target.",
       );
     }
   }

--- a/packages/mcp/src/tools/campaign-add-action.ts
+++ b/packages/mcp/src/tools/campaign-add-action.ts
@@ -61,7 +61,7 @@ export function registerCampaignAddAction(server: McpServer): void {
       allowRemote: z
         .boolean()
         .optional()
-        .describe("Allow non-loopback CDP connections"),
+        .describe("SECURITY: Allow non-loopback CDP connections. Enables remote code execution on target host. Only use if network path is secured."),
     },
     async ({
       campaignId,

--- a/packages/mcp/src/tools/campaign-create.ts
+++ b/packages/mcp/src/tools/campaign-create.ts
@@ -42,7 +42,7 @@ export function registerCampaignCreate(server: McpServer): void {
       allowRemote: z
         .boolean()
         .optional()
-        .describe("Allow non-loopback CDP connections"),
+        .describe("SECURITY: Allow non-loopback CDP connections. Enables remote code execution on target host. Only use if network path is secured."),
     },
     async ({ config, format, cdpPort, cdpHost, allowRemote }) => {
       // Parse campaign config

--- a/packages/mcp/src/tools/campaign-delete.ts
+++ b/packages/mcp/src/tools/campaign-delete.ts
@@ -38,7 +38,7 @@ export function registerCampaignDelete(server: McpServer): void {
       allowRemote: z
         .boolean()
         .optional()
-        .describe("Allow non-loopback CDP connections"),
+        .describe("SECURITY: Allow non-loopback CDP connections. Enables remote code execution on target host. Only use if network path is secured."),
     },
     async ({ campaignId, cdpPort, cdpHost, allowRemote }) => {
       let accountId: number;

--- a/packages/mcp/src/tools/campaign-exclude-add.ts
+++ b/packages/mcp/src/tools/campaign-exclude-add.ts
@@ -51,7 +51,7 @@ export function registerCampaignExcludeAdd(server: McpServer): void {
       allowRemote: z
         .boolean()
         .optional()
-        .describe("Allow non-loopback CDP connections"),
+        .describe("SECURITY: Allow non-loopback CDP connections. Enables remote code execution on target host. Only use if network path is secured."),
     },
     async ({ campaignId, personIds, actionId, cdpPort, cdpHost, allowRemote }) => {
       let accountId: number;

--- a/packages/mcp/src/tools/campaign-exclude-list.ts
+++ b/packages/mcp/src/tools/campaign-exclude-list.ts
@@ -47,7 +47,7 @@ export function registerCampaignExcludeList(server: McpServer): void {
       allowRemote: z
         .boolean()
         .optional()
-        .describe("Allow non-loopback CDP connections"),
+        .describe("SECURITY: Allow non-loopback CDP connections. Enables remote code execution on target host. Only use if network path is secured."),
     },
     async ({ campaignId, actionId, cdpPort, cdpHost, allowRemote }) => {
       let accountId: number;

--- a/packages/mcp/src/tools/campaign-exclude-remove.ts
+++ b/packages/mcp/src/tools/campaign-exclude-remove.ts
@@ -51,7 +51,7 @@ export function registerCampaignExcludeRemove(server: McpServer): void {
       allowRemote: z
         .boolean()
         .optional()
-        .describe("Allow non-loopback CDP connections"),
+        .describe("SECURITY: Allow non-loopback CDP connections. Enables remote code execution on target host. Only use if network path is secured."),
     },
     async ({ campaignId, personIds, actionId, cdpPort, cdpHost, allowRemote }) => {
       let accountId: number;

--- a/packages/mcp/src/tools/campaign-export.ts
+++ b/packages/mcp/src/tools/campaign-export.ts
@@ -44,7 +44,7 @@ export function registerCampaignExport(server: McpServer): void {
       allowRemote: z
         .boolean()
         .optional()
-        .describe("Allow non-loopback CDP connections"),
+        .describe("SECURITY: Allow non-loopback CDP connections. Enables remote code execution on target host. Only use if network path is secured."),
     },
     async ({ campaignId, format, cdpPort, cdpHost, allowRemote }) => {
       let accountId: number;

--- a/packages/mcp/src/tools/campaign-get.ts
+++ b/packages/mcp/src/tools/campaign-get.ts
@@ -37,7 +37,7 @@ export function registerCampaignGet(server: McpServer): void {
       allowRemote: z
         .boolean()
         .optional()
-        .describe("Allow non-loopback CDP connections"),
+        .describe("SECURITY: Allow non-loopback CDP connections. Enables remote code execution on target host. Only use if network path is secured."),
     },
     async ({ campaignId, cdpPort, cdpHost, allowRemote }) => {
       let accountId: number;

--- a/packages/mcp/src/tools/campaign-list.ts
+++ b/packages/mcp/src/tools/campaign-list.ts
@@ -36,7 +36,7 @@ export function registerCampaignList(server: McpServer): void {
       allowRemote: z
         .boolean()
         .optional()
-        .describe("Allow non-loopback CDP connections"),
+        .describe("SECURITY: Allow non-loopback CDP connections. Enables remote code execution on target host. Only use if network path is secured."),
     },
     async ({ includeArchived, cdpPort, cdpHost, allowRemote }) => {
       let accountId: number;

--- a/packages/mcp/src/tools/campaign-move-next.ts
+++ b/packages/mcp/src/tools/campaign-move-next.ts
@@ -48,7 +48,7 @@ export function registerCampaignMoveNext(server: McpServer): void {
       allowRemote: z
         .boolean()
         .optional()
-        .describe("Allow non-loopback CDP connections"),
+        .describe("SECURITY: Allow non-loopback CDP connections. Enables remote code execution on target host. Only use if network path is secured."),
     },
     async ({ campaignId, actionId, personIds, cdpPort, cdpHost, allowRemote }) => {
       let accountId: number;

--- a/packages/mcp/src/tools/campaign-remove-action.ts
+++ b/packages/mcp/src/tools/campaign-remove-action.ts
@@ -44,7 +44,7 @@ export function registerCampaignRemoveAction(server: McpServer): void {
       allowRemote: z
         .boolean()
         .optional()
-        .describe("Allow non-loopback CDP connections"),
+        .describe("SECURITY: Allow non-loopback CDP connections. Enables remote code execution on target host. Only use if network path is secured."),
     },
     async ({ campaignId, actionId, cdpPort, cdpHost, allowRemote }) => {
       let accountId: number;

--- a/packages/mcp/src/tools/campaign-reorder-actions.ts
+++ b/packages/mcp/src/tools/campaign-reorder-actions.ts
@@ -43,7 +43,7 @@ export function registerCampaignReorderActions(server: McpServer): void {
       allowRemote: z
         .boolean()
         .optional()
-        .describe("Allow non-loopback CDP connections"),
+        .describe("SECURITY: Allow non-loopback CDP connections. Enables remote code execution on target host. Only use if network path is secured."),
     },
     async ({ campaignId, actionIds, cdpPort, cdpHost, allowRemote }) => {
       let accountId: number;

--- a/packages/mcp/src/tools/campaign-retry.ts
+++ b/packages/mcp/src/tools/campaign-retry.ts
@@ -41,7 +41,7 @@ export function registerCampaignRetry(server: McpServer): void {
       allowRemote: z
         .boolean()
         .optional()
-        .describe("Allow non-loopback CDP connections"),
+        .describe("SECURITY: Allow non-loopback CDP connections. Enables remote code execution on target host. Only use if network path is secured."),
     },
     async ({ campaignId, personIds, cdpPort, cdpHost, allowRemote }) => {
       let accountId: number;

--- a/packages/mcp/src/tools/campaign-start.ts
+++ b/packages/mcp/src/tools/campaign-start.ts
@@ -43,7 +43,7 @@ export function registerCampaignStart(server: McpServer): void {
       allowRemote: z
         .boolean()
         .optional()
-        .describe("Allow non-loopback CDP connections"),
+        .describe("SECURITY: Allow non-loopback CDP connections. Enables remote code execution on target host. Only use if network path is secured."),
     },
     async ({ campaignId, personIds, cdpPort, cdpHost, allowRemote }) => {
       let accountId: number;

--- a/packages/mcp/src/tools/campaign-statistics.ts
+++ b/packages/mcp/src/tools/campaign-statistics.ts
@@ -51,7 +51,7 @@ export function registerCampaignStatistics(server: McpServer): void {
       allowRemote: z
         .boolean()
         .optional()
-        .describe("Allow non-loopback CDP connections"),
+        .describe("SECURITY: Allow non-loopback CDP connections. Enables remote code execution on target host. Only use if network path is secured."),
     },
     async ({ campaignId, actionId, maxErrors, cdpPort, cdpHost, allowRemote }) => {
       let accountId: number;

--- a/packages/mcp/src/tools/campaign-status.ts
+++ b/packages/mcp/src/tools/campaign-status.ts
@@ -48,7 +48,7 @@ export function registerCampaignStatus(server: McpServer): void {
       allowRemote: z
         .boolean()
         .optional()
-        .describe("Allow non-loopback CDP connections"),
+        .describe("SECURITY: Allow non-loopback CDP connections. Enables remote code execution on target host. Only use if network path is secured."),
     },
     async ({ campaignId, includeResults, limit, cdpPort, cdpHost, allowRemote }) => {
       try {

--- a/packages/mcp/src/tools/campaign-stop.ts
+++ b/packages/mcp/src/tools/campaign-stop.ts
@@ -38,7 +38,7 @@ export function registerCampaignStop(server: McpServer): void {
       allowRemote: z
         .boolean()
         .optional()
-        .describe("Allow non-loopback CDP connections"),
+        .describe("SECURITY: Allow non-loopback CDP connections. Enables remote code execution on target host. Only use if network path is secured."),
     },
     async ({ campaignId, cdpPort, cdpHost, allowRemote }) => {
       let accountId: number;

--- a/packages/mcp/src/tools/campaign-update.ts
+++ b/packages/mcp/src/tools/campaign-update.ts
@@ -46,7 +46,7 @@ export function registerCampaignUpdate(server: McpServer): void {
       allowRemote: z
         .boolean()
         .optional()
-        .describe("Allow non-loopback CDP connections"),
+        .describe("SECURITY: Allow non-loopback CDP connections. Enables remote code execution on target host. Only use if network path is secured."),
     },
     async ({ campaignId, name, description, cdpPort, cdpHost, allowRemote }) => {
       // Validate that at least one field is provided

--- a/packages/mcp/src/tools/check-replies.ts
+++ b/packages/mcp/src/tools/check-replies.ts
@@ -37,7 +37,7 @@ export function registerCheckReplies(server: McpServer): void {
       allowRemote: z
         .boolean()
         .optional()
-        .describe("Allow non-loopback CDP connections"),
+        .describe("SECURITY: Allow non-loopback CDP connections. Enables remote code execution on target host. Only use if network path is secured."),
     },
     async ({ since, cdpPort, cdpHost, allowRemote }) => {
       const cutoff =

--- a/packages/mcp/src/tools/check-status.ts
+++ b/packages/mcp/src/tools/check-status.ts
@@ -26,7 +26,7 @@ export function registerCheckStatus(server: McpServer): void {
       allowRemote: z
         .boolean()
         .optional()
-        .describe("Allow non-loopback CDP connections"),
+        .describe("SECURITY: Allow non-loopback CDP connections. Enables remote code execution on target host. Only use if network path is secured."),
     },
     async ({ cdpPort, cdpHost, allowRemote }) => {
       try {

--- a/packages/mcp/src/tools/import-people-from-urls.ts
+++ b/packages/mcp/src/tools/import-people-from-urls.ts
@@ -42,7 +42,7 @@ export function registerImportPeopleFromUrls(server: McpServer): void {
       allowRemote: z
         .boolean()
         .optional()
-        .describe("Allow non-loopback CDP connections"),
+        .describe("SECURITY: Allow non-loopback CDP connections. Enables remote code execution on target host. Only use if network path is secured."),
     },
     async ({ campaignId, linkedInUrls, cdpPort, cdpHost, allowRemote }) => {
       let accountId: number;

--- a/packages/mcp/src/tools/list-accounts.ts
+++ b/packages/mcp/src/tools/list-accounts.ts
@@ -29,7 +29,7 @@ export function registerListAccounts(server: McpServer): void {
       allowRemote: z
         .boolean()
         .optional()
-        .describe("Allow non-loopback CDP connections"),
+        .describe("SECURITY: Allow non-loopback CDP connections. Enables remote code execution on target host. Only use if network path is secured."),
     },
     async ({ cdpPort, cdpHost, allowRemote }) => {
       const launcher = new LauncherService(cdpPort, { ...(cdpHost !== undefined && { host: cdpHost }), ...(allowRemote !== undefined && { allowRemote }) });

--- a/packages/mcp/src/tools/query-messages.ts
+++ b/packages/mcp/src/tools/query-messages.ts
@@ -60,7 +60,7 @@ export function registerQueryMessages(server: McpServer): void {
       allowRemote: z
         .boolean()
         .optional()
-        .describe("Allow non-loopback CDP connections"),
+        .describe("SECURITY: Allow non-loopback CDP connections. Enables remote code execution on target host. Only use if network path is secured."),
     },
     async ({ personId, chatId, search, limit, offset, cdpPort, cdpHost, allowRemote }) => {
       let accountId: number;

--- a/packages/mcp/src/tools/scrape-messaging-history.ts
+++ b/packages/mcp/src/tools/scrape-messaging-history.ts
@@ -31,7 +31,7 @@ export function registerScrapeMessagingHistory(server: McpServer): void {
       allowRemote: z
         .boolean()
         .optional()
-        .describe("Allow non-loopback CDP connections"),
+        .describe("SECURITY: Allow non-loopback CDP connections. Enables remote code execution on target host. Only use if network path is secured."),
     },
     async ({ cdpPort, cdpHost, allowRemote }) => {
       let accountId: number;

--- a/packages/mcp/src/tools/start-instance.ts
+++ b/packages/mcp/src/tools/start-instance.ts
@@ -39,7 +39,7 @@ export function registerStartInstance(server: McpServer): void {
       allowRemote: z
         .boolean()
         .optional()
-        .describe("Allow non-loopback CDP connections"),
+        .describe("SECURITY: Allow non-loopback CDP connections. Enables remote code execution on target host. Only use if network path is secured."),
     },
     async ({ accountId, cdpPort, cdpHost, allowRemote }) => {
       const launcher = new LauncherService(cdpPort, { ...(cdpHost !== undefined && { host: cdpHost }), ...(allowRemote !== undefined && { allowRemote }) });

--- a/packages/mcp/src/tools/stop-instance.ts
+++ b/packages/mcp/src/tools/stop-instance.ts
@@ -38,7 +38,7 @@ export function registerStopInstance(server: McpServer): void {
       allowRemote: z
         .boolean()
         .optional()
-        .describe("Allow non-loopback CDP connections"),
+        .describe("SECURITY: Allow non-loopback CDP connections. Enables remote code execution on target host. Only use if network path is secured."),
     },
     async ({ accountId, cdpPort, cdpHost, allowRemote }) => {
       const launcher = new LauncherService(cdpPort, { ...(cdpHost !== undefined && { host: cdpHost }), ...(allowRemote !== undefined && { allowRemote }) });


### PR DESCRIPTION
## Summary

- Updated `allowRemote` descriptions across all 26 MCP tools, 24 CLI commands, and the CDPClient error message to explicitly warn about remote code execution risk
- Added `console.warn` in `CDPClient` constructor when `allowRemote` is used with a non-loopback host
- Changed the CDPClient guard error from coaching bypass ("Use the allowRemote option...") to warning about security implications

## Test plan

- [x] Existing loopback validation tests updated to match new error message wording
- [x] New test: verifies `console.warn` is emitted with `[SECURITY WARNING]` for non-loopback host with `allowRemote: true`
- [x] New test: verifies no warning for loopback host with `allowRemote: true`
- [x] `pnpm build` passes
- [x] `pnpm test` passes (574 core tests, 247 MCP tests)
- [x] `pnpm lint` passes

Closes #280

🤖 Generated with [Claude Code](https://claude.com/claude-code)