### PR TITLE
(feat) core: detect and surface UI errors, dialogs, and blocking popups

### DIFF
--- a/packages/cli/src/handlers/get-errors.test.ts
+++ b/packages/cli/src/handlers/get-errors.test.ts
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return {
+    ...actual,
+    getErrors: vi.fn(),
+  };
+});
+
+import { type GetErrorsOutput, getErrors } from "@lhremote/core";
+
+import { handleGetErrors } from "./get-errors.js";
+
+const mockedGetErrors = vi.mocked(getErrors);
+
+describe("handleGetErrors", () => {
+  const originalExitCode = process.exitCode;
+
+  beforeEach(() => {
+    process.exitCode = undefined;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.exitCode = originalExitCode;
+    vi.restoreAllMocks();
+  });
+
+  it("prints JSON with --json", async () => {
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockReturnValue(true);
+
+    const output: GetErrorsOutput = {
+      accountId: 1,
+      healthy: true,
+      issues: [],
+      popup: null,
+    };
+
+    mockedGetErrors.mockResolvedValue(output);
+
+    await handleGetErrors({ json: true });
+
+    expect(process.exitCode).toBeUndefined();
+    const text = stdoutSpy.mock.calls
+      .map((call) => String(call[0]))
+      .join("");
+    expect(JSON.parse(text)).toEqual(output);
+  });
+
+  it("prints healthy status in human-friendly format", async () => {
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockReturnValue(true);
+
+    mockedGetErrors.mockResolvedValue({
+      accountId: 1,
+      healthy: true,
+      issues: [],
+      popup: null,
+    });
+
+    await handleGetErrors({});
+
+    expect(process.exitCode).toBeUndefined();
+    expect(stdoutSpy).toHaveBeenCalledWith("Health: healthy\n");
+    expect(stdoutSpy).toHaveBeenCalledWith("Account: 1\n");
+    expect(stdoutSpy).toHaveBeenCalledWith("Issues: none\n");
+    expect(stdoutSpy).toHaveBeenCalledWith("Popup: none\n");
+  });
+
+  it("prints dialog issues", async () => {
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockReturnValue(true);
+
+    mockedGetErrors.mockResolvedValue({
+      accountId: 1,
+      healthy: false,
+      issues: [
+        {
+          type: "dialog",
+          id: "d1",
+          data: {
+            id: "d1",
+            options: {
+              message: "Instance closed from launcher",
+              controls: [
+                { id: "ok", text: "OK" },
+                { id: "cancel", text: "Cancel" },
+              ],
+            },
+          },
+        },
+      ],
+      popup: null,
+    });
+
+    await handleGetErrors({});
+
+    expect(stdoutSpy).toHaveBeenCalledWith("Health: BLOCKED\n");
+    expect(stdoutSpy).toHaveBeenCalledWith("Issues: 1\n");
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      "  Dialog: Instance closed from launcher [OK, Cancel]\n",
+    );
+  });
+
+  it("prints critical error issues", async () => {
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockReturnValue(true);
+
+    mockedGetErrors.mockResolvedValue({
+      accountId: 1,
+      healthy: false,
+      issues: [
+        {
+          type: "critical-error",
+          id: "e1",
+          data: { message: "Database unavailable" },
+        },
+      ],
+      popup: null,
+    });
+
+    await handleGetErrors({});
+
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      "  Critical error: Database unavailable\n",
+    );
+  });
+
+  it("prints blocking popup state", async () => {
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockReturnValue(true);
+
+    mockedGetErrors.mockResolvedValue({
+      accountId: 1,
+      healthy: false,
+      issues: [],
+      popup: { blocked: true, message: "Network issue", closable: false },
+    });
+
+    await handleGetErrors({});
+
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      "Popup: Network issue (unclosable)\n",
+    );
+  });
+
+  it("sets exitCode 1 on error", async () => {
+    const stderrSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockReturnValue(true);
+
+    mockedGetErrors.mockRejectedValue(new Error("unexpected"));
+
+    await handleGetErrors({});
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("unexpected\n");
+  });
+});

