### PR TITLE
(refactor) mcp: extract shared CDP schemas and account resolution helpers

### DIFF
--- a/packages/core/src/db/errors.ts
+++ b/packages/core/src/db/errors.ts
@@ -53,9 +53,12 @@ export class ProfileNotFoundError extends DatabaseError {
  * Thrown when a campaign lookup yields no results.
  */
 export class CampaignNotFoundError extends DatabaseError {
+  readonly campaignId: number;
+
   constructor(campaignId: number) {
     super(`Campaign not found for id ${String(campaignId)}`);
     this.name = "CampaignNotFoundError";
+    this.campaignId = campaignId;
   }
 }
 

--- a/packages/mcp/src/helpers.ts
+++ b/packages/mcp/src/helpers.ts
@@ -3,12 +3,57 @@
 
 import {
   AccountResolutionError,
+  CampaignNotFoundError,
+  DEFAULT_CDP_PORT,
   errorMessage,
   LinkedHelperNotRunningError,
 } from "@lhremote/core";
+import { z } from "zod";
 
 type TextContent = { type: "text"; text: string };
 type McpResult = { isError?: boolean; content: TextContent[] };
+
+/**
+ * Shared Zod schema fields for CDP connection parameters.
+ *
+ * Spread into every tool that connects to a LinkedHelper instance:
+ * ```ts
+ * { campaignId: z.number(), ...cdpConnectionSchema }
+ * ```
+ */
+export const cdpConnectionSchema = {
+  cdpPort: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .default(DEFAULT_CDP_PORT)
+    .describe("CDP port"),
+  cdpHost: z
+    .string()
+    .optional()
+    .describe("CDP host (default: 127.0.0.1)"),
+  allowRemote: z
+    .boolean()
+    .optional()
+    .describe("SECURITY: Allow non-loopback CDP connections. Enables remote code execution on target host. Only use if network path is secured."),
+};
+
+/**
+ * Build the CDP connection options object from parsed tool arguments.
+ *
+ * Replaces the inline conditional-spread pattern used by tools that
+ * call `resolveAccount` or construct a `LauncherService`.
+ */
+export function buildCdpOptions(args: {
+  cdpHost?: string | undefined;
+  allowRemote?: boolean | undefined;
+}): { host?: string; allowRemote?: boolean } {
+  return {
+    ...(args.cdpHost !== undefined && { host: args.cdpHost }),
+    ...(args.allowRemote !== undefined && { allowRemote: args.allowRemote }),
+  };
+}
 
 /**
  * Build an MCP error response from a plain message string.
@@ -31,10 +76,11 @@ export function mcpSuccess(text: string): McpResult {
 
 /**
  * Map common infrastructure errors (launcher not running, account
- * resolution failures) to an MCP error response.
+ * resolution failures) and domain errors (campaign not found) to an
+ * MCP error response.
  *
- * Returns `undefined` if the error is not a recognised infrastructure
- * error so the caller can fall through to domain-specific handling.
+ * Returns `undefined` if the error is not a recognised error so the
+ * caller can fall through to domain-specific handling.
  */
 export function mapErrorToMcpResponse(error: unknown): McpResult | undefined {
   if (error instanceof LinkedHelperNotRunningError) {
@@ -42,6 +88,11 @@ export function mapErrorToMcpResponse(error: unknown): McpResult | undefined {
   }
   if (error instanceof AccountResolutionError) {
     return mcpError(error.message);
+  }
+  if (error instanceof CampaignNotFoundError) {
+    return mcpError(
+      `Campaign ${String(error.campaignId)} not found.`,
+    );
   }
   return undefined;
 }

--- a/packages/mcp/src/tools/campaign-delete.ts
+++ b/packages/mcp/src/tools/campaign-delete.ts
@@ -4,14 +4,18 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   CampaignExecutionError,
-  CampaignNotFoundError,
   CampaignService,
-  DEFAULT_CDP_PORT,
   resolveAccount,
   withInstanceDatabase,
 } from "@lhremote/core";
 import { z } from "zod";
-import { mcpCatchAll, mcpError, mcpSuccess } from "../helpers.js";
+import {
+  buildCdpOptions,
+  cdpConnectionSchema,
+  mcpCatchAll,
+  mcpError,
+  mcpSuccess,
+} from "../helpers.js";
 
 /** Register the {@link https://github.com/alexey-pelykh/lhremote#campaign-delete | campaign-delete} MCP tool. */
 export function registerCampaignDelete(server: McpServer): void {
@@ -24,26 +28,12 @@ export function registerCampaignDelete(server: McpServer): void {
         .int()
         .positive()
         .describe("Campaign ID"),
-      cdpPort: z
-        .number()
-        .int()
-        .positive()
-        .optional()
-        .default(DEFAULT_CDP_PORT)
-        .describe("CDP port"),
-      cdpHost: z
-        .string()
-        .optional()
-        .describe("CDP host (default: 127.0.0.1)"),
-      allowRemote: z
-        .boolean()
-        .optional()
-        .describe("SECURITY: Allow non-loopback CDP connections. Enables remote code execution on target host. Only use if network path is secured."),
+      ...cdpConnectionSchema,
     },
     async ({ campaignId, cdpPort, cdpHost, allowRemote }) => {
       let accountId: number;
       try {
-        accountId = await resolveAccount(cdpPort, { ...(cdpHost !== undefined && { host: cdpHost }), ...(allowRemote !== undefined && { allowRemote }) });
+        accountId = await resolveAccount(cdpPort, buildCdpOptions({ cdpHost, allowRemote }));
       } catch (error) {
         return mcpCatchAll(error, "Failed to connect to LinkedHelper");
       }
@@ -62,9 +52,6 @@ export function registerCampaignDelete(server: McpServer): void {
           );
         });
       } catch (error) {
-        if (error instanceof CampaignNotFoundError) {
-          return mcpError(`Campaign ${String(campaignId)} not found.`);
-        }
         if (error instanceof CampaignExecutionError) {
           return mcpError(`Failed to delete campaign: ${error.message}`);
         }

--- a/packages/mcp/src/tools/campaign-exclude-list.ts
+++ b/packages/mcp/src/tools/campaign-exclude-list.ts
@@ -4,15 +4,19 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   ActionNotFoundError,
-  CampaignNotFoundError,
   CampaignRepository,
-  DEFAULT_CDP_PORT,
   ExcludeListNotFoundError,
   resolveAccount,
   withDatabase,
 } from "@lhremote/core";
 import { z } from "zod";
