### PR TITLE
(chore) licensing: fix copyright headers in operations layer

### DIFF
--- a/packages/core/src/operations/campaign-add-action.test.ts
+++ b/packages/core/src/operations/campaign-add-action.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alexey Pelykh
+// Copyright (C) 2026 Oleksii PELYKH
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/core/src/operations/campaign-add-action.ts
+++ b/packages/core/src/operations/campaign-add-action.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alexey Pelykh
+// Copyright (C) 2026 Oleksii PELYKH
 
 import type { CampaignAction, CampaignActionConfig } from "../types/index.js";
 import { resolveAccount } from "../services/account-resolution.js";

--- a/packages/core/src/operations/campaign-create.test.ts
+++ b/packages/core/src/operations/campaign-create.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alexey Pelykh
+// Copyright (C) 2026 Oleksii PELYKH
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/core/src/operations/campaign-create.ts
+++ b/packages/core/src/operations/campaign-create.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alexey Pelykh
+// Copyright (C) 2026 Oleksii PELYKH
 
 import type { Campaign, CampaignConfig } from "../types/index.js";
 import { resolveAccount } from "../services/account-resolution.js";

--- a/packages/core/src/operations/campaign-delete.test.ts
+++ b/packages/core/src/operations/campaign-delete.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alexey Pelykh
+// Copyright (C) 2026 Oleksii PELYKH
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/core/src/operations/campaign-delete.ts
+++ b/packages/core/src/operations/campaign-delete.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alexey Pelykh
+// Copyright (C) 2026 Oleksii PELYKH
 
 import { resolveAccount } from "../services/account-resolution.js";
 import { withInstanceDatabase } from "../services/instance-context.js";

--- a/packages/core/src/operations/campaign-exclude-add.test.ts
+++ b/packages/core/src/operations/campaign-exclude-add.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alexey Pelykh
+// Copyright (C) 2026 Oleksii PELYKH
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/core/src/operations/campaign-exclude-add.ts
+++ b/packages/core/src/operations/campaign-exclude-add.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alexey Pelykh
+// Copyright (C) 2026 Oleksii PELYKH
 
 import { resolveAccount } from "../services/account-resolution.js";
 import { withDatabase } from "../services/instance-context.js";

--- a/packages/core/src/operations/campaign-exclude-list.test.ts
+++ b/packages/core/src/operations/campaign-exclude-list.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alexey Pelykh
+// Copyright (C) 2026 Oleksii PELYKH
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/core/src/operations/campaign-exclude-list.ts
+++ b/packages/core/src/operations/campaign-exclude-list.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alexey Pelykh
+// Copyright (C) 2026 Oleksii PELYKH
 
 import { resolveAccount } from "../services/account-resolution.js";
 import { withDatabase } from "../services/instance-context.js";

--- a/packages/core/src/operations/campaign-exclude-remove.test.ts
+++ b/packages/core/src/operations/campaign-exclude-remove.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alexey Pelykh
+// Copyright (C) 2026 Oleksii PELYKH
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/core/src/operations/campaign-exclude-remove.ts
+++ b/packages/core/src/operations/campaign-exclude-remove.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alexey Pelykh
+// Copyright (C) 2026 Oleksii PELYKH
 
 import { resolveAccount } from "../services/account-resolution.js";
 import { withDatabase } from "../services/instance-context.js";

--- a/packages/core/src/operations/campaign-export.test.ts
+++ b/packages/core/src/operations/campaign-export.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alexey Pelykh
+// Copyright (C) 2026 Oleksii PELYKH
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/core/src/operations/campaign-export.ts
+++ b/packages/core/src/operations/campaign-export.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alexey Pelykh
+// Copyright (C) 2026 Oleksii PELYKH
 
 import { resolveAccount } from "../services/account-resolution.js";
 import { withDatabase } from "../services/instance-context.js";