--- a/packages/cli/src/handlers/get-errors.ts
+++ b/packages/cli/src/handlers/get-errors.ts
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { getErrors, errorMessage, DEFAULT_CDP_PORT } from "@lhremote/core";
+
+/** Handle the {@link https://github.com/alexey-pelykh/lhremote#get-errors | get-errors} CLI command. */
+export async function handleGetErrors(options: {
+  cdpPort?: number;
+  cdpHost?: string;
+  allowRemote?: boolean;
+  json?: boolean;
+}): Promise<void> {
+  try {
+    const result = await getErrors({
+      cdpPort: options.cdpPort ?? DEFAULT_CDP_PORT,
+      cdpHost: options.cdpHost,
+      allowRemote: options.allowRemote,
+    });
+
+    if (options.json) {
+      process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+      return;
+    }
+
+    // Overall health
+    process.stdout.write(
+      `Health: ${result.healthy ? "healthy" : "BLOCKED"}\n`,
+    );
+    process.stdout.write(
+      `Account: ${String(result.accountId)}\n`,
+    );
+
+    // Instance issues
+    if (result.issues.length === 0) {
+      process.stdout.write("Issues: none\n");
+    } else {
+      process.stdout.write(`Issues: ${String(result.issues.length)}\n`);
+      for (const issue of result.issues) {
+        if (issue.type === "dialog") {
+          const controls = issue.data.options.controls
+            .map((c) => c.text)
+            .join(", ");
+          process.stdout.write(
+            `  Dialog: ${issue.data.options.message} [${controls}]\n`,
+          );
+        } else {
+          process.stdout.write(
+            `  Critical error: ${issue.data.message}\n`,
+          );
+        }
+      }
+    }
+
+    // Popup state
+    if (result.popup === null || !result.popup.blocked) {
+      process.stdout.write("Popup: none\n");
+    } else {
+      const closable = result.popup.closable ? "closable" : "unclosable";
+      process.stdout.write(
+        `Popup: ${result.popup.message ?? "blocking overlay"} (${closable})\n`,
+      );
+    }
+  } catch (error) {
+    const message = errorMessage(error);
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/packages/cli/src/handlers/index.ts
+++ b/packages/cli/src/handlers/index.ts
@@ -24,6 +24,7 @@ export { handleCheckReplies } from "./check-replies.js";
 export { handleDescribeActions } from "./describe-actions.js";
 export { handleCheckStatus } from "./check-status.js";
 export { handleFindApp } from "./find-app.js";
+export { handleGetErrors } from "./get-errors.js";
 export { handleQueryMessages } from "./query-messages.js";
 export { handleQueryProfile } from "./query-profile.js";
 export { handleQueryProfiles } from "./query-profiles.js";

--- a/packages/cli/src/program.test.ts
+++ b/packages/cli/src/program.test.ts
@@ -68,7 +68,8 @@ describe("createProgram", () => {
     expect(commandNames).toContain("campaign-exclude-list");
     expect(commandNames).toContain("campaign-exclude-add");
     expect(commandNames).toContain("campaign-exclude-remove");
-    expect(commandNames).toHaveLength(32);
+    expect(commandNames).toContain("get-errors");
+    expect(commandNames).toHaveLength(33);
   });
 
   describe("launch-app", () => {

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -29,6 +29,7 @@ import {
   handleCheckStatus,
   handleDescribeActions,
   handleFindApp,
+  handleGetErrors,
   handleLaunchApp,
   handleListAccounts,
   handleQueryMessages,
@@ -443,6 +444,15 @@ export function createProgram(): Command {
     .option("--allow-remote", "SECURITY: allow non-loopback CDP connections (enables remote code execution on target)")
     .option("--json", "Output as JSON")
     .action(handleCheckStatus);
+
+  program
+    .command("get-errors")
+    .description("Query current UI errors, dialogs, and blocking popups")
+    .option("--cdp-port <port>", "CDP debugging port", parsePositiveInt)
+    .option("--cdp-host <host>", "CDP host (default: 127.0.0.1)")
+    .option("--allow-remote", "SECURITY: allow non-loopback CDP connections (enables remote code execution on target)")
+    .option("--json", "Output as JSON")
+    .action(handleGetErrors);
 
   return program;
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -21,6 +21,8 @@ export type {
   CampaignStatus,
   CampaignSummary,
   CampaignUpdateConfig,
+  CriticalErrorIssueData,
+  DialogIssueData,
   ExcludeListEntry,
   Chat,
   ChatParticipant,
@@ -34,12 +36,14 @@ export type {
   GetStatisticsOptions,
   ImportPeopleResult,
   InstanceInfo,
+  InstanceIssue,
   InstanceStatus,
   ListCampaignsOptions,
   Message,
   MessageStats,
   MessageSummary,
   MiniProfile,
+  PopupState,
   Position,
   Profile,
   ProfileSearchOptions,
@@ -49,6 +53,7 @@ export type {
   Skill,
   StartInstanceParams,
   StartInstanceResult,
+  UIHealthStatus,
 } from "./types/index.js";
 
 // Services
@@ -75,6 +80,7 @@ export {
   ServiceError,
   StartInstanceError,
   startInstanceWithRecovery,
+  UIBlockedError,
   type StartInstanceOutcome,
   checkStatus,
   type AccountInstanceStatus,
@@ -207,6 +213,10 @@ export {
   campaignExcludeList,
   type CampaignExcludeListInput,
   type CampaignExcludeListOutput,
+  // Error detection
+  getErrors,
+  type GetErrorsInput,
+  type GetErrorsOutput,
   // Messaging
   queryMessages,
   type QueryMessagesInput,

--- a/packages/core/src/operations/get-errors.test.ts
+++ b/packages/core/src/operations/get-errors.test.ts
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../services/account-resolution.js", () => ({
+  resolveAccount: vi.fn(),
+}));
+
+vi.mock("../services/launcher.js", () => ({
+  LauncherService: vi.fn(),
+}));
+
+import { resolveAccount } from "../services/account-resolution.js";
+import { LauncherService } from "../services/launcher.js";
+import type { UIHealthStatus } from "../types/index.js";
+import { getErrors } from "./get-errors.js";
+
+describe("getErrors", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns healthy status when no issues or popups", async () => {
+    vi.mocked(resolveAccount).mockResolvedValue(1);
+
+    const health: UIHealthStatus = {
+      healthy: true,
+      issues: [],
+      popup: null,
+    };
+
+    const mockLauncher = {
+      connect: vi.fn().mockResolvedValue(undefined),
+      disconnect: vi.fn(),
+      checkUIHealth: vi.fn().mockResolvedValue(health),
+    };
+    vi.mocked(LauncherService).mockImplementation(function () {
+      return mockLauncher as unknown as LauncherService;
+    });
+
+    const result = await getErrors({ cdpPort: 9222 });
+
+    expect(result.healthy).toBe(true);
+    expect(result.accountId).toBe(1);
+    expect(result.issues).toEqual([]);
+    expect(result.popup).toBeNull();
+  });
+
+  it("returns blocked status with dialog issues", async () => {
+    vi.mocked(resolveAccount).mockResolvedValue(1);
+
+    const health: UIHealthStatus = {
+      healthy: false,
+      issues: [
+        {
+          type: "dialog",
+          id: "d1",
+          data: {
+            id: "d1",
+            options: {
+              message: "Instance closed from launcher",
+              controls: [{ id: "ok", text: "OK" }],
+            },
+          },
+        },
+      ],
+      popup: null,
+    };
+
+    const mockLauncher = {
+      connect: vi.fn().mockResolvedValue(undefined),
+      disconnect: vi.fn(),
+      checkUIHealth: vi.fn().mockResolvedValue(health),
+    };
+    vi.mocked(LauncherService).mockImplementation(function () {
+      return mockLauncher as unknown as LauncherService;
+    });
+
+    const result = await getErrors({ cdpPort: 9222 });
+
+    expect(result.healthy).toBe(false);
+    expect(result.issues).toHaveLength(1);
+    expect(result.issues[0]?.type).toBe("dialog");
+  });
+
+  it("returns blocked status with popup overlay", async () => {
+    vi.mocked(resolveAccount).mockResolvedValue(1);
+
+    const health: UIHealthStatus = {
+      healthy: false,
+      issues: [],
+      popup: { blocked: true, message: "Network issue", closable: false },
+    };
+
+    const mockLauncher = {
+      connect: vi.fn().mockResolvedValue(undefined),
+      disconnect: vi.fn(),
+      checkUIHealth: vi.fn().mockResolvedValue(health),
+    };
+    vi.mocked(LauncherService).mockImplementation(function () {
+      return mockLauncher as unknown as LauncherService;
+    });
+
+    const result = await getErrors({ cdpPort: 9222 });
+
+    expect(result.healthy).toBe(false);
+    expect(result.popup?.blocked).toBe(true);
+    expect(result.popup?.message).toBe("Network issue");
+  });
+
+  it("passes connection options to resolveAccount", async () => {
+    vi.mocked(resolveAccount).mockResolvedValue(1);
+
+    const mockLauncher = {
+      connect: vi.fn().mockResolvedValue(undefined),
+      disconnect: vi.fn(),
+      checkUIHealth: vi.fn().mockResolvedValue({
+        healthy: true,
+        issues: [],
+        popup: null,
+      }),
+    };
+    vi.mocked(LauncherService).mockImplementation(function () {
+      return mockLauncher as unknown as LauncherService;
+    });
+
+    await getErrors({
+      cdpPort: 1234,
+      cdpHost: "192.168.1.1",
+      allowRemote: true,
+    });
+
+    expect(resolveAccount).toHaveBeenCalledWith(1234, {
+      host: "192.168.1.1",
+      allowRemote: true,
+    });
+  });
+
+  it("disconnects launcher even on error", async () => {
+    vi.mocked(resolveAccount).mockResolvedValue(1);
+
+    const mockLauncher = {
+      connect: vi.fn().mockResolvedValue(undefined),
+      disconnect: vi.fn(),
+      checkUIHealth: vi.fn().mockRejectedValue(new Error("CDP failure")),
+    };
+    vi.mocked(LauncherService).mockImplementation(function () {
+      return mockLauncher as unknown as LauncherService;
+    });
+
+    await expect(getErrors({ cdpPort: 9222 })).rejects.toThrow("CDP failure");
+    expect(mockLauncher.disconnect).toHaveBeenCalledOnce();
+  });
+
+  it("propagates resolveAccount errors", async () => {
+    vi.mocked(resolveAccount).mockRejectedValue(
+      new Error("connection refused"),
+    );
+
+    await expect(getErrors({ cdpPort: 9222 })).rejects.toThrow(
+      "connection refused",
+    );
+  });
+});

--- a/packages/core/src/operations/get-errors.ts
+++ b/packages/core/src/operations/get-errors.ts
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import type { UIHealthStatus } from "../types/index.js";
+import { resolveAccount } from "../services/account-resolution.js";
+import { LauncherService } from "../services/launcher.js";
+import { DEFAULT_CDP_PORT } from "../constants.js";
+import type { ConnectionOptions } from "./types.js";
+
+/**
+ * Input for the get-errors operation.
+ */
+export type GetErrorsInput = ConnectionOptions;
+
+/**
+ * Output from the get-errors operation.
+ */
+export interface GetErrorsOutput extends UIHealthStatus {
+  readonly accountId: number;
+}
+
+/**
+ * Query the current error/dialog/popup state of a LinkedHelper instance.
+ *
+ * Connects to the launcher, resolves the account, and returns the
+ * aggregated UI health status including active instance issues and
+ * popup overlay state.
+ */
+export async function getErrors(
+  input: GetErrorsInput,
+): Promise<GetErrorsOutput> {
+  const cdpPort = input.cdpPort ?? DEFAULT_CDP_PORT;
+
+  const cdpOptions = {
+    ...(input.cdpHost !== undefined && { host: input.cdpHost }),
+    ...(input.allowRemote !== undefined && { allowRemote: input.allowRemote }),
+  };
+
+  const accountId = await resolveAccount(cdpPort, cdpOptions);
+
+  const launcher = new LauncherService(cdpPort, cdpOptions);
+  try {
+    await launcher.connect();
+    const health = await launcher.checkUIHealth(accountId);
+    return { accountId, ...health };
+  } finally {
+    launcher.disconnect();
+  }
+}

--- a/packages/core/src/operations/index.ts
+++ b/packages/core/src/operations/index.ts
@@ -101,6 +101,13 @@ export {
   type CampaignExcludeListOutput,
 } from "./campaign-exclude-list.js";
 
+// Error detection
+export {
+  getErrors,
+  type GetErrorsInput,
+  type GetErrorsOutput,
+} from "./get-errors.js";
+
 // Messaging
 export {
   queryMessages,

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -2,7 +2,7 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 export { AppService, type AppServiceOptions } from "./app.js";
-export { InstanceService, type ActionResult } from "./instance.js";
+export { InstanceService, type ActionResult, type HealthChecker } from "./instance.js";
 export {
   startInstanceWithRecovery,
   waitForInstancePort,
@@ -41,5 +41,6 @@ export {
   LinkedHelperNotRunningError,
   ServiceError,
   StartInstanceError,
+  UIBlockedError,
   WrongPortError,
 } from "./errors.js";

--- a/packages/core/src/services/instance.test.ts
+++ b/packages/core/src/services/instance.test.ts
@@ -24,35 +24,39 @@ let clientInstances: ClientMocks[] = [];
 /** Lookup by target ID after connect() is called. */
 let clientsByTargetId: Map<string, ClientMocks> = new Map();
 
-vi.mock("../cdp/index.js", () => ({
-  CDPClient: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
-    const mocks: ClientMocks = {
-      connect: vi.fn().mockImplementation(async (targetId?: string) => {
-        if (targetId) {
-          clientsByTargetId.set(targetId, mocks);
-        }
-      }),
-      disconnect: vi.fn(),
-      send: vi.fn().mockResolvedValue(undefined),
-      navigate: vi.fn().mockResolvedValue({ frameId: "F1" }),
-      evaluate: vi.fn().mockResolvedValue(undefined),
-      waitForEvent: vi.fn().mockResolvedValue(undefined),
-      isConnected: vi.fn<() => boolean>().mockReturnValue(true),
-    };
-    clientInstances.push(mocks);
+vi.mock("../cdp/index.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../cdp/index.js")>();
+  return {
+    ...actual,
+    CDPClient: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
+      const mocks: ClientMocks = {
+        connect: vi.fn().mockImplementation(async (targetId?: string) => {
+          if (targetId) {
+            clientsByTargetId.set(targetId, mocks);
+          }
+        }),
+        disconnect: vi.fn(),
+        send: vi.fn().mockResolvedValue(undefined),
+        navigate: vi.fn().mockResolvedValue({ frameId: "F1" }),
+        evaluate: vi.fn().mockResolvedValue(undefined),
+        waitForEvent: vi.fn().mockResolvedValue(undefined),
+        isConnected: vi.fn<() => boolean>().mockReturnValue(true),
+      };
+      clientInstances.push(mocks);
 
-    this.connect = mocks.connect;
-    this.disconnect = mocks.disconnect;
-    this.send = mocks.send;
-    this.navigate = mocks.navigate;
-    this.evaluate = mocks.evaluate;
-    this.waitForEvent = mocks.waitForEvent;
-    Object.defineProperty(this, "isConnected", {
-      get: mocks.isConnected,
-    });
-  }),
-  discoverTargets: vi.fn(),
-}));
+      this.connect = mocks.connect;
+      this.disconnect = mocks.disconnect;
+      this.send = mocks.send;
+      this.navigate = mocks.navigate;
+      this.evaluate = mocks.evaluate;
+      this.waitForEvent = mocks.waitForEvent;
+      Object.defineProperty(this, "isConnected", {
+        get: mocks.isConnected,
+      });
+    }),
+    discoverTargets: vi.fn(),
+  };
+});
 
 import { discoverTargets } from "../cdp/index.js";
 

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -35,6 +35,14 @@ export type {
 } from "./messaging.js";
 
 export type {
+  CriticalErrorIssueData,
+  DialogIssueData,
+  InstanceIssue,
+  PopupState,
+  UIHealthStatus,
+} from "./ui-health.js";
+
+export type {
   ActionConfig,
   ActionErrorSummary,
   ActionPeopleCounts,

--- a/packages/core/src/types/ui-health.ts
+++ b/packages/core/src/types/ui-health.ts
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+/**
+ * Data for a dialog instance issue (requires user interaction to dismiss).
+ */
+export interface DialogIssueData {
+  readonly id: string;
+  readonly options: {
+    readonly message: string;
+    readonly controls: ReadonlyArray<{
+      readonly id: string;
+      readonly text: string;
+    }>;
+  };
+}
+
+/**
+ * Data for a critical-error instance issue (informational, blocks the instance).
+ */
+export interface CriticalErrorIssueData {
+  readonly message: string;
+}
+
+/**
+ * An issue reported on a LinkedHelper instance.
+ *
+ * Dialog issues require a button selection to dismiss.
+ * Critical-error issues are informational and block the instance.
+ */
+export type InstanceIssue =
+  | { readonly type: "dialog"; readonly id: string; readonly data: DialogIssueData }
+  | { readonly type: "critical-error"; readonly id: string; readonly data: CriticalErrorIssueData };
+
+/**
+ * State of a blocking popup overlay in the LinkedHelper launcher UI.
+ *
+ * Popups managed via `popupBS` BehaviorSubject in the frontend.
+ * When a popup has `unclosable: true`, the user cannot dismiss it.
+ */
+export interface PopupState {
+  /** Whether a blocking popup overlay is present. */
+  readonly blocked: boolean;
+  /** The popup message text, if available. */
+  readonly message?: string;
+  /** Whether the popup can be closed by the user. */
+  readonly closable?: boolean;
+}
+
+/**
+ * Aggregated UI health status for a LinkedHelper instance.
+ */
+export interface UIHealthStatus {
+  /** Whether the UI is in a healthy (non-blocked) state. */
+  readonly healthy: boolean;
+  /** Active instance issues (dialogs and critical errors). */
+  readonly issues: readonly InstanceIssue[];
+  /** Current popup overlay state, or `null` if no popup is present. */
+  readonly popup: PopupState | null;
+}

--- a/packages/mcp/src/helpers.ts
+++ b/packages/mcp/src/helpers.ts
@@ -7,6 +7,7 @@ import {
   DEFAULT_CDP_PORT,
   errorMessage,
   LinkedHelperNotRunningError,
+  UIBlockedError,
 } from "@lhremote/core";
 import { z } from "zod";
 
@@ -92,6 +93,11 @@ export function mapErrorToMcpResponse(error: unknown): McpResult | undefined {
   if (error instanceof CampaignNotFoundError) {
     return mcpError(
       `Campaign ${String(error.campaignId)} not found.`,
+    );
+  }
+  if (error instanceof UIBlockedError) {
+    return mcpError(
+      `${error.message}\n\nUI Health:\n${JSON.stringify(error.health, null, 2)}`,
     );
   }
   return undefined;

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -107,6 +107,7 @@ describe("createServer", () => {
     expect(names).toContain("campaign-exclude-list");
     expect(names).toContain("campaign-exclude-add");
     expect(names).toContain("campaign-exclude-remove");
-    expect(names).toHaveLength(32);
+    expect(names).toContain("get-errors");
+    expect(names).toHaveLength(33);
   });
 });

