### PR TITLE
Expose extracted profile data from campaign results

### DIFF
--- a/packages/cli/src/handlers/campaign-status.test.ts
+++ b/packages/cli/src/handlers/campaign-status.test.ts
@@ -33,8 +33,8 @@ const MOCK_STATUS_RESULT: CampaignStatusOutput = {
 };
 
 const MOCK_RESULTS: CampaignStatusOutput["results"] = [
-  { id: 1, personId: 100, result: 3, actionVersionId: 1, platform: "linkedin", createdAt: "2026-01-01T00:00:00Z" },
-  { id: 2, personId: 101, result: 0, actionVersionId: 1, platform: "linkedin", createdAt: "2026-01-01T00:01:00Z" },
+  { id: 1, personId: 100, result: 3, actionVersionId: 1, platform: "linkedin", createdAt: "2026-01-01T00:00:00Z", profile: { firstName: "Alice", lastName: "Smith", headline: "Engineer", company: "Acme", title: "Software Engineer" } },
+  { id: 2, personId: 101, result: 0, actionVersionId: 1, platform: "linkedin", createdAt: "2026-01-01T00:01:00Z", profile: null },
 ];
 
 describe("handleCampaignStatus", () => {
@@ -91,7 +91,9 @@ describe("handleCampaignStatus", () => {
     expect(process.exitCode).toBeUndefined();
     const output = getStdout(stdoutSpy);
     expect(output).toContain("Results (2):");
-    expect(output).toContain("Person 100: result=3");
+    expect(output).toContain("Person 100 (Alice Smith): result=3");
+    expect(output).toContain("Software Engineer");
+    expect(output).toContain("at Acme");
     expect(output).toContain("Person 101: result=0");
   });
 
@@ -105,6 +107,25 @@ describe("handleCampaignStatus", () => {
 
     const parsed = JSON.parse(getStdout(stdoutSpy));
     expect(parsed.results).toHaveLength(2);
+  });
+
+  it("includes profile data in JSON results", async () => {
+    vi.mocked(campaignStatus).mockResolvedValue({
+      ...MOCK_STATUS_RESULT,
+      results: MOCK_RESULTS,
+    });
+
+    await handleCampaignStatus(1, { includeResults: true, json: true });
+
+    const parsed = JSON.parse(getStdout(stdoutSpy));
+    expect(parsed.results[0].profile).toEqual({
+      firstName: "Alice",
+      lastName: "Smith",
+      headline: "Engineer",
+      company: "Acme",
+      title: "Software Engineer",
+    });
+    expect(parsed.results[1].profile).toBeNull();
   });
 
   it("prints 'No results yet' when results empty", async () => {

--- a/packages/cli/src/handlers/campaign-status.ts
+++ b/packages/cli/src/handlers/campaign-status.ts
@@ -72,9 +72,21 @@ export async function handleCampaignStatus(
       if (results.length > 0) {
         process.stdout.write(`\nResults (${String(results.length)}):\n`);
         for (const r of results) {
-          process.stdout.write(
-            `  Person ${String(r.personId)}: result=${String(r.result)} (action version #${String(r.actionVersionId)})\n`,
-          );
+          let line = `  Person ${String(r.personId)}`;
+          if (r.profile) {
+            const name = [r.profile.firstName, r.profile.lastName]
+              .filter(Boolean)
+              .join(" ");
+            if (name) line += ` (${name})`;
+          }
+          line += `: result=${String(r.result)} (action version #${String(r.actionVersionId)})`;
+          if (r.profile) {
+            const details: string[] = [];
+            if (r.profile.title) details.push(r.profile.title);
+            if (r.profile.company) details.push(`at ${r.profile.company}`);
+            if (details.length > 0) line += `\n    ${details.join(" ")}`;
+          }
+          process.stdout.write(line + "\n");
         }
       } else {
         process.stdout.write("\nNo results yet.\n");

--- a/packages/core/src/db/repositories/campaign.test.ts
+++ b/packages/core/src/db/repositories/campaign.test.ts
@@ -178,6 +178,53 @@ describe("CampaignRepository", () => {
       expect(result?.createdAt).toBeDefined();
     });
 
+    it("includes profile data from person_mini_profile and person_current_position", () => {
+      const results = repo.getResults(1);
+
+      // Person 1 (Ada Lovelace): full profile
+      const ada = results.find((r) => r.personId === 1);
+      expect(ada?.profile).toEqual({
+        firstName: "Ada",
+        lastName: "Lovelace",
+        headline: "Principal Analytical Engine Programmer",
+        company: "Babbage Industries",
+        title: "Lead Programmer",
+      });
+
+      // Person 2 (Charlie): mini_profile only, no current position
+      const charlie = results.find((r) => r.personId === 2);
+      expect(charlie?.profile).toEqual({
+        firstName: "Charlie",
+        lastName: null,
+        headline: null,
+        company: null,
+        title: null,
+      });
+
+      // Person 3 (Grace Hopper): full profile
+      const grace = results.find((r) => r.personId === 3);
+      expect(grace?.profile).toEqual({
+        firstName: "Grace",
+        lastName: "Hopper",
+        headline: "Compiler Pioneer at COBOL Systems",
+        company: "COBOL Systems Inc",
+        title: "Distinguished Engineer",
+      });
+    });
+
+    it("returns null profile when person has no mini_profile", () => {
+      // Insert a person without mini_profile
+      db.exec(`
+        INSERT INTO people (id, original_id) VALUES (99, 99);
+        INSERT INTO action_results (action_version_id, person_id, result, platform, created_at)
+        VALUES (1, 99, 1, 'LINKEDIN', '2025-01-16T00:00:00.000Z');
+      `);
+
+      const results = repo.getResults(1);
+      const orphan = results.find((r) => r.personId === 99);
+      expect(orphan?.profile).toBeNull();
+    });
+
     it("respects limit parameter", () => {
       const results = repo.getResults(1, { limit: 1 });
       expect(results).toHaveLength(1);

--- a/packages/core/src/db/repositories/campaign.ts
+++ b/packages/core/src/db/repositories/campaign.ts
@@ -60,6 +60,11 @@ interface ActionResultRow {
   result: number;
   platform: string | null;
   created_at: string;
+  first_name: string | null;
+  last_name: string | null;
+  headline: string | null;
+  company: string | null;
+  title: string | null;
 }
 
 function deriveCampaignState(
@@ -146,10 +151,14 @@ export class CampaignRepository {
 
     this.stmtGetResults = db.prepare(
       `SELECT ar.id, ar.action_version_id, ar.person_id, ar.result,
-              ar.platform, ar.created_at
+              ar.platform, ar.created_at,
+              mp.first_name, mp.last_name, mp.headline,
+              cp.company, cp.position AS title
        FROM action_results ar
        JOIN action_versions av ON ar.action_version_id = av.id
        JOIN actions a ON av.action_id = a.id
+       LEFT JOIN person_mini_profile mp ON ar.person_id = mp.person_id
+       LEFT JOIN person_current_position cp ON ar.person_id = cp.person_id
        WHERE a.campaign_id = ?
        ORDER BY ar.created_at DESC
        LIMIT ?`,
@@ -268,6 +277,16 @@ export class CampaignRepository {
       result: r.result,
       platform: r.platform,
       createdAt: r.created_at,
+      profile:
+        r.first_name != null
+          ? {
+              firstName: r.first_name,
+              lastName: r.last_name,
+              headline: r.headline,
+              company: r.company,
+              title: r.title,
+            }
+          : null,
     }));
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,6 +17,7 @@ export type {
   CampaignConfig,
   CampaignRunResult,
   CampaignState,
+  ResultProfileData,
   CampaignStatistics,
   CampaignStatus,
   CampaignSummary,

--- a/packages/core/src/operations/campaign-status.test.ts
+++ b/packages/core/src/operations/campaign-status.test.ts
@@ -33,9 +33,9 @@ const MOCK_STATUS = {
 const MOCK_RESULTS = {
   campaignId: 42,
   results: [
-    { id: 1, actionVersionId: 1, personId: 100, result: 3, platform: "linkedin", createdAt: "2026-01-01T00:00:00Z" },
-    { id: 2, actionVersionId: 1, personId: 101, result: 3, platform: "linkedin", createdAt: "2026-01-01T00:01:00Z" },
-    { id: 3, actionVersionId: 1, personId: 102, result: 3, platform: "linkedin", createdAt: "2026-01-01T00:02:00Z" },
+    { id: 1, actionVersionId: 1, personId: 100, result: 3, platform: "linkedin", createdAt: "2026-01-01T00:00:00Z", profile: { firstName: "Alice", lastName: "Smith", headline: "Engineer", company: "Acme", title: "Software Engineer" } },
+    { id: 2, actionVersionId: 1, personId: 101, result: 3, platform: "linkedin", createdAt: "2026-01-01T00:01:00Z", profile: { firstName: "Bob", lastName: null, headline: null, company: null, title: null } },
+    { id: 3, actionVersionId: 1, personId: 102, result: 3, platform: "linkedin", createdAt: "2026-01-01T00:02:00Z", profile: null },
   ],
   actionCounts: MOCK_STATUS.actionCounts,
 };
@@ -108,6 +108,34 @@ describe("campaignStatus", () => {
     });
 
     expect(result.results).toHaveLength(1);
+  });
+
+  it("includes profile data in results", async () => {
+    setupMocks();
+
+    const result = await campaignStatus({
+      campaignId: 42,
+      cdpPort: 9222,
+      includeResults: true,
+    });
+
+    const results = result.results ?? [];
+    expect(results).toHaveLength(3);
+    expect(results.at(0)?.profile).toEqual({
+      firstName: "Alice",
+      lastName: "Smith",
+      headline: "Engineer",
+      company: "Acme",
+      title: "Software Engineer",
+    });
+    expect(results.at(1)?.profile).toEqual({
+      firstName: "Bob",
+      lastName: null,
+      headline: null,
+      company: null,
+      title: null,
+    });
+    expect(results.at(2)?.profile).toBeNull();
   });
 
   it("defaults limit to 20", async () => {

--- a/packages/core/src/services/campaign.test.ts
+++ b/packages/core/src/services/campaign.test.ts
@@ -109,6 +109,7 @@ const MOCK_RESULTS: CampaignActionResult[] = [
     result: 1,
     platform: "LINKEDIN",
     createdAt: "2025-01-15T12:00:00Z",
+    profile: { firstName: "Ada", lastName: "Lovelace", headline: "Engineer", company: "Acme", title: "Lead" },
   },
 ];
 

--- a/packages/core/src/types/campaign.ts
+++ b/packages/core/src/types/campaign.ts
@@ -70,6 +70,19 @@ export interface CampaignAction {
 }
 
 /**
+ * Profile data extracted during campaign execution (e.g., VisitAndExtract).
+ *
+ * Sourced from `person_mini_profile` and `person_current_position` tables.
+ */
+export interface ResultProfileData {
+  firstName: string;
+  lastName: string | null;
+  headline: string | null;
+  company: string | null;
+  title: string | null;
+}
+
+/**
  * Result of a campaign action execution.
  */
 export interface CampaignActionResult {
@@ -79,6 +92,8 @@ export interface CampaignActionResult {
   result: number;
   platform: string | null;
   createdAt: string;
+  /** Profile data for the person, joined from profile tables. */
+  profile: ResultProfileData | null;
 }
 
 /**

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -56,6 +56,7 @@ export type {
   CampaignConfig,
   CampaignRunResult,
   CampaignState,
+  ResultProfileData,
   CampaignStatistics,
   CampaignUpdateConfig,
   ExcludeListEntry,

--- a/packages/mcp/src/tools/campaign-status.test.ts
+++ b/packages/mcp/src/tools/campaign-status.test.ts
@@ -43,6 +43,7 @@ const defaultResults = [
     result: 3,
     platform: "linkedin",
     createdAt: "2026-02-07T10:00:00Z",
+    profile: { firstName: "Alice", lastName: "Smith", headline: "Engineer", company: "Acme", title: "Software Engineer" },
   },
   {
     id: 2,
@@ -51,6 +52,7 @@ const defaultResults = [
     result: 3,
     platform: "linkedin",
     createdAt: "2026-02-07T10:01:00Z",
+    profile: null,
   },
 ] as CampaignActionResult[];
 


### PR DESCRIPTION
## Summary

- Adds `ResultProfileData` type and optional `profile` field to `CampaignActionResult`
- Modifies `CampaignRepository.getResults()` to JOIN `person_mini_profile` and `person_current_position` tables via LEFT JOIN
- Enhances CLI human-readable output to show person name, title, and company alongside results
- Profile is `null` when no `person_mini_profile` exists for a person

Closes #376

## Test plan

- [x] Unit tests: core operation tests verify profile data flows through (with data, partial data, null)
- [x] Unit tests: repository tests verify JOIN against real SQLite fixture (Ada Lovelace, Charlie, Grace Hopper)
- [x] Unit tests: repository test verifies null profile for person without mini_profile record
- [x] Unit tests: MCP tool tests verify profile data in JSON output
- [x] Unit tests: CLI handler tests verify profile data in human-readable and JSON output
- [x] Build passes (`pnpm build`)
- [x] Lint passes (`pnpm lint`)
- [x] All 1290 tests pass (`pnpm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)