### PR TITLE
(test) e2e: campaign CRUD lifecycle

### DIFF
--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -18,7 +18,8 @@
   "dependencies": {
     "@lhremote/cli": "workspace:^",
     "@lhremote/core": "workspace:^",
-    "@lhremote/mcp": "workspace:^"
+    "@lhremote/mcp": "workspace:^",
+    "yaml": "catalog:"
   },
   "devDependencies": {
     "@types/node": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -172,6 +172,9 @@ importers:
       '@lhremote/mcp':
         specifier: workspace:^
         version: link:../mcp
+      yaml:
+        specifier: 'catalog:'
+        version: 2.8.2
     devDependencies:
       '@types/node':
         specifier: 'catalog:'


### PR DESCRIPTION
## Summary

- Add E2E tests covering the full campaign CRUD lifecycle: create → get → list → update → export → delete
- Test both CLI handler and MCP tool paths following existing E2E patterns (`createMockServer`, stdout spy)
- Sequential test block where each step depends on previous (shared `campaignId`)
- `afterAll` cleanup archives test campaign if tests fail partway through
- Verify export in both YAML and JSON formats (parsed and validated)
- Verify archived campaign excluded from default listing

Closes #341

## Test plan

- [ ] Run `pnpm test:e2e` locally with LinkedHelper running to execute the full lifecycle
- [ ] CI build + lint passes (no E2E in CI — requires LinkedHelper app)
- [ ] Verify cleanup: test campaign is archived even on partial failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)