--- a/packages/mcp/src/tools/get-errors.test.ts
+++ b/packages/mcp/src/tools/get-errors.test.ts
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return {
+    ...actual,
+    getErrors: vi.fn(),
+  };
+});
+
+import { type GetErrorsOutput, getErrors } from "@lhremote/core";
+
+import { registerGetErrors } from "./get-errors.js";
+import { createMockServer } from "./testing/mock-server.js";
+
+const mockedGetErrors = vi.mocked(getErrors);
+
+describe("registerGetErrors", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("registers a tool named get-errors", () => {
+    const { server } = createMockServer();
+    registerGetErrors(server);
+
+    expect(server.tool).toHaveBeenCalledOnce();
+    expect(server.tool).toHaveBeenCalledWith(
+      "get-errors",
+      expect.any(String),
+      expect.any(Object),
+      expect.any(Function),
+    );
+  });
+
+  it("returns healthy status as JSON", async () => {
+    const { server, getHandler } = createMockServer();
+    registerGetErrors(server);
+
+    const output: GetErrorsOutput = {
+      accountId: 1,
+      healthy: true,
+      issues: [],
+      popup: null,
+    };
+
+    mockedGetErrors.mockResolvedValue(output);
+
+    const handler = getHandler("get-errors");
+    const result = (await handler({ cdpPort: 9222 })) as {
+      content: [{ text: string }];
+    };
+
+    expect(JSON.parse(result.content[0].text)).toEqual(output);
+  });
+
+  it("returns blocked status with issues", async () => {
+    const { server, getHandler } = createMockServer();
+    registerGetErrors(server);
+
+    const output: GetErrorsOutput = {
+      accountId: 1,
+      healthy: false,
+      issues: [
+        {
+          type: "critical-error",
+          id: "e1",
+          data: { message: "Database unavailable" },
+        },
+      ],
+      popup: null,
+    };
+
+    mockedGetErrors.mockResolvedValue(output);
+
+    const handler = getHandler("get-errors");
+    const result = (await handler({ cdpPort: 9222 })) as {
+      content: [{ text: string }];
+    };
+
+    const parsed = JSON.parse(result.content[0].text) as GetErrorsOutput;
+    expect(parsed.healthy).toBe(false);
+    expect(parsed.issues).toHaveLength(1);
+  });
+
+  it("returns error when getErrors throws", async () => {
+    const { server, getHandler } = createMockServer();
+    registerGetErrors(server);
+
+    mockedGetErrors.mockRejectedValue(new Error("unexpected failure"));
+
+    const handler = getHandler("get-errors");
+    const result = await handler({ cdpPort: 9222 });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "Failed to get errors: unexpected failure",
+        },
+      ],
+    });
+  });
+
+  it("passes cdpPort to getErrors", async () => {
+    const { server, getHandler } = createMockServer();
+    registerGetErrors(server);
+
+    mockedGetErrors.mockResolvedValue({
+      accountId: 1,
+      healthy: true,
+      issues: [],
+      popup: null,
+    });
+
+    const handler = getHandler("get-errors");
+    await handler({ cdpPort: 4567 });
+
+    expect(mockedGetErrors).toHaveBeenCalledWith({
+      cdpPort: 4567,
+      cdpHost: undefined,
+      allowRemote: undefined,
+    });
+  });
+});