-import { mcpCatchAll, mcpError, mcpSuccess } from "../helpers.js";
+import {
+  buildCdpOptions,
+  cdpConnectionSchema,
+  mcpCatchAll,
+  mcpError,
+  mcpSuccess,
+} from "../helpers.js";
 
 /** Register the {@link https://github.com/alexey-pelykh/lhremote#campaign-exclude-list | campaign-exclude-list} MCP tool. */
 export function registerCampaignExcludeList(server: McpServer): void {
@@ -33,26 +37,12 @@ export function registerCampaignExcludeList(server: McpServer): void {
         .describe(
           "Action ID (optional). If provided, shows the action-level exclude list. Otherwise, shows the campaign-level exclude list.",
         ),
-      cdpPort: z
-        .number()
-        .int()
-        .positive()
-        .optional()
-        .default(DEFAULT_CDP_PORT)
-        .describe("CDP port"),
-      cdpHost: z
-        .string()
-        .optional()
-        .describe("CDP host (default: 127.0.0.1)"),
-      allowRemote: z
-        .boolean()
-        .optional()
-        .describe("SECURITY: Allow non-loopback CDP connections. Enables remote code execution on target host. Only use if network path is secured."),
+      ...cdpConnectionSchema,
     },
     async ({ campaignId, actionId, cdpPort, cdpHost, allowRemote }) => {
       let accountId: number;
       try {
-        accountId = await resolveAccount(cdpPort, { ...(cdpHost !== undefined && { host: cdpHost }), ...(allowRemote !== undefined && { allowRemote }) });
+        accountId = await resolveAccount(cdpPort, buildCdpOptions({ cdpHost, allowRemote }));
       } catch (error) {
         return mcpCatchAll(error, "Failed to connect to LinkedHelper");
       }
@@ -84,9 +74,6 @@ export function registerCampaignExcludeList(server: McpServer): void {
           );
         });
       } catch (error) {
-        if (error instanceof CampaignNotFoundError) {
-          return mcpError(`Campaign ${String(campaignId)} not found.`);
-        }
         if (error instanceof ActionNotFoundError) {
           return mcpError(`Action ${String(actionId)} not found in campaign ${String(campaignId)}.`);
         }

--- a/packages/mcp/src/tools/campaign-exclude-remove.ts
+++ b/packages/mcp/src/tools/campaign-exclude-remove.ts
@@ -4,15 +4,19 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   ActionNotFoundError,
-  CampaignNotFoundError,
   CampaignRepository,
-  DEFAULT_CDP_PORT,
   ExcludeListNotFoundError,
   resolveAccount,
   withDatabase,
 } from "@lhremote/core";
 import { z } from "zod";
