### PR TITLE
(fix) core: open database read-write in campaign-create and campaign-start

### DIFF
--- a/packages/core/src/operations/campaign-create.test.ts
+++ b/packages/core/src/operations/campaign-create.test.ts
@@ -112,6 +112,22 @@ describe("campaignCreate", () => {
     expect(resolveAccount).toHaveBeenCalledWith(9222, {});
   });
 
+  it("passes db readOnly: false to withInstanceDatabase", async () => {
+    setupMocks();
+
+    await campaignCreate({
+      config: MOCK_CONFIG,
+      cdpPort: 9222,
+    });
+
+    expect(withInstanceDatabase).toHaveBeenCalledWith(
+      9222,
+      1,
+      expect.any(Function),
+      { db: { readOnly: false } },
+    );
+  });
+
   it("propagates resolveAccount errors", async () => {
     vi.mocked(resolveAccount).mockRejectedValue(new Error("connection refused"));
 

--- a/packages/core/src/operations/campaign-create.ts
+++ b/packages/core/src/operations/campaign-create.ts
@@ -36,5 +36,5 @@ export async function campaignCreate(
   return withInstanceDatabase(cdpPort, accountId, async ({ instance, db }) => {
     const campaignService = new CampaignService(instance, db);
     return campaignService.create(input.config);
-  });
+  }, { db: { readOnly: false } });
 }

--- a/packages/core/src/operations/campaign-start.test.ts
+++ b/packages/core/src/operations/campaign-start.test.ts
@@ -93,6 +93,23 @@ describe("campaignStart", () => {
     expect(resolveAccount).toHaveBeenCalledWith(9222, {});
   });
 
+  it("passes db readOnly: false to withInstanceDatabase", async () => {
+    setupMocks();
+
+    await campaignStart({
+      campaignId: 42,
+      cdpPort: 9222,
+      personIds: [100],
+    });
+
+    expect(withInstanceDatabase).toHaveBeenCalledWith(
+      9222,
+      1,
+      expect.any(Function),
+      { db: { readOnly: false } },
+    );
+  });
+
   it("propagates resolveAccount errors", async () => {
     vi.mocked(resolveAccount).mockRejectedValue(new Error("connection refused"));
 

--- a/packages/core/src/operations/campaign-start.ts
+++ b/packages/core/src/operations/campaign-start.ts
@@ -39,5 +39,5 @@ export async function campaignStart(
       personsQueued: input.personIds.length,
       message: "Campaign started. Use campaign-status to monitor progress.",
     };
-  });
+  }, { db: { readOnly: false } });
 }


### PR DESCRIPTION
## Summary

- Pass `{ db: { readOnly: false } }` to `withInstanceDatabase` in `campaign-create` and `campaign-start` operations, which execute write statements but were opening the database in default read-only mode
- Add regression tests verifying both operations pass the correct database options

Closes #330

## Test plan

- [x] New unit tests verify `withInstanceDatabase` is called with `{ db: { readOnly: false } }`
- [x] All 14 tests in both test files pass
- [x] Build passes (TypeScript compilation succeeds)
- [x] Full test suite passes (the single flaky timeout in `instance-discovery.integration.test.ts` is pre-existing and unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)