### PR TITLE
Package lhremote as Claude Code plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,25 @@
+{
+  "name": "lhremote",
+  "owner": {
+    "name": "Alexey Pelykh"
+  },
+  "metadata": {
+    "description": "LinkedHelper automation toolkit for Claude Code"
+  },
+  "plugins": [
+    {
+      "name": "lhremote",
+      "source": "./",
+      "description": "LinkedHelper automation toolkit — MCP server and workflow guidance for Claude Code",
+      "version": "0.2.1",
+      "author": {
+        "name": "Alexey Pelykh"
+      },
+      "homepage": "https://github.com/alexey-pelykh/lhremote",
+      "repository": "https://github.com/alexey-pelykh/lhremote",
+      "license": "AGPL-3.0-only",
+      "keywords": ["linkedhelper", "linkedin", "automation", "mcp"],
+      "category": "productivity"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,5 +1,13 @@
 {
   "name": "lhremote",
-  "version": "0.1.0",
-  "description": "LinkedHelper automation toolkit — MCP server and workflow guidance for Claude Code"
+  "version": "0.2.1",
+  "description": "LinkedHelper automation toolkit — MCP server and workflow guidance for Claude Code",
+  "author": {
+    "name": "Alexey Pelykh",
+    "url": "https://github.com/alexey-pelykh"
+  },
+  "homepage": "https://github.com/alexey-pelykh/lhremote",
+  "repository": "https://github.com/alexey-pelykh/lhremote",
+  "license": "AGPL-3.0-only",
+  "keywords": ["linkedhelper", "linkedin", "automation", "mcp"]
 }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -156,6 +156,32 @@ When you are done, stop the campaign:
 lhremote campaign-stop <campaignId>
 ```
 
+## Using lhremote with Claude Code (plugin)
+
+The easiest way to use lhremote with Claude Code is via the plugin system. This installs the MCP server and workflow skill automatically.
+
+### Install the plugin
+
+From within Claude Code, add the marketplace and install:
+
+```shell
+/plugin marketplace add alexey-pelykh/lhremote
+/plugin install lhremote@lhremote
+```
+
+This sets up:
+
+- **MCP server** — Claude Code can call all lhremote tools directly
+- **Workflow skill** — Claude Code learns lhremote discovery flows, campaign patterns, and error handling
+
+### Verify the installation
+
+Run `/plugin` and check the **Installed** tab to confirm lhremote appears. Then try asking Claude Code to interact with LinkedHelper:
+
+```
+Find LinkedHelper and check its status
+```
+
 ## Using lhremote with Claude Desktop (MCP)
 
 lhremote includes a built-in [MCP](https://modelcontextprotocol.io) server that lets AI assistants like Claude control LinkedHelper directly.


### PR DESCRIPTION
## Summary

- Enhanced `.claude-plugin/plugin.json` with full metadata (author, homepage, repository, license, keywords)
- Created `.claude-plugin/marketplace.json` so the repo acts as its own plugin marketplace
- Added Claude Code plugin installation section to `docs/getting-started.md`

Users can now install via:

```
/plugin marketplace add alexey-pelykh/lhremote
/plugin install lhremote@lhremote
```

This auto-configures the MCP server and the `lhremote-mcp` workflow skill.

## Test plan

- [ ] Verify `plugin.json` and `marketplace.json` are valid JSON
- [ ] Test `/plugin marketplace add` with this repo
- [ ] Test `/plugin install lhremote@lhremote` installs MCP server and skill
- [ ] Verify getting-started docs render correctly

Closes #334