--- a/packages/mcp/src/tools/get-errors.ts
+++ b/packages/mcp/src/tools/get-errors.ts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { getErrors } from "@lhremote/core";
+import { cdpConnectionSchema, mcpCatchAll, mcpSuccess } from "../helpers.js";
+
+/** Register the {@link https://github.com/alexey-pelykh/lhremote#get-errors | get-errors} MCP tool. */
+export function registerGetErrors(server: McpServer): void {
+  server.tool(
+    "get-errors",
+    "Query current LinkedHelper UI errors, dialogs, and blocking popups. Returns instance issues (dialog and critical-error), popup overlay state, and overall health status.",
+    {
+      ...cdpConnectionSchema,
+    },
+    async ({ cdpPort, cdpHost, allowRemote }) => {
+      try {
+        const result = await getErrors({ cdpPort, cdpHost, allowRemote });
+        return mcpSuccess(JSON.stringify(result, null, 2));
+      } catch (error) {
+        return mcpCatchAll(error, "Failed to get errors");
+      }
+    },
+  );
+}

--- a/packages/mcp/src/tools/index.ts
+++ b/packages/mcp/src/tools/index.ts
@@ -26,6 +26,7 @@ import { registerCheckReplies } from "./check-replies.js";
 import { registerCheckStatus } from "./check-status.js";
 import { registerDescribeActions } from "./describe-actions.js";
 import { registerFindApp } from "./find-app.js";