--- a/packages/core/src/operations/campaign-get.test.ts
+++ b/packages/core/src/operations/campaign-get.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alexey Pelykh
+// Copyright (C) 2026 Oleksii PELYKH
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/core/src/operations/campaign-get.ts
+++ b/packages/core/src/operations/campaign-get.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alexey Pelykh
+// Copyright (C) 2026 Oleksii PELYKH
 
 import type { Campaign, CampaignAction } from "../types/index.js";
 import { resolveAccount } from "../services/account-resolution.js";

--- a/packages/core/src/operations/campaign-list.test.ts
+++ b/packages/core/src/operations/campaign-list.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alexey Pelykh
+// Copyright (C) 2026 Oleksii PELYKH
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/core/src/operations/campaign-list.ts
+++ b/packages/core/src/operations/campaign-list.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alexey Pelykh
+// Copyright (C) 2026 Oleksii PELYKH
 
 import type { CampaignSummary } from "../types/index.js";
 import { resolveAccount } from "../services/account-resolution.js";

--- a/packages/core/src/operations/campaign-move-next.test.ts
+++ b/packages/core/src/operations/campaign-move-next.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alexey Pelykh
+// Copyright (C) 2026 Oleksii PELYKH
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/core/src/operations/campaign-move-next.ts
+++ b/packages/core/src/operations/campaign-move-next.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alexey Pelykh
+// Copyright (C) 2026 Oleksii PELYKH
 
 import { resolveAccount } from "../services/account-resolution.js";
 import { withDatabase } from "../services/instance-context.js";

--- a/packages/core/src/operations/campaign-remove-action.test.ts
+++ b/packages/core/src/operations/campaign-remove-action.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alexey Pelykh
+// Copyright (C) 2026 Oleksii PELYKH
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/core/src/operations/campaign-remove-action.ts
+++ b/packages/core/src/operations/campaign-remove-action.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alexey Pelykh
+// Copyright (C) 2026 Oleksii PELYKH
 
 import { resolveAccount } from "../services/account-resolution.js";
 import { withInstanceDatabase } from "../services/instance-context.js";

--- a/packages/core/src/operations/campaign-reorder-actions.test.ts
+++ b/packages/core/src/operations/campaign-reorder-actions.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alexey Pelykh
+// Copyright (C) 2026 Oleksii PELYKH
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/core/src/operations/campaign-reorder-actions.ts
+++ b/packages/core/src/operations/campaign-reorder-actions.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alexey Pelykh
+// Copyright (C) 2026 Oleksii PELYKH
 
 import type { CampaignAction } from "../types/index.js";
 import { resolveAccount } from "../services/account-resolution.js";

--- a/packages/core/src/operations/campaign-retry.test.ts
+++ b/packages/core/src/operations/campaign-retry.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alexey Pelykh
+// Copyright (C) 2026 Oleksii PELYKH
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/core/src/operations/campaign-retry.ts
+++ b/packages/core/src/operations/campaign-retry.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alexey Pelykh
+// Copyright (C) 2026 Oleksii PELYKH
 
 import { resolveAccount } from "../services/account-resolution.js";
 import { withDatabase } from "../services/instance-context.js";

--- a/packages/core/src/operations/campaign-start.test.ts
+++ b/packages/core/src/operations/campaign-start.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alexey Pelykh
+// Copyright (C) 2026 Oleksii PELYKH
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/core/src/operations/campaign-start.ts
+++ b/packages/core/src/operations/campaign-start.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alexey Pelykh
+// Copyright (C) 2026 Oleksii PELYKH
 
 import { resolveAccount } from "../services/account-resolution.js";
 import { withInstanceDatabase } from "../services/instance-context.js";

