### PR TITLE
Remove unused InstanceService.triggerExtraction method

### DIFF
--- a/packages/core/src/services/instance.test.ts
+++ b/packages/core/src/services/instance.test.ts
@@ -410,25 +410,4 @@ describe("InstanceService", () => {
     });
   });
 
-  describe("triggerExtraction", () => {
-    it("delegates to executeAction with SaveCurrentProfile", async () => {
-      mockedDiscoverTargets.mockResolvedValue([LINKEDIN_TARGET, UI_TARGET]);
-      await service.connect();
-
-      await service.triggerExtraction();
-
-      const uiClient = getClientMocks("UI1");
-
-      expect(uiClient.evaluate).toHaveBeenCalledWith(
-        expect.stringContaining("SaveCurrentProfile"),
-        true,
-      );
-    });
-
-    it("throws ServiceError when not connected", async () => {
-      await expect(service.triggerExtraction()).rejects.toThrow(
-        ServiceError,
-      );
-    });
-  });
 });

--- a/packages/core/src/services/instance.ts
+++ b/packages/core/src/services/instance.ts
@@ -191,16 +191,6 @@ export class InstanceService {
   }
 
   /**
-   * Trigger the SaveCurrentProfile action via the instance UI.
-   *
-   * This tells LinkedHelper to extract data from the currently
-   * displayed LinkedIn profile and save it to the database.
-   */
-  async triggerExtraction(): Promise<void> {
-    await this.executeAction("SaveCurrentProfile");
-  }
-
-  /**
    * Evaluate a JavaScript expression in the LinkedHelper UI context.
    *
    * Provides access to `window.mainWindowService.mainWindow.source.*`


### PR DESCRIPTION
## Summary
- Remove `triggerExtraction()` from `InstanceService` — zero production callers
- Remove corresponding test describe block
- Callers that need extraction can use `executeAction("SaveCurrentProfile")` directly

Closes #340

## Test plan
- [x] Build passes
- [x] All tests pass (732 core + 253 mcp)

🤖 Generated with [Claude Code](https://claude.com/claude-code)