### PR TITLE
query-profiles: support searching past positions (company history)

### DIFF
--- a/packages/cli/src/handlers/query-profiles.test.ts
+++ b/packages/cli/src/handlers/query-profiles.test.ts
@@ -272,6 +272,28 @@ describe("handleQueryProfiles", () => {
     });
   });
 
+  it("passes includeHistory to repository when specified", async () => {
+    vi.spyOn(process.stdout, "write").mockReturnValue(true);
+
+    mockDiscovery();
+    mockDb();
+
+    const searchFn = vi.fn().mockReturnValue({ profiles: [], total: 0 });
+    vi.mocked(ProfileRepository).mockImplementation(function () {
+      return { search: searchFn } as unknown as ProfileRepository;
+    });
+
+    await handleQueryProfiles({
+      company: "Acme",
+      includeHistory: true,
+    });
+
+    expect(searchFn).toHaveBeenCalledWith({
+      company: "Acme",
+      includeHistory: true,
+    });
+  });
+
   it("applies limit/offset to merged results across databases", async () => {
     const stdoutSpy = vi
       .spyOn(process.stdout, "write")

--- a/packages/cli/src/handlers/query-profiles.ts
+++ b/packages/cli/src/handlers/query-profiles.ts
@@ -13,11 +13,12 @@ import {
 export async function handleQueryProfiles(options: {
   query?: string;
   company?: string;
+  includeHistory?: boolean;
   limit?: number;
   offset?: number;
   json?: boolean;
 }): Promise<void> {
-  const { query, company, limit = 20, offset = 0 } = options;
+  const { query, company, includeHistory, limit = 20, offset = 0 } = options;
 
   const databases = discoverAllDatabases();
   if (databases.size === 0) {
@@ -37,6 +38,7 @@ export async function handleQueryProfiles(options: {
       const result = repo.search({
         ...(query !== undefined && { query }),
         ...(company !== undefined && { company }),
+        ...(includeHistory !== undefined && { includeHistory }),
       });
       allProfiles.push(...result.profiles);
       totalCount += result.total;

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -410,6 +410,7 @@ export function createProgram(): Command {
     .description("Search for profiles in the local database")
     .option("--query <text>", "Search name or headline")
     .option("--company <name>", "Filter by company")
+    .option("--include-history", "Search past positions too (not just current)")
     .option("--limit <n>", "Max results (default: 20)", parsePositiveInt)
     .option("--offset <n>", "Pagination offset (default: 0)", parseNonNegativeInt)
     .option("--json", "Output as JSON")

--- a/packages/core/src/db/repositories/profile.integration.test.ts
+++ b/packages/core/src/db/repositories/profile.integration.test.ts
@@ -282,5 +282,60 @@ describe("ProfileRepository (integration)", () => {
       expect(partial.total).toBe(1);
       expect(partial.profiles[0]?.firstName).toBe("Grace");
     });
+
+    it("does not match past positions without includeHistory", () => {
+      // Ada's past company "Difference Engine Co" should not be searchable by default
+      const result = repo.search({ company: "Difference Engine" });
+
+      expect(result.total).toBe(0);
+      expect(result.profiles).toHaveLength(0);
+    });
+
+    it("matches past positions when includeHistory is true", () => {
+      const result = repo.search({
+        company: "Difference Engine",
+        includeHistory: true,
+      });
+
+      expect(result.total).toBe(1);
+      expect(result.profiles).toHaveLength(1);
+      expect(result.profiles[0]?.firstName).toBe("Ada");
+    });
+
+    it("still matches current company when includeHistory is true", () => {
+      const result = repo.search({
+        company: "Babbage",
+        includeHistory: true,
+      });
+
+      expect(result.total).toBe(1);
+      expect(result.profiles[0]?.firstName).toBe("Ada");
+      expect(result.profiles[0]?.company).toBe("Babbage Industries");
+    });
+
+    it("combines query and company with includeHistory using AND logic", () => {
+      // Ada + her past company should match
+      const match = repo.search({
+        query: "Ada",
+        company: "Difference Engine",
+        includeHistory: true,
+      });
+      expect(match.total).toBe(1);
+      expect(match.profiles[0]?.firstName).toBe("Ada");
+
+      // Grace + Ada's past company should not match
+      const noMatch = repo.search({
+        query: "Grace",
+        company: "Difference Engine",
+        includeHistory: true,
+      });
+      expect(noMatch.total).toBe(0);
+    });
+
+    it("includeHistory without company filter returns all profiles", () => {
+      // includeHistory only affects company filtering; with no company specified, all profiles return
+      const result = repo.search({ includeHistory: true });
+      expect(result.total).toBe(4);
+    });
   });
 });

--- a/packages/core/src/db/repositories/profile.test.ts
+++ b/packages/core/src/db/repositories/profile.test.ts
@@ -265,5 +265,53 @@ describe("ProfileRepository", () => {
       expect(result.profiles).toHaveLength(1);
       expect(result.profiles[0]?.firstName).toBe("Alan");
     });
+
+    it("does not match past positions by default", () => {
+      const result = repo.search({ company: "Difference Engine" });
+
+      expect(result.total).toBe(0);
+      expect(result.profiles).toHaveLength(0);
+    });
+
+    it("matches past positions when includeHistory is true", () => {
+      const result = repo.search({
+        company: "Difference Engine",
+        includeHistory: true,
+      });
+
+      expect(result.total).toBe(1);
+      expect(result.profiles).toHaveLength(1);
+      expect(result.profiles[0]?.firstName).toBe("Ada");
+    });
+
+    it("still matches current company when includeHistory is true", () => {
+      const result = repo.search({
+        company: "Babbage",
+        includeHistory: true,
+      });
+
+      expect(result.total).toBe(1);
+      expect(result.profiles).toHaveLength(1);
+      expect(result.profiles[0]?.firstName).toBe("Ada");
+    });
+
+    it("combines query and company with includeHistory", () => {
+      const result = repo.search({
+        query: "Ada",
+        company: "Difference Engine",
+        includeHistory: true,
+      });
+
+      expect(result.total).toBe(1);
+      expect(result.profiles[0]?.firstName).toBe("Ada");
+
+      // Query for Grace but company filter for past position of Ada should return empty
+      const noMatch = repo.search({
+        query: "Grace",
+        company: "Difference Engine",
+        includeHistory: true,
+      });
+      expect(noMatch.total).toBe(0);
+    });
   });
 });