--- a/packages/core/src/operations/campaign-statistics.test.ts
+++ b/packages/core/src/operations/campaign-statistics.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alexey Pelykh
+// Copyright (C) 2026 Oleksii PELYKH
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/core/src/operations/campaign-statistics.ts
+++ b/packages/core/src/operations/campaign-statistics.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alexey Pelykh
+// Copyright (C) 2026 Oleksii PELYKH
 
 import type { CampaignStatistics, GetStatisticsOptions } from "../types/index.js";
 import { resolveAccount } from "../services/account-resolution.js";

--- a/packages/core/src/operations/campaign-stop.test.ts
+++ b/packages/core/src/operations/campaign-stop.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alexey Pelykh
+// Copyright (C) 2026 Oleksii PELYKH
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/core/src/operations/campaign-stop.ts
+++ b/packages/core/src/operations/campaign-stop.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alexey Pelykh
+// Copyright (C) 2026 Oleksii PELYKH
 
 import { resolveAccount } from "../services/account-resolution.js";
 import { withInstanceDatabase } from "../services/instance-context.js";

--- a/packages/core/src/operations/campaign-update.test.ts
+++ b/packages/core/src/operations/campaign-update.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alexey Pelykh
+// Copyright (C) 2026 Oleksii PELYKH
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/core/src/operations/campaign-update.ts
+++ b/packages/core/src/operations/campaign-update.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alexey Pelykh
+// Copyright (C) 2026 Oleksii PELYKH
 
 import type { Campaign, CampaignUpdateConfig } from "../types/index.js";
 import { resolveAccount } from "../services/account-resolution.js";

--- a/packages/core/src/operations/check-replies.test.ts
+++ b/packages/core/src/operations/check-replies.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alexey Pelykh
+// Copyright (C) 2026 Oleksii PELYKH
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/core/src/operations/check-replies.ts
+++ b/packages/core/src/operations/check-replies.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alexey Pelykh
+// Copyright (C) 2026 Oleksii PELYKH
 
 import type { ConversationMessages } from "../types/index.js";
 import { resolveAccount } from "../services/account-resolution.js";

--- a/packages/core/src/operations/import-people-from-urls.test.ts
+++ b/packages/core/src/operations/import-people-from-urls.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alexey Pelykh
+// Copyright (C) 2026 Oleksii PELYKH
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/core/src/operations/import-people-from-urls.ts
+++ b/packages/core/src/operations/import-people-from-urls.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alexey Pelykh
+// Copyright (C) 2026 Oleksii PELYKH
 
 import { resolveAccount } from "../services/account-resolution.js";
 import { withInstanceDatabase } from "../services/instance-context.js";

--- a/packages/core/src/operations/query-messages.test.ts
+++ b/packages/core/src/operations/query-messages.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alexey Pelykh
+// Copyright (C) 2026 Oleksii PELYKH
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/core/src/operations/query-messages.ts
+++ b/packages/core/src/operations/query-messages.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alexey Pelykh
+// Copyright (C) 2026 Oleksii PELYKH
 
 import type { Chat, ConversationThread, Message } from "../types/index.js";
 import { resolveAccount } from "../services/account-resolution.js";

--- a/packages/core/src/operations/scrape-messaging-history.test.ts
+++ b/packages/core/src/operations/scrape-messaging-history.test.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alexey Pelykh
+// Copyright (C) 2026 Oleksii PELYKH
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/packages/core/src/operations/scrape-messaging-history.ts
+++ b/packages/core/src/operations/scrape-messaging-history.ts
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: AGPL-3.0-only
-// Copyright (C) 2025 Alexey Pelykh
+// Copyright (C) 2026 Oleksii PELYKH
 
 import type { MessageStats } from "../types/index.js";
 import { resolveAccount } from "../services/account-resolution.js";


### PR DESCRIPTION
## Summary
- Fix 42 files in `packages/core/src/operations/` with incorrect copyright headers
- Year: 2025 → 2026, name: Alexey Pelykh → Oleksii PELYKH
- These were introduced in 0aba227 and broke lint on main

## Test plan
- [x] `pnpm lint` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)