-import { mcpCatchAll, mcpError, mcpSuccess } from "../helpers.js";
+import {
+  buildCdpOptions,
+  cdpConnectionSchema,
+  mcpCatchAll,
+  mcpError,
+  mcpSuccess,
+} from "../helpers.js";
 
 /** Register the {@link https://github.com/alexey-pelykh/lhremote#campaign-exclude-remove | campaign-exclude-remove} MCP tool. */
 export function registerCampaignExcludeRemove(server: McpServer): void {
@@ -37,26 +41,12 @@ export function registerCampaignExcludeRemove(server: McpServer): void {
         .describe(
           "Action ID (optional). If provided, removes from the action-level exclude list. Otherwise, removes from the campaign-level exclude list.",
         ),
-      cdpPort: z
-        .number()
-        .int()
-        .positive()
-        .optional()
-        .default(DEFAULT_CDP_PORT)
-        .describe("CDP port"),
-      cdpHost: z
-        .string()
-        .optional()
-        .describe("CDP host (default: 127.0.0.1)"),
-      allowRemote: z
-        .boolean()
-        .optional()
-        .describe("SECURITY: Allow non-loopback CDP connections. Enables remote code execution on target host. Only use if network path is secured."),
+      ...cdpConnectionSchema,
     },
     async ({ campaignId, personIds, actionId, cdpPort, cdpHost, allowRemote }) => {
       let accountId: number;
       try {
-        accountId = await resolveAccount(cdpPort, { ...(cdpHost !== undefined && { host: cdpHost }), ...(allowRemote !== undefined && { allowRemote }) });
+        accountId = await resolveAccount(cdpPort, buildCdpOptions({ cdpHost, allowRemote }));
       } catch (error) {
         return mcpCatchAll(error, "Failed to connect to LinkedHelper");
       }
@@ -93,9 +83,6 @@ export function registerCampaignExcludeRemove(server: McpServer): void {
           );
         }, { readOnly: false });
       } catch (error) {
-        if (error instanceof CampaignNotFoundError) {
-          return mcpError(`Campaign ${String(campaignId)} not found.`);
-        }
         if (error instanceof ActionNotFoundError) {
           return mcpError(`Action ${String(actionId)} not found in campaign ${String(campaignId)}.`);
         }

--- a/packages/mcp/src/tools/campaign-move-next.ts
+++ b/packages/mcp/src/tools/campaign-move-next.ts
@@ -4,15 +4,13 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   ActionNotFoundError,
-  CampaignNotFoundError,
   CampaignRepository,
-  DEFAULT_CDP_PORT,
   NoNextActionError,
   resolveAccount,
   withDatabase,
 } from "@lhremote/core";
 import { z } from "zod";
-import { mcpCatchAll, mcpError, mcpSuccess } from "../helpers.js";
+import { buildCdpOptions, cdpConnectionSchema, mcpCatchAll, mcpError, mcpSuccess } from "../helpers.js";
 
 /** Register the {@link https://github.com/alexey-pelykh/lhremote#campaign-move-next | campaign-move-next} MCP tool. */
 export function registerCampaignMoveNext(server: McpServer): void {
@@ -34,26 +32,12 @@ export function registerCampaignMoveNext(server: McpServer): void {
         .array(z.number().int().positive())
         .nonempty()
         .describe("Person IDs to advance to the next action"),
-      cdpPort: z
-        .number()
-        .int()
-        .positive()
-        .optional()
-        .default(DEFAULT_CDP_PORT)
-        .describe("CDP port"),
-      cdpHost: z
-        .string()
-        .optional()
-        .describe("CDP host (default: 127.0.0.1)"),
-      allowRemote: z
-        .boolean()
-        .optional()
-        .describe("SECURITY: Allow non-loopback CDP connections. Enables remote code execution on target host. Only use if network path is secured."),
+      ...cdpConnectionSchema,
     },
     async ({ campaignId, actionId, personIds, cdpPort, cdpHost, allowRemote }) => {
       let accountId: number;
       try {
-        accountId = await resolveAccount(cdpPort, { ...(cdpHost !== undefined && { host: cdpHost }), ...(allowRemote !== undefined && { allowRemote }) });
+        accountId = await resolveAccount(cdpPort, buildCdpOptions({ cdpHost, allowRemote }));
       } catch (error) {
         return mcpCatchAll(error, "Failed to connect to LinkedHelper");
       }
@@ -82,9 +66,6 @@ export function registerCampaignMoveNext(server: McpServer): void {
           );
         }, { readOnly: false });
       } catch (error) {
-        if (error instanceof CampaignNotFoundError) {
-          return mcpError(`Campaign ${String(campaignId)} not found.`);
-        }
         if (error instanceof ActionNotFoundError) {
           return mcpError(`Action ${String(actionId)} not found in campaign ${String(campaignId)}.`);
         }

--- a/packages/mcp/src/tools/campaign-remove-action.ts
+++ b/packages/mcp/src/tools/campaign-remove-action.ts
@@ -5,14 +5,18 @@ import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   ActionNotFoundError,
   CampaignExecutionError,
-  CampaignNotFoundError,
   CampaignService,
-  DEFAULT_CDP_PORT,
   resolveAccount,
   withInstanceDatabase,
 } from "@lhremote/core";
 import { z } from "zod";