+import { registerGetErrors } from "./get-errors.js";
 import { registerLaunchApp } from "./launch-app.js";
 import { registerListAccounts } from "./list-accounts.js";
 import { registerQuitApp } from "./quit-app.js";
@@ -59,6 +60,7 @@ export {
   registerCheckStatus,
   registerDescribeActions,
   registerFindApp,
+  registerGetErrors,
   registerImportPeopleFromUrls,
   registerLaunchApp,
   registerListAccounts,
@@ -91,6 +93,7 @@ export function registerAllTools(server: McpServer): void {
   registerCampaignStop(server);
   registerCampaignUpdate(server);
   registerFindApp(server);
+  registerGetErrors(server);
   registerLaunchApp(server);
   registerQuitApp(server);
   registerListAccounts(server);


### PR DESCRIPTION
## Summary

- Add `UIHealthStatus` types, `UIBlockedError` class, and health detection methods to `LauncherService` (`getInstanceIssues`, `getPopupState`, `checkUIHealth`)
- Wire post-evaluation health checks into `InstanceService` via pluggable `HealthChecker` callback — triggered after `evaluateUI`/`executeAction` and on `CDPTimeoutError` to diagnose blocking states before 30s timeouts
- Expose standalone `get-errors` operation, MCP tool, and CLI command for on-demand health queries
- `withInstanceDatabase` now opens a launcher connection alongside the instance for automatic health checking

## Test plan

- [x] Unit tests for `getErrors` operation (6 tests: healthy, dialog issues, popup overlay, connection options passthrough, disconnect on error, propagated errors)
- [x] Unit tests for MCP `get-errors` tool (5 tests: registration, healthy JSON, blocked JSON, error handling, cdpPort passthrough)
- [x] Unit tests for CLI `handleGetErrors` handler (6 tests: JSON output, human-friendly healthy, dialog issues, critical errors, popup state, error exitCode)
- [x] Existing `InstanceService` tests updated for health checker integration
- [x] Existing `withInstanceDatabase` tests updated for launcher mock
- [x] CLI program and MCP server command count tests updated
- [x] All 987+ tests pass across all packages
- [x] Lint clean

Closes #337

🤖 Generated with [Claude Code](https://claude.com/claude-code)