### PR TITLE
(fix) docs: correct campaign config format in SKILL.md

### DIFF
--- a/packages/mcp/src/tools/campaign-create.ts
+++ b/packages/mcp/src/tools/campaign-create.ts
@@ -24,7 +24,13 @@ export function registerCampaignCreate(server: McpServer): void {
     "campaign-create",
     "Create a new LinkedHelper campaign from YAML or JSON configuration",
     {
-      config: z.string().describe("Campaign configuration in YAML or JSON format"),
+      config: z.string().describe(
+        "Campaign configuration in YAML or JSON format. " +
+        "Required fields: version (must be \"1\"), name, actions (array). " +
+        "Each action needs: type (e.g. \"VisitAndExtract\", \"InvitePerson\"). " +
+        "Optional per-action: cooldownMs, maxActionsPerRun, config (action-specific settings). " +
+        "Use describe-actions to discover available action types and their config schemas.",
+      ),
       format: z
         .enum(["yaml", "json"])
         .optional()

--- a/skills/lhremote-mcp/SKILL.md
+++ b/skills/lhremote-mcp/SKILL.md
@@ -55,15 +55,14 @@ Use `describe-actions` to see available action types and their configuration sch
 `campaign-create` accepts YAML (default) or JSON configuration:
 
 ```yaml
+version: "1"
 name: "Visit & Connect"
 actions:
-  - name: "Visit profiles"
-    actionType: "VisitAndExtract"
-    coolDown: 60000
-    maxActionResultsPerIteration: 10
-  - name: "Send connection request"
-    actionType: "InvitePerson"
-    actionSettings:
+  - type: "VisitAndExtract"
+    cooldownMs: 60000
+    maxActionsPerRun: 10
+  - type: "InvitePerson"
+    config:
       message: "Hi {firstName}, I'd like to connect!"
 ```
 


### PR DESCRIPTION
## Summary

- Fixed SKILL.md campaign creation example to use the correct portable document format (`CampaignDocument`) instead of internal runtime field names (`CampaignActionConfig`)
- Added `version: "1"` (required), replaced `actionType` with `type`, `coolDown` with `cooldownMs`, `maxActionResultsPerIteration` with `maxActionsPerRun`, `actionSettings` with `config`, removed per-action `name` field
- Improved the MCP `campaign-create` tool's `config` parameter description to hint at required schema fields (version, name, actions, type)

Closes #331

## Test plan

- [x] Build passes (`pnpm build`)
- [x] All tests pass (`pnpm test` — 726 core + 248 MCP)
- [x] Lint passes (`pnpm lint`)
- [ ] CI passes on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)