-import { mcpCatchAll, mcpError, mcpSuccess } from "../helpers.js";
+import {
+  buildCdpOptions,
+  cdpConnectionSchema,
+  mcpCatchAll,
+  mcpError,
+  mcpSuccess,
+} from "../helpers.js";
 
 /** Register the {@link https://github.com/alexey-pelykh/lhremote#campaign-remove-action | campaign-remove-action} MCP tool. */
 export function registerCampaignRemoveAction(server: McpServer): void {
@@ -30,26 +34,12 @@ export function registerCampaignRemoveAction(server: McpServer): void {
         .int()
         .positive()
         .describe("Action ID to remove"),
-      cdpPort: z
-        .number()
-        .int()
-        .positive()
-        .optional()
-        .default(DEFAULT_CDP_PORT)
-        .describe("CDP port"),
-      cdpHost: z
-        .string()
-        .optional()
-        .describe("CDP host (default: 127.0.0.1)"),
-      allowRemote: z
-        .boolean()
-        .optional()
-        .describe("SECURITY: Allow non-loopback CDP connections. Enables remote code execution on target host. Only use if network path is secured."),
+      ...cdpConnectionSchema,
     },
     async ({ campaignId, actionId, cdpPort, cdpHost, allowRemote }) => {
       let accountId: number;
       try {
-        accountId = await resolveAccount(cdpPort, { ...(cdpHost !== undefined && { host: cdpHost }), ...(allowRemote !== undefined && { allowRemote }) });
+        accountId = await resolveAccount(cdpPort, buildCdpOptions({ cdpHost, allowRemote }));
       } catch (error) {
         return mcpCatchAll(error, "Failed to connect to LinkedHelper");
       }
@@ -72,9 +62,6 @@ export function registerCampaignRemoveAction(server: McpServer): void {
           );
         });
       } catch (error) {
-        if (error instanceof CampaignNotFoundError) {
-          return mcpError(`Campaign ${String(campaignId)} not found.`);
-        }
         if (error instanceof ActionNotFoundError) {
           return mcpError(`Action ${String(actionId)} not found in campaign ${String(campaignId)}.`);
         }

--- a/packages/mcp/src/tools/campaign-start.ts
+++ b/packages/mcp/src/tools/campaign-start.ts
@@ -4,15 +4,19 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   CampaignExecutionError,
-  CampaignNotFoundError,
   CampaignService,
   CampaignTimeoutError,
-  DEFAULT_CDP_PORT,
   resolveAccount,
   withInstanceDatabase,
 } from "@lhremote/core";
 import { z } from "zod";