--- a/packages/core/src/db/repositories/profile.ts
+++ b/packages/core/src/db/repositories/profile.ts
@@ -96,6 +96,7 @@ export class ProfileRepository {
   private readonly stmtSkills;
   private readonly stmtEmails;
   private readonly stmtSearch;
+  private readonly stmtSearchWithHistory;
   private readonly stmtProfileCount;
 
   constructor(client: DatabaseClient) {
@@ -170,6 +171,25 @@ export class ProfileRepository {
        ORDER BY mp.first_name, mp.last_name
        LIMIT ? OFFSET ?`,
     );
+
+    this.stmtSearchWithHistory = db.prepare(
+      `SELECT
+         p.id,
+         mp.first_name,
+         mp.last_name,
+         mp.headline,
+         cp.company,
+         cp.position AS title,
+         COUNT(*) OVER() AS total
+       FROM people p
+       LEFT JOIN person_mini_profile mp ON p.id = mp.person_id
+       LEFT JOIN person_current_position cp ON p.id = cp.person_id
+       WHERE (? IS NULL OR mp.first_name LIKE ? ESCAPE '\\' OR mp.last_name LIKE ? ESCAPE '\\' OR mp.headline LIKE ? ESCAPE '\\')
+         AND (? IS NULL OR cp.company LIKE ? ESCAPE '\\'
+              OR p.id IN (SELECT pp.person_id FROM person_positions pp WHERE pp.company_name LIKE ? ESCAPE '\\'))
+       ORDER BY mp.first_name, mp.last_name
+       LIMIT ? OFFSET ?`,
+    );
   }
 
   /**
@@ -208,21 +228,33 @@ export class ProfileRepository {
    * Search for profiles by name, headline, or company.
    */
   search(options: ProfileSearchOptions = {}): ProfileSearchResult {
-    const { query, company, limit = 20, offset = 0 } = options;
+    const { query, company, includeHistory = false, limit = 20, offset = 0 } = options;
 
     const queryPattern = query ? `%${escapeLike(query)}%` : null;
     const companyPattern = company ? `%${escapeLike(company)}%` : null;
 
-    const rows = this.stmtSearch.all(
-      queryPattern,
-      queryPattern,
-      queryPattern,
-      queryPattern,
-      companyPattern,
-      companyPattern,
-      limit,
-      offset,
-    ) as unknown as ProfileSearchRow[];
+    const rows = includeHistory
+      ? (this.stmtSearchWithHistory.all(
+          queryPattern,
+          queryPattern,
+          queryPattern,
+          queryPattern,
+          companyPattern,
+          companyPattern,
+          companyPattern,
+          limit,
+          offset,
+        ) as unknown as ProfileSearchRow[])
+      : (this.stmtSearch.all(
+          queryPattern,
+          queryPattern,
+          queryPattern,
+          queryPattern,
+          companyPattern,
+          companyPattern,
+          limit,
+          offset,
+        ) as unknown as ProfileSearchRow[]);
 
     const total = rows.length > 0 ? (rows[0] as ProfileSearchRow).total : 0;
 

--- a/packages/core/src/types/profile.ts
+++ b/packages/core/src/types/profile.ts
@@ -65,8 +65,10 @@ export interface Profile {
 export interface ProfileSearchOptions {
   /** Match against first_name, last_name, headline */
   query?: string;
-  /** Match against current position company */
+  /** Match against current position company (or all positions when includeHistory is true) */
   company?: string;
+  /** When true, company filter also searches past positions in addition to current */
+  includeHistory?: boolean;
   /** Maximum number of results (default 20) */
   limit?: number;
   /** Pagination offset (default 0) */

--- a/packages/mcp/src/tools/query-profiles.test.ts
+++ b/packages/mcp/src/tools/query-profiles.test.ts
@@ -130,6 +130,28 @@ describe("registerQueryProfiles", () => {
     });
   });
 
+  it("passes includeHistory to repository when specified", async () => {
+    const { server, getHandler } = createMockServer();
+    registerQueryProfiles(server);
+    vi.mocked(discoverAllDatabases).mockReturnValue(
+      new Map([[1, "/path/to/db"]]),
+    );
+    mockDb();
+
+    const searchFn = vi.fn().mockReturnValue({ profiles: [], total: 0 });
+    vi.mocked(ProfileRepository).mockImplementation(function () {
+      return { search: searchFn } as unknown as ProfileRepository;
+    });
+
+    const handler = getHandler("query-profiles");
+    await handler({ company: "Acme", includeHistory: true });
+
+    expect(searchFn).toHaveBeenCalledWith({
+      company: "Acme",
+      includeHistory: true,
+    });
+  });
+
   it("returns error when no databases found", async () => {
     const { server, getHandler } = createMockServer();
     registerQueryProfiles(server);

--- a/packages/mcp/src/tools/query-profiles.ts
+++ b/packages/mcp/src/tools/query-profiles.ts
@@ -25,6 +25,12 @@ export function registerQueryProfiles(server: McpServer): void {
         .string()
         .optional()
         .describe("Filter by company name (LIKE match)"),
+      includeHistory: z
+        .boolean()
+        .optional()
+        .describe(
+          "When true, company filter also searches past positions (company history), not just the current position",
+        ),
       limit: z
         .number()
         .int()
@@ -38,7 +44,7 @@ export function registerQueryProfiles(server: McpServer): void {
         .optional()
         .describe("Pagination offset (default: 0)"),
     },
-    async ({ query, company, limit, offset }) => {
+    async ({ query, company, includeHistory, limit, offset }) => {
       const databases = discoverAllDatabases();
       if (databases.size === 0) {
         return mcpError("No LinkedHelper databases found.");
@@ -55,6 +61,7 @@ export function registerQueryProfiles(server: McpServer): void {
           const result = repo.search({
             ...(query !== undefined && { query }),
             ...(company !== undefined && { company }),
+            ...(includeHistory !== undefined && { includeHistory }),
           });
           allProfiles.push(...result.profiles);
           totalCount += result.total;


### PR DESCRIPTION
## Summary

- Adds `includeHistory` boolean parameter to `query-profiles` (MCP tool, CLI `--include-history`, and core `ProfileSearchOptions`)
- When `true`, the company filter also searches `person_positions.company_name` (all positions history) via a subquery, not just `person_current_position.company`
- Default behavior (`false`/omitted) is unchanged — only current position is searched

## Test plan

- [x] Unit tests: 4 new tests in `profile.test.ts` — default no-match, history match, current still works, combined query+company
- [x] Integration tests: 5 new tests in `profile.integration.test.ts` — same scenarios plus `includeHistory` without company returns all
- [x] MCP tool test: verifies `includeHistory` is passed through to repository
- [x] CLI handler test: verifies `includeHistory` is passed through to repository
- [x] Build passes, lint clean, all existing tests still pass

Closes #368

🤖 Generated with [Claude Code](https://claude.com/claude-code)