### PR TITLE
Prepare v0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.2.0] — 2026-02-16
+
 ### Added
 
 - `campaign-create` tool for creating campaigns from YAML/JSON definitions with action chains
@@ -31,25 +33,32 @@ All notable changes to this project will be documented in this file.
 - Action execution service for running LinkedHelper actions programmatically
 - Action types catalog with advanced configuration schemas for all LinkedHelper action types
 - `MessageRepository` for conversation and message database access
+- `CampaignFormatError` integrated into domain error hierarchy
 - URL validation for `navigateToProfile` to reject malformed LinkedIn URLs
 - URL scheme validation in `CDPClient.navigate()` to reject non-HTTP(S) schemes
+- Security warnings for `allowRemote` CDP parameter
 - Claude Code plugin with `lhremote-mcp` skill for IDE integration
 - SPDX license headers on all source files
 - ESLint rule to enforce SPDX license headers on new files
 - Dependency license compatibility check in CI
+- CODEOWNERS for security-sensitive files
 - Issue templates for bug reports and feature requests
 - Dependabot configuration for automated dependency updates
 - CONTRIBUTING guide with development setup instructions
 - Getting started guide
 - Architecture Decision Records (ADRs)
-- Security documentation for localhost trust model and loopback validation
+- Security documentation for localhost trust model, loopback validation, and MCP trust model
 - npm provenance attestation for release publishing
 - GitHub Pages documentation site built via pandoc on every CI run
-- Test coverage reporting with Codecov integration
+- Test coverage reporting with Codecov integration and coverage thresholds
 
 ### Changed
 
 - Replaced `better-sqlite3` with Node.js built-in `node:sqlite` module
+- Extracted operations layer for 21 MCP/CLI tools, reducing duplication between CLI and MCP
+- Decomposed `CampaignRepository` into focused repositories
+- Enriched error reporting in `checkStatus` and CDP reconnection
+- Exported `WrongPortError` from public API
 - Pinned GitHub Actions to commit SHAs for supply-chain security
 - Added `timeout-minutes` to all CI workflow jobs
 - Moved E2E tests out of core to dedicated package
@@ -57,9 +66,12 @@ All notable changes to this project will be documented in this file.
 - Converted root devDependencies to pnpm workspace catalog refs
 - Added `fail-fast: false` to CI matrix strategy
 - Pinned npm version in release workflow
+- Added license-check to release validation job
 
 ### Fixed
 
+- Bare `parseInt` usage on `--max-results` CLI option (now uses explicit radix)
+- Removed unused options from `launch-app`/`quit-app` CLI commands
 - Windows compatibility for pnpm execution in CI scripts
 - Explicit timer advancement for polling tests
 - LIKE wildcard escaping for search queries

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -3,44 +3,22 @@
 This is a living document. Timelines are approximate and priorities may shift as the
 project evolves. For the latest changes, see [CHANGELOG.md](CHANGELOG.md).
 
-## Next Release: v0.2.0
+## Latest Release: v0.2.0
 
 A major capability expansion over v0.1.0, adding full campaign lifecycle management,
-messaging tools, and significant infrastructure hardening.
-
-**Campaign management** — create, configure, execute, monitor, export, and retry
-campaigns via `campaign-*` tools. Includes action chain management, exclude lists, bulk
-people import, and execution statistics.
-
-**Messaging** — query conversation history (`query-messages`), scrape full threads
-(`scrape-messaging-history`), and detect new replies (`check-replies`).
-
-**Profile querying** — look up profiles by URL (`query-profile`) and search across
-stored profiles (`query-profiles`).
-
-**Action catalog** — `describe-actions` tool exposing all LinkedHelper action types
-with configuration schemas.
-
-**Infrastructure** — SPDX license headers with ESLint enforcement, Dependabot,
-dependency license checks, npm provenance attestation, Codecov integration, GitHub Pages
-docs site, and pinned GitHub Actions SHAs with job timeouts.
-
-**Platform** — replaced `better-sqlite3` with Node.js built-in `node:sqlite`.
+messaging tools, and significant infrastructure hardening. See
+[CHANGELOG.md](CHANGELOG.md) for full details.
 
 ## Near-Term Priorities
 
 Areas of focus after v0.2.0, in approximate priority order:
 
-- **Operations layer extraction** (#264, #263) — reduce duplication between CLI and MCP
-  by consolidating shared logic into core
-- **Test coverage improvements** (#274) — strengthen shared test infrastructure and
-  expand coverage across packages
-- **Error hierarchy completion** (#269) — integrate remaining error types into the
-  domain error hierarchy
-- **Documentation completeness** (#276, #275, #277, #278, #285) — README accuracy,
-  missing API docs, ADR updates
-- **Security documentation** (#279, #280) — document CDP/MCP trust models and enhance
-  remote-access security warnings
+- **Remote connection support** — extend beyond same-machine limitation with secure
+  remote CDP connections
+- **Multi-account orchestration** — support managing multiple LinkedIn accounts in a
+  single session
+- **Webhook/event notifications** — push-based notifications for campaign status changes
+  and new message replies
 
 ## Out of Scope (Near-Term)
 


### PR DESCRIPTION
## Summary

- Stamp CHANGELOG `[Unreleased]` → `[0.2.0] — 2026-02-16` with missing entries from 30+ recent commits
- Update ROADMAP to mark v0.2.0 as latest release and refresh near-term priorities (all 11 prior near-term issues are closed)

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (726 tests)
- [ ] CI validates on ubuntu/macos/windows matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)