-import { mcpCatchAll, mcpError, mcpSuccess } from "../helpers.js";
+import {
+  buildCdpOptions,
+  cdpConnectionSchema,
+  mcpCatchAll,
+  mcpError,
+  mcpSuccess,
+} from "../helpers.js";
 
 /** Register the {@link https://github.com/alexey-pelykh/lhremote#campaign-start | campaign-start} MCP tool. */
 export function registerCampaignStart(server: McpServer): void {
@@ -29,26 +33,12 @@ export function registerCampaignStart(server: McpServer): void {
         .array(z.number().int().positive())
         .nonempty()
         .describe("Person IDs to target"),
-      cdpPort: z
-        .number()
-        .int()
-        .positive()
-        .optional()
-        .default(DEFAULT_CDP_PORT)
-        .describe("CDP port"),
-      cdpHost: z
-        .string()
-        .optional()
-        .describe("CDP host (default: 127.0.0.1)"),
-      allowRemote: z
-        .boolean()
-        .optional()
-        .describe("SECURITY: Allow non-loopback CDP connections. Enables remote code execution on target host. Only use if network path is secured."),
+      ...cdpConnectionSchema,
     },
     async ({ campaignId, personIds, cdpPort, cdpHost, allowRemote }) => {
       let accountId: number;
       try {
-        accountId = await resolveAccount(cdpPort, { ...(cdpHost !== undefined && { host: cdpHost }), ...(allowRemote !== undefined && { allowRemote }) });
+        accountId = await resolveAccount(cdpPort, buildCdpOptions({ cdpHost, allowRemote }));
       } catch (error) {
         return mcpCatchAll(error, "Failed to connect to LinkedHelper");
       }
@@ -73,9 +63,6 @@ export function registerCampaignStart(server: McpServer): void {
           );
         });
       } catch (error) {
-        if (error instanceof CampaignNotFoundError) {
-          return mcpError(`Campaign ${String(campaignId)} not found.`);
-        }
         if (error instanceof CampaignTimeoutError) {
           return mcpError(`Campaign start timed out: ${error.message}`);
         }

--- a/packages/mcp/src/tools/campaign-stop.ts
+++ b/packages/mcp/src/tools/campaign-stop.ts
@@ -4,14 +4,18 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   CampaignExecutionError,
-  CampaignNotFoundError,
   CampaignService,
-  DEFAULT_CDP_PORT,
   resolveAccount,
   withInstanceDatabase,
 } from "@lhremote/core";
 import { z } from "zod";
-import { mcpCatchAll, mcpError, mcpSuccess } from "../helpers.js";
+import {
+  buildCdpOptions,
+  cdpConnectionSchema,
+  mcpCatchAll,
+  mcpError,
+  mcpSuccess,
+} from "../helpers.js";
 
 /** Register the {@link https://github.com/alexey-pelykh/lhremote#campaign-stop | campaign-stop} MCP tool. */
 export function registerCampaignStop(server: McpServer): void {
@@ -24,26 +28,12 @@ export function registerCampaignStop(server: McpServer): void {
         .int()
         .positive()
         .describe("Campaign ID"),
-      cdpPort: z
-        .number()
-        .int()
-        .positive()
-        .optional()
-        .default(DEFAULT_CDP_PORT)
-        .describe("CDP port"),
-      cdpHost: z
-        .string()
-        .optional()
-        .describe("CDP host (default: 127.0.0.1)"),
-      allowRemote: z
-        .boolean()
-        .optional()
-        .describe("SECURITY: Allow non-loopback CDP connections. Enables remote code execution on target host. Only use if network path is secured."),
+      ...cdpConnectionSchema,
     },
     async ({ campaignId, cdpPort, cdpHost, allowRemote }) => {
       let accountId: number;
       try {
-        accountId = await resolveAccount(cdpPort, { ...(cdpHost !== undefined && { host: cdpHost }), ...(allowRemote !== undefined && { allowRemote }) });
+        accountId = await resolveAccount(cdpPort, buildCdpOptions({ cdpHost, allowRemote }));
       } catch (error) {
         return mcpCatchAll(error, "Failed to connect to LinkedHelper");
       }
@@ -66,9 +56,6 @@ export function registerCampaignStop(server: McpServer): void {
           );
         });
       } catch (error) {
-        if (error instanceof CampaignNotFoundError) {
-          return mcpError(`Campaign ${String(campaignId)} not found.`);
-        }
         if (error instanceof CampaignExecutionError) {
           return mcpError(`Failed to stop campaign: ${error.message}`);
         }

--- a/packages/mcp/src/tools/import-people-from-urls.ts
+++ b/packages/mcp/src/tools/import-people-from-urls.ts
@@ -4,14 +4,12 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   CampaignExecutionError,
-  CampaignNotFoundError,
   CampaignService,
-  DEFAULT_CDP_PORT,
   resolveAccount,
   withInstanceDatabase,
 } from "@lhremote/core";
 import { z } from "zod";
-import { mcpCatchAll, mcpError, mcpSuccess } from "../helpers.js";
+import { buildCdpOptions, cdpConnectionSchema, mcpCatchAll, mcpError, mcpSuccess } from "../helpers.js";
 
 /** Register the {@link https://github.com/alexey-pelykh/lhremote#import-people-from-urls | import-people-from-urls} MCP tool. */
 export function registerImportPeopleFromUrls(server: McpServer): void {
@@ -28,26 +26,12 @@ export function registerImportPeopleFromUrls(server: McpServer): void {
         .array(z.string().url())
         .nonempty()
         .describe("LinkedIn profile URLs to import"),
-      cdpPort: z
-        .number()
-        .int()
-        .positive()
-        .optional()
-        .default(DEFAULT_CDP_PORT)
-        .describe("CDP port"),
-      cdpHost: z
-        .string()
-        .optional()
-        .describe("CDP host (default: 127.0.0.1)"),
-      allowRemote: z
-        .boolean()
-        .optional()
-        .describe("SECURITY: Allow non-loopback CDP connections. Enables remote code execution on target host. Only use if network path is secured."),
+      ...cdpConnectionSchema,
     },
     async ({ campaignId, linkedInUrls, cdpPort, cdpHost, allowRemote }) => {
       let accountId: number;
       try {
-        accountId = await resolveAccount(cdpPort, { ...(cdpHost !== undefined && { host: cdpHost }), ...(allowRemote !== undefined && { allowRemote }) });
+        accountId = await resolveAccount(cdpPort, buildCdpOptions({ cdpHost, allowRemote }));
       } catch (error) {
         return mcpCatchAll(error, "Failed to connect to LinkedHelper");
       }
@@ -77,9 +61,6 @@ export function registerImportPeopleFromUrls(server: McpServer): void {
           );
         });
       } catch (error) {
-        if (error instanceof CampaignNotFoundError) {
-          return mcpError(`Campaign ${String(campaignId)} not found.`);
-        }
         if (error instanceof CampaignExecutionError) {
           return mcpError(`Failed to import people: ${error.message}`);
         }

--- a/packages/mcp/src/tools/list-accounts.ts
+++ b/packages/mcp/src/tools/list-accounts.ts
@@ -2,12 +2,8 @@
 // Copyright (C) 2025 Alexey Pelykh
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import {
-  DEFAULT_CDP_PORT,
-  LauncherService,
-} from "@lhremote/core";
-import { z } from "zod";
-import { mcpCatchAll, mcpSuccess } from "../helpers.js";
+import { LauncherService } from "@lhremote/core";
+import { buildCdpOptions, cdpConnectionSchema, mcpCatchAll, mcpSuccess } from "../helpers.js";
 
 /** Register the {@link https://github.com/alexey-pelykh/lhremote#list-accounts | list-accounts} MCP tool. */
 export function registerListAccounts(server: McpServer): void {
@@ -15,24 +11,10 @@ export function registerListAccounts(server: McpServer): void {
     "list-accounts",
     "List available LinkedHelper accounts",
     {
-      cdpPort: z
-        .number()
-        .int()
-        .positive()
-        .optional()
-        .default(DEFAULT_CDP_PORT)
-        .describe("CDP port"),
-      cdpHost: z
-        .string()
-        .optional()
-        .describe("CDP host (default: 127.0.0.1)"),
-      allowRemote: z
-        .boolean()
-        .optional()
-        .describe("SECURITY: Allow non-loopback CDP connections. Enables remote code execution on target host. Only use if network path is secured."),
+      ...cdpConnectionSchema,
     },
     async ({ cdpPort, cdpHost, allowRemote }) => {
-      const launcher = new LauncherService(cdpPort, { ...(cdpHost !== undefined && { host: cdpHost }), ...(allowRemote !== undefined && { allowRemote }) });
+      const launcher = new LauncherService(cdpPort, buildCdpOptions({ cdpHost, allowRemote }));
 
       try {
         await launcher.connect();

--- a/packages/mcp/src/tools/start-instance.ts
+++ b/packages/mcp/src/tools/start-instance.ts
@@ -4,12 +4,11 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   type Account,
-  DEFAULT_CDP_PORT,
   LauncherService,
   startInstanceWithRecovery,
 } from "@lhremote/core";
 import { z } from "zod";
-import { mcpCatchAll, mcpError, mcpSuccess } from "../helpers.js";
+import { buildCdpOptions, cdpConnectionSchema, mcpCatchAll, mcpError, mcpSuccess } from "../helpers.js";
 
 /** Register the {@link https://github.com/alexey-pelykh/lhremote#start-instance | start-instance} MCP tool. */
 export function registerStartInstance(server: McpServer): void {
@@ -25,24 +24,10 @@ export function registerStartInstance(server: McpServer): void {
         .describe(
           "Account ID (omit to auto-select if single account)",
         ),
-      cdpPort: z
-        .number()
-        .int()
-        .positive()
-        .optional()
-        .default(DEFAULT_CDP_PORT)
-        .describe("CDP port"),
-      cdpHost: z
-        .string()
-        .optional()
-        .describe("CDP host (default: 127.0.0.1)"),
-      allowRemote: z
-        .boolean()
-        .optional()
-        .describe("SECURITY: Allow non-loopback CDP connections. Enables remote code execution on target host. Only use if network path is secured."),
+      ...cdpConnectionSchema,
     },
     async ({ accountId, cdpPort, cdpHost, allowRemote }) => {
-      const launcher = new LauncherService(cdpPort, { ...(cdpHost !== undefined && { host: cdpHost }), ...(allowRemote !== undefined && { allowRemote }) });
+      const launcher = new LauncherService(cdpPort, buildCdpOptions({ cdpHost, allowRemote }));
 
       try {
         await launcher.connect();

--- a/packages/mcp/src/tools/stop-instance.ts
+++ b/packages/mcp/src/tools/stop-instance.ts
@@ -4,11 +4,10 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   type Account,
-  DEFAULT_CDP_PORT,
   LauncherService,
 } from "@lhremote/core";
 import { z } from "zod";
-import { mcpCatchAll, mcpError, mcpSuccess } from "../helpers.js";
+import { buildCdpOptions, cdpConnectionSchema, mcpCatchAll, mcpError, mcpSuccess } from "../helpers.js";
 
 /** Register the {@link https://github.com/alexey-pelykh/lhremote#stop-instance | stop-instance} MCP tool. */
 export function registerStopInstance(server: McpServer): void {
@@ -24,24 +23,10 @@ export function registerStopInstance(server: McpServer): void {
         .describe(
           "Account ID (omit to stop the only running instance)",
         ),
-      cdpPort: z
-        .number()
-        .int()
-        .positive()
-        .optional()
-        .default(DEFAULT_CDP_PORT)
-        .describe("CDP port"),
-      cdpHost: z
-        .string()
-        .optional()
-        .describe("CDP host (default: 127.0.0.1)"),
-      allowRemote: z
-        .boolean()
-        .optional()
-        .describe("SECURITY: Allow non-loopback CDP connections. Enables remote code execution on target host. Only use if network path is secured."),
+      ...cdpConnectionSchema,
     },
     async ({ accountId, cdpPort, cdpHost, allowRemote }) => {
-      const launcher = new LauncherService(cdpPort, { ...(cdpHost !== undefined && { host: cdpHost }), ...(allowRemote !== undefined && { allowRemote }) });
+      const launcher = new LauncherService(cdpPort, buildCdpOptions({ cdpHost, allowRemote }));
 
       try {
         await launcher.connect();


### PR DESCRIPTION
## Summary

- Extract `cdpConnectionSchema` (shared Zod fields) into `helpers.ts`, replacing inline CDP schema definitions across 26 tools (~390 lines removed)
- Extract `buildCdpOptions()` helper, replacing inline conditional-spread boilerplate across 21 tools (~130 lines removed)
- Centralize `CampaignNotFoundError` handling in `mapErrorToMcpResponse()`, eliminating duplicated catch clauses across 17 tools (~51 lines removed)
- Add `readonly campaignId` field to `CampaignNotFoundError` for centralized message formatting

Net result: **-316 lines** (228 added, 544 removed) with zero behavioral change.

Closes #263

## Test plan

- [x] `pnpm turbo build --force` — all 5 packages compile with zero errors
- [x] `pnpm test` — 1,111 tests pass (247 MCP + 292 CLI + 572 core)
- [x] `pnpm turbo lint` — clean
- [x] Verified no inline CDP schema patterns remain in tool files
- [x] Verified no inline `CampaignNotFoundError` catches remain in tool files
- [x] Verified all 26 tools use `cdpConnectionSchema` spread
- [x] Verified error message format preserved (`"Campaign N not found."`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)