### PR TITLE
Gitignore MCP Registry publisher tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,9 @@
 # MCP configuration with credentials
 .mcp.json.local
 
+# MCP Registry publisher tokens (created by mcp-publisher in cwd)
+.mcpregistry_*
+
 # Build output (CI: gh-pages, etc.)
 build/gh-pages/
 


### PR DESCRIPTION
## Summary
- Add `.mcpregistry_*` pattern to `.gitignore` to prevent `mcp-publisher` CLI from leaving ephemeral auth tokens in the repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)