### PR TITLE
Add rate limiting guidance for VisitAndExtract campaigns

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -87,6 +87,7 @@ version: "1"
 name: "My First Campaign"
 description: "Visit profiles and extract their information"
 settings:
+  cooldownMs: 90000
   maxActionsPerRun: 5
 actions:
   - type: VisitAndExtract
@@ -101,6 +102,41 @@ lhremote campaign-create --file my-campaign.yaml
 The output includes the new campaign's ID. Note it for the next steps.
 
 > **Tip**: Use `lhremote describe-actions` to explore all available action types. You can filter by category (`people`, `messaging`, `engagement`, `crm`, `workflow`) or get details for a specific type with `--type <ActionType>`.
+
+## Rate Limiting
+
+LinkedIn monitors automated activity and may issue warnings or restrict accounts that visit too many profiles too quickly. lhremote provides two campaign settings to control pacing:
+
+| Setting | YAML field | Scope | Default | Description |
+|---------|------------|-------|---------|-------------|
+| Cooldown | `cooldownMs` | Campaign or per-action | 60 000 ms (60 s) | Minimum delay between individual profile visits |
+| Max actions per run | `maxActionsPerRun` | Campaign or per-action | 10 | Profiles processed per campaign execution cycle |
+
+### Recommended limits for VisitAndExtract
+
+| Phase | Daily visits | `maxActionsPerRun` | `cooldownMs` |
+|-------|-------------|--------------------|--------------|
+| Warm-up (first week) | ~50 | 5 | 90 000 |
+| Cruising (no warnings) | 100–200 | 10 | 60 000 |
+
+Start conservative and increase only after confirming no LinkedIn warnings. Warnings are easier to prevent than recover from.
+
+### Example: rate-limited campaign
+
+```yaml
+version: "1"
+name: "Profile Enrichment (safe)"
+description: "Visit and extract with conservative pacing"
+settings:
+  cooldownMs: 90000
+  maxActionsPerRun: 5
+actions:
+  - type: VisitAndExtract
+```
+
+Both `cooldownMs` and `maxActionsPerRun` can be set at the campaign level (under `settings`) or overridden per action. Per-action values take priority over the campaign default.
+
+> **Tip**: If you receive a LinkedIn warning, stop the campaign immediately, wait 24–48 hours, then resume with lower limits.
 
 ## Step 6: Import targets
 

--- a/packages/core/src/data/action-types.ts
+++ b/packages/core/src/data/action-types.ts
@@ -49,7 +49,10 @@ export interface ActionTypeCatalog {
 const ACTION_TYPE_INFOS: ActionTypeInfo[] = [
   {
     name: "VisitAndExtract",
-    description: "Visit a LinkedIn profile and extract data (name, positions, education, skills).",
+    description:
+      "Visit a LinkedIn profile and extract data (name, positions, education, skills). " +
+      "Rate limiting: start at ~50 visits/day and scale to 100\u2013200/day after confirming no LinkedIn warnings. " +
+      "Use cooldownMs (default 60 000 ms) and maxActionsPerRun in campaign settings to control pacing.",
     category: "people",
     configSchema: {
       extractCurrentOrganizations: {


### PR DESCRIPTION
## Summary

- Add a **Rate Limiting** section to the Getting Started guide with recommended pacing for VisitAndExtract campaigns (warm-up vs cruising limits)
- Document `cooldownMs` and `maxActionsPerRun` campaign settings with defaults, scoping, and a concrete YAML example
- Add `cooldownMs: 90000` to the first campaign example so new users start with safe defaults
- Include a rate limiting note in the VisitAndExtract action type description (surfaced by `describe-actions`)

Closes #364

## Test plan

- [x] `pnpm lint` passes
- [x] `action-types.test.ts` (28 tests) and `campaign-format.test.ts` (36 tests) pass — no snapshot or description assertions affected
- [ ] CI passes (docs + lint + build + test)
- [ ] Verify Getting Started renders correctly on GH Pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)