### PR TITLE
Add campaign-list-people endpoint to enumerate campaign targets

### DIFF
--- a/packages/cli/src/handlers/campaign-list-people.test.ts
+++ b/packages/cli/src/handlers/campaign-list-people.test.ts
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return {
+    ...actual,
+    campaignListPeople: vi.fn(),
+  };
+});
+
+import {
+  type CampaignListPeopleOutput,
+  ActionNotFoundError,
+  CampaignNotFoundError,
+  campaignListPeople,
+} from "@lhremote/core";
+
+import { handleCampaignListPeople } from "./campaign-list-people.js";
+import { getStdout } from "./testing/mock-helpers.js";
+
+const MOCK_RESULT: CampaignListPeopleOutput = {
+  campaignId: 1,
+  people: [
+    {
+      personId: 100,
+      firstName: "Alice",
+      lastName: "Smith",
+      publicId: "alice-smith",
+      status: "queued",
+      currentActionId: 1,
+    },
+    {
+      personId: 200,
+      firstName: "Bob",
+      lastName: null,
+      publicId: null,
+      status: "successful",
+      currentActionId: 2,
+    },
+  ],
+  total: 2,
+  limit: 20,
+  offset: 0,
+};
+
+describe("handleCampaignListPeople", () => {
+  const originalExitCode = process.exitCode;
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    process.exitCode = undefined;
+    vi.clearAllMocks();
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    process.exitCode = originalExitCode;
+    vi.restoreAllMocks();
+  });
+
+  it("prints human-readable people list", async () => {
+    vi.mocked(campaignListPeople).mockResolvedValue(MOCK_RESULT);
+
+    await handleCampaignListPeople(1, {});
+
+    expect(process.exitCode).toBeUndefined();
+    const output = getStdout(stdoutSpy);
+    expect(output).toContain("Campaign #1 People (2 total)");
+    expect(output).toContain("#100 Alice Smith (alice-smith)");
+    expect(output).toContain("queued at action #1");
+    expect(output).toContain("#200 Bob");
+    expect(output).toContain("successful at action #2");
+  });
+
+  it("prints JSON with --json", async () => {
+    vi.mocked(campaignListPeople).mockResolvedValue(MOCK_RESULT);
+
+    await handleCampaignListPeople(1, { json: true });
+
+    expect(process.exitCode).toBeUndefined();
+    const parsed = JSON.parse(getStdout(stdoutSpy));
+    expect(parsed.campaignId).toBe(1);
+    expect(parsed.people).toHaveLength(2);
+    expect(parsed.total).toBe(2);
+  });
+
+  it("prints empty message when no people found", async () => {
+    vi.mocked(campaignListPeople).mockResolvedValue({
+      ...MOCK_RESULT,
+      people: [],
+      total: 0,
+    });
+
+    await handleCampaignListPeople(1, {});
+
+    const output = getStdout(stdoutSpy);
+    expect(output).toContain("No people found.");
+  });
+
+  it("shows pagination hint when more results available", async () => {
+    vi.mocked(campaignListPeople).mockResolvedValue({
+      ...MOCK_RESULT,
+      total: 50,
+      limit: 20,
+      offset: 0,
+    });
+
+    await handleCampaignListPeople(1, {});
+
+    const output = getStdout(stdoutSpy);
+    expect(output).toContain("Showing 1-2 of 50");
+    expect(output).toContain("--offset");
+    expect(output).toContain("--limit");
+  });
+
+  it("does not show pagination hint when all results shown", async () => {
+    vi.mocked(campaignListPeople).mockResolvedValue(MOCK_RESULT);
+
+    await handleCampaignListPeople(1, {});
+
+    const output = getStdout(stdoutSpy);
+    expect(output).not.toContain("Showing");
+  });
+
+  it("passes actionId, status, limit, and offset options", async () => {
+    vi.mocked(campaignListPeople).mockResolvedValue(MOCK_RESULT);
+
+    await handleCampaignListPeople(1, {
+      actionId: 5,
+      status: "queued",
+      limit: 10,
+      offset: 20,
+    });
+
+    expect(campaignListPeople).toHaveBeenCalledWith(
+      expect.objectContaining({
+        campaignId: 1,
+        actionId: 5,
+        status: "queued",
+        limit: 10,
+        offset: 20,
+      }),
+    );
+  });
+
+  it("sets exitCode 1 when campaign not found", async () => {
+    vi.mocked(campaignListPeople).mockRejectedValue(
+      new CampaignNotFoundError(999),
+    );
+
+    await handleCampaignListPeople(999, {});
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("Campaign 999 not found.\n");
+  });
+
+  it("sets exitCode 1 when action not found", async () => {
+    vi.mocked(campaignListPeople).mockRejectedValue(
+      new ActionNotFoundError(99, 1),
+    );
+
+    await handleCampaignListPeople(1, { actionId: 99 });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "Action 99 not found in campaign 1.\n",
+    );
+  });
+
+  it("sets exitCode 1 when resolveAccount fails", async () => {
+    vi.mocked(campaignListPeople).mockRejectedValue(new Error("timeout"));
+
+    await handleCampaignListPeople(1, {});
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("timeout\n");
+  });
+});

--- a/packages/cli/src/handlers/campaign-list-people.ts
+++ b/packages/cli/src/handlers/campaign-list-people.ts
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import {
+  ActionNotFoundError,
+  CampaignNotFoundError,
+  DEFAULT_CDP_PORT,
+  errorMessage,
+  campaignListPeople,
+  type CampaignListPeopleOutput,
+  type CampaignPersonState,
+} from "@lhremote/core";
+
+/** Handle the {@link https://github.com/alexey-pelykh/lhremote#campaigns | campaign-list-people} CLI command. */
+export async function handleCampaignListPeople(
+  campaignId: number,
+  options: {
+    actionId?: number;
+    status?: string;
+    limit?: number;
+    offset?: number;
+    cdpPort?: number;
+    cdpHost?: string;
+    allowRemote?: boolean;
+    json?: boolean;
+  },
+): Promise<void> {
+  let result: CampaignListPeopleOutput;
+  try {
+    result = await campaignListPeople({
+      campaignId,
+      actionId: options.actionId,
+      status: options.status as CampaignPersonState | undefined,
+      limit: options.limit,
+      offset: options.offset,
+      cdpPort: options.cdpPort ?? DEFAULT_CDP_PORT,
+      cdpHost: options.cdpHost,
+      allowRemote: options.allowRemote,
+    });
+  } catch (error) {
+    if (error instanceof CampaignNotFoundError) {
+      process.stderr.write(`Campaign ${String(campaignId)} not found.\n`);
+    } else if (error instanceof ActionNotFoundError) {
+      process.stderr.write(
+        `Action ${String(options.actionId)} not found in campaign ${String(campaignId)}.\n`,
+      );
+    } else {
+      const message = errorMessage(error);
+      process.stderr.write(`${message}\n`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  if (options.json) {
+    process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+  } else {
+    process.stdout.write(
+      `Campaign #${String(campaignId)} People (${String(result.total)} total)\n`,
+    );
+
+    if (result.people.length === 0) {
+      process.stdout.write("  No people found.\n");
+    } else {
+      for (const person of result.people) {
+        const name = person.lastName
+          ? `${person.firstName} ${person.lastName}`
+          : person.firstName;
+        const publicId = person.publicId ? ` (${person.publicId})` : "";
+        process.stdout.write(
+          `  #${String(person.personId)} ${name}${publicId} — ${person.status} at action #${String(person.currentActionId)}\n`,
+        );
+      }
+
+      if (result.total > result.offset + result.people.length) {
+        process.stdout.write(
+          `\nShowing ${String(result.offset + 1)}-${String(result.offset + result.people.length)} of ${String(result.total)}. Use --offset and --limit for pagination.\n`,
+        );
+      }
+    }
+  }
+}

--- a/packages/cli/src/handlers/index.ts
+++ b/packages/cli/src/handlers/index.ts
@@ -10,6 +10,7 @@ export { handleCampaignExcludeRemove } from "./campaign-exclude-remove.js";
 export { handleCampaignExport } from "./campaign-export.js";
 export { handleCampaignGet } from "./campaign-get.js";
 export { handleCampaignList } from "./campaign-list.js";
+export { handleCampaignListPeople } from "./campaign-list-people.js";
 export { handleCampaignMoveNext } from "./campaign-move-next.js";
 export { handleCampaignRemoveAction } from "./campaign-remove-action.js";
 export { handleCampaignReorderActions } from "./campaign-reorder-actions.js";

--- a/packages/cli/src/program.test.ts
+++ b/packages/cli/src/program.test.ts
@@ -68,8 +68,9 @@ describe("createProgram", () => {
     expect(commandNames).toContain("campaign-exclude-list");
     expect(commandNames).toContain("campaign-exclude-add");
     expect(commandNames).toContain("campaign-exclude-remove");
+    expect(commandNames).toContain("campaign-list-people");
     expect(commandNames).toContain("get-errors");
-    expect(commandNames).toHaveLength(33);
+    expect(commandNames).toHaveLength(34);
   });
 
   describe("launch-app", () => {

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -15,6 +15,7 @@ import {
   handleCampaignExport,
   handleCampaignGet,
   handleCampaignList,
+  handleCampaignListPeople,
   handleCampaignMoveNext,
   handleCampaignRemoveAction,
   handleCampaignReorderActions,
@@ -133,6 +134,20 @@ export function createProgram(): Command {
     .option("--include-archived", "Include archived campaigns")
     .option("--json", "Output as JSON")
     .action(handleCampaignList);
+
+  program
+    .command("campaign-list-people")
+    .description("List people assigned to a campaign")
+    .argument("<campaignId>", "Campaign ID", parsePositiveInt)
+    .option("--action-id <id>", "Filter to a specific action", parsePositiveInt)
+    .option("--status <status>", "Filter by status (queued, processed, successful, failed)")
+    .option("--limit <n>", "Max results (default: 20)", parsePositiveInt)
+    .option("--offset <n>", "Pagination offset (default: 0)", parseNonNegativeInt)
+    .option("--cdp-port <port>", "CDP debugging port", parsePositiveInt)
+    .option("--cdp-host <host>", "CDP host (default: 127.0.0.1)")
+    .option("--allow-remote", "SECURITY: allow non-loopback CDP connections (enables remote code execution on target)")
+    .option("--json", "Output as JSON")
+    .action(handleCampaignListPeople);
 
   program
     .command("campaign-create")

--- a/packages/core/src/db/repositories/campaign.ts
+++ b/packages/core/src/db/repositories/campaign.ts
@@ -8,10 +8,13 @@ import type {
   CampaignActionResult,
   Campaign,
   CampaignAction,
+  CampaignPersonEntry,
+  CampaignPersonState,
   CampaignState,
   CampaignSummary,
   CampaignUpdateConfig,
   GetResultsOptions,
+  ListCampaignPeopleOptions,
   ListCampaignsOptions,
 } from "../../types/index.js";
 import type { DatabaseSync } from "node:sqlite";
@@ -66,6 +69,30 @@ interface ActionResultRow {
   company: string | null;
   title: string | null;
 }
+
+interface CampaignPersonRow {
+  person_id: number;
+  first_name: string;
+  last_name: string | null;
+  public_id: string | null;
+  state: number;
+  action_id: number;
+  total: number;
+}
+
+const PERSON_STATE_MAP: Record<number, CampaignPersonState> = {
+  1: "queued",
+  2: "processed",
+  3: "successful",
+  4: "failed",
+};
+
+const PERSON_STATE_REVERSE: Record<string, number> = {
+  queued: 1,
+  processed: 2,
+  successful: 3,
+  failed: 4,
+};
 
 function deriveCampaignState(
   isPaused: number | null,
@@ -288,6 +315,85 @@ export class CampaignRepository {
             }
           : null,
     }));
+  }
+
+  /**
+   * List people assigned to a campaign, with optional filtering and pagination.
+   *
+   * @throws {CampaignNotFoundError} if no campaign exists with the given ID.
+   * @throws {ActionNotFoundError} if actionId is specified but doesn't belong to the campaign.
+   */
+  listPeople(
+    campaignId: number,
+    options: ListCampaignPeopleOptions = {},
+  ): { people: CampaignPersonEntry[]; total: number } {
+    // Verify campaign exists
+    this.getCampaign(campaignId);
+
+    const { actionId, status, limit = 20, offset = 0 } = options;
+
+    // If actionId is provided, verify it belongs to this campaign
+    if (actionId !== undefined) {
+      const actions = this.getCampaignActions(campaignId);
+      if (!actions.some((a) => a.id === actionId)) {
+        throw new ActionNotFoundError(actionId, campaignId);
+      }
+    }
+
+    const conditions: string[] = ["a.campaign_id = ?"];
+    const params: (number | string)[] = [campaignId];
+
+    if (actionId !== undefined) {
+      conditions.push("atp.action_id = ?");
+      params.push(actionId);
+    }
+
+    if (status !== undefined) {
+      const stateNum = PERSON_STATE_REVERSE[status];
+      if (stateNum !== undefined) {
+        conditions.push("atp.state = ?");
+        params.push(stateNum);
+      }
+    }
+
+    const where = conditions.join(" AND ");
+
+    const sql = `
+      SELECT
+        atp.person_id,
+        COALESCE(mp.first_name, '') AS first_name,
+        mp.last_name,
+        pei.external_id AS public_id,
+        atp.state,
+        atp.action_id,
+        COUNT(*) OVER() AS total
+      FROM action_target_people atp
+      JOIN actions a ON atp.action_id = a.id
+      LEFT JOIN person_mini_profile mp ON atp.person_id = mp.person_id
+      LEFT JOIN person_external_ids pei
+        ON atp.person_id = pei.person_id AND pei.type_group = 'public'
+      WHERE ${where}
+      ORDER BY atp.person_id
+      LIMIT ? OFFSET ?`;
+
+    const rows = this.client.db.prepare(sql).all(
+      ...params,
+      limit,
+      offset,
+    ) as unknown as CampaignPersonRow[];
+
+    const total = rows.length > 0 ? (rows[0] as CampaignPersonRow).total : 0;
+
+    const people: CampaignPersonEntry[] = rows.map((r) => ({
+      personId: r.person_id,
+      firstName: r.first_name,
+      lastName: r.last_name,
+      publicId: r.public_id,
+      status: PERSON_STATE_MAP[r.state] ?? "queued",
+      currentActionId: r.action_id,
+    }));
+
+    return { people, total };
   }
 
   /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,6 +15,8 @@ export type {
   Campaign,
   CampaignAction,
   CampaignConfig,
+  CampaignPersonEntry,
+  CampaignPersonState,
   CampaignRunResult,
   CampaignState,
   ResultProfileData,
@@ -39,6 +41,7 @@ export type {
   InstanceInfo,
   InstanceIssue,
   InstanceStatus,
+  ListCampaignPeopleOptions,
   ListCampaignsOptions,
   Message,
   MessageStats,
@@ -172,6 +175,10 @@ export {
   campaignDelete,
   type CampaignDeleteInput,
   type CampaignDeleteOutput,
+  // Campaign people
+  campaignListPeople,
+  type CampaignListPeopleInput,
+  type CampaignListPeopleOutput,
   // Campaign execution
   campaignStart,
   type CampaignStartInput,

--- a/packages/core/src/operations/campaign-list-people.test.ts
+++ b/packages/core/src/operations/campaign-list-people.test.ts
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../services/account-resolution.js", () => ({
+  resolveAccount: vi.fn(),
+}));
+
+vi.mock("../services/instance-context.js", () => ({
+  withDatabase: vi.fn(),
+}));
+
+vi.mock("../db/index.js", () => ({
+  CampaignRepository: vi.fn(),
+}));
+
+import type { DatabaseContext } from "../services/instance-context.js";
+import { resolveAccount } from "../services/account-resolution.js";
+import { withDatabase } from "../services/instance-context.js";
+import { CampaignRepository } from "../db/index.js";
+import { campaignListPeople } from "./campaign-list-people.js";
+
+const MOCK_PEOPLE = {
+  people: [
+    {
+      personId: 100,
+      firstName: "Alice",
+      lastName: "Smith",
+      publicId: "alice-smith",
+      status: "queued" as const,
+      currentActionId: 1,
+    },
+    {
+      personId: 200,
+      firstName: "Bob",
+      lastName: null,
+      publicId: null,
+      status: "successful" as const,
+      currentActionId: 2,
+    },
+  ],
+  total: 2,
+};
+
+function setupMocks() {
+  vi.mocked(resolveAccount).mockResolvedValue(1);
+
+  vi.mocked(withDatabase).mockImplementation(
+    async (_accountId, callback) =>
+      callback({ db: {} } as unknown as DatabaseContext),
+  );
+
+  vi.mocked(CampaignRepository).mockImplementation(function () {
+    return {
+      listPeople: vi.fn().mockReturnValue(MOCK_PEOPLE),
+    } as unknown as CampaignRepository;
+  });
+}
+
+describe("campaignListPeople", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns people for a campaign", async () => {
+    setupMocks();
+
+    const result = await campaignListPeople({
+      campaignId: 42,
+      cdpPort: 9222,
+    });
+
+    expect(result.campaignId).toBe(42);
+    expect(result.people).toHaveLength(2);
+    expect(result.people[0]?.personId).toBe(100);
+    expect(result.people[1]?.personId).toBe(200);
+    expect(result.total).toBe(2);
+    expect(result.limit).toBe(20);
+    expect(result.offset).toBe(0);
+  });
+
+  it("passes actionId, status, limit, and offset to repository", async () => {
+    setupMocks();
+
+    await campaignListPeople({
+      campaignId: 42,
+      cdpPort: 9222,
+      actionId: 5,
+      status: "queued",
+      limit: 10,
+      offset: 20,
+    });
+
+    const mockResult = vi.mocked(CampaignRepository).mock.results[0] as {
+      value: InstanceType<typeof CampaignRepository>;
+    };
+    expect(mockResult.value.listPeople).toHaveBeenCalledWith(42, {
+      actionId: 5,
+      status: "queued",
+      limit: 10,
+      offset: 20,
+    });
+  });
+
+  it("uses default limit and offset when not provided", async () => {
+    setupMocks();
+
+    await campaignListPeople({
+      campaignId: 42,
+      cdpPort: 9222,
+    });
+
+    const mockResult = vi.mocked(CampaignRepository).mock.results[0] as {
+      value: InstanceType<typeof CampaignRepository>;
+    };
+    expect(mockResult.value.listPeople).toHaveBeenCalledWith(42, {
+      limit: 20,
+      offset: 0,
+    });
+  });
+
+  it("passes connection options to resolveAccount", async () => {
+    setupMocks();
+
+    await campaignListPeople({
+      campaignId: 42,
+      cdpPort: 1234,
+      cdpHost: "192.168.1.1",
+      allowRemote: true,
+    });
+
+    expect(resolveAccount).toHaveBeenCalledWith(1234, {
+      host: "192.168.1.1",
+      allowRemote: true,
+    });
+  });
+
+  it("omits undefined connection options", async () => {
+    setupMocks();
+
+    await campaignListPeople({
+      campaignId: 42,
+      cdpPort: 9222,
+    });
+
+    expect(resolveAccount).toHaveBeenCalledWith(9222, {});
+  });
+
+  it("propagates resolveAccount errors", async () => {
+    vi.mocked(resolveAccount).mockRejectedValue(
+      new Error("connection refused"),
+    );
+
+    await expect(
+      campaignListPeople({ campaignId: 42, cdpPort: 9222 }),
+    ).rejects.toThrow("connection refused");
+  });
+
+  it("propagates withDatabase errors", async () => {
+    vi.mocked(resolveAccount).mockResolvedValue(1);
+    vi.mocked(withDatabase).mockRejectedValue(
+      new Error("database not found"),
+    );
+
+    await expect(
+      campaignListPeople({ campaignId: 42, cdpPort: 9222 }),
+    ).rejects.toThrow("database not found");
+  });
+
+  it("propagates CampaignRepository errors", async () => {
+    vi.mocked(resolveAccount).mockResolvedValue(1);
+    vi.mocked(withDatabase).mockImplementation(
+      async (_accountId, callback) =>
+        callback({ db: {} } as unknown as DatabaseContext),
+    );
+    vi.mocked(CampaignRepository).mockImplementation(function () {
+      return {
+        listPeople: vi.fn().mockImplementation(() => {
+          throw new Error("repository error");
+        }),
+      } as unknown as CampaignRepository;
+    });
+
+    await expect(
+      campaignListPeople({ campaignId: 42, cdpPort: 9222 }),
+    ).rejects.toThrow("repository error");
+  });
+});

--- a/packages/core/src/operations/campaign-list-people.ts
+++ b/packages/core/src/operations/campaign-list-people.ts
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import type { CampaignPersonEntry, CampaignPersonState } from "../types/index.js";
+import { resolveAccount } from "../services/account-resolution.js";
+import { withDatabase } from "../services/instance-context.js";
+import { CampaignRepository } from "../db/index.js";
+import { DEFAULT_CDP_PORT } from "../constants.js";
+import type { ConnectionOptions } from "./types.js";
+
+/**
+ * Input for the campaign-list-people operation.
+ */
+export interface CampaignListPeopleInput extends ConnectionOptions {
+  readonly campaignId: number;
+  readonly actionId?: number | undefined;
+  readonly status?: CampaignPersonState | undefined;
+  readonly limit?: number | undefined;
+  readonly offset?: number | undefined;
+}
+
+/**
+ * Output from the campaign-list-people operation.
+ */
+export interface CampaignListPeopleOutput {
+  readonly campaignId: number;
+  readonly people: CampaignPersonEntry[];
+  readonly total: number;
+  readonly limit: number;
+  readonly offset: number;
+}
+
+/**
+ * List people assigned to a campaign with optional filtering and pagination.
+ *
+ * This is the shared business logic used by both the CLI handler and
+ * the MCP tool.
+ */
+export async function campaignListPeople(
+  input: CampaignListPeopleInput,
+): Promise<CampaignListPeopleOutput> {
+  const cdpPort = input.cdpPort ?? DEFAULT_CDP_PORT;
+  const limit = input.limit ?? 20;
+  const offset = input.offset ?? 0;
+
+  const accountId = await resolveAccount(cdpPort, {
+    ...(input.cdpHost !== undefined && { host: input.cdpHost }),
+    ...(input.allowRemote !== undefined && { allowRemote: input.allowRemote }),
+  });
+
+  return withDatabase(accountId, ({ db }) => {
+    const campaignRepo = new CampaignRepository(db);
+    const result = campaignRepo.listPeople(input.campaignId, {
+      ...(input.actionId !== undefined && { actionId: input.actionId }),
+      ...(input.status !== undefined && { status: input.status }),
+      limit,
+      offset,
+    });
+
+    return {
+      campaignId: input.campaignId,
+      people: result.people,
+      total: result.total,
+      limit,
+      offset,
+    };
+  });
+}

--- a/packages/core/src/operations/index.ts
+++ b/packages/core/src/operations/index.ts
@@ -30,6 +30,13 @@ export {
   type CampaignDeleteOutput,
 } from "./campaign-delete.js";
 
+// Campaign people
+export {
+  campaignListPeople,
+  type CampaignListPeopleInput,
+  type CampaignListPeopleOutput,
+} from "./campaign-list-people.js";
+
 // Campaign execution
 export {
   campaignStart,

--- a/packages/core/src/types/campaign.ts
+++ b/packages/core/src/types/campaign.ts
@@ -122,6 +122,43 @@ export interface GetResultsOptions {
 }
 
 /**
+ * Processing state of a person in a campaign action target list.
+ */
+export type CampaignPersonState = "queued" | "processed" | "successful" | "failed";
+
+/**
+ * A person assigned to a campaign with their processing state.
+ */
+export interface CampaignPersonEntry {
+  /** Internal person ID. */
+  personId: number;
+  /** First name from mini profile. */
+  firstName: string;
+  /** Last name from mini profile. */
+  lastName: string | null;
+  /** LinkedIn public ID (slug). */
+  publicId: string | null;
+  /** Processing state in the action target list. */
+  status: CampaignPersonState;
+  /** Action ID the person is currently assigned to. */
+  currentActionId: number;
+}
+
+/**
+ * Options for listing people in a campaign.
+ */
+export interface ListCampaignPeopleOptions {
+  /** Filter to people in a specific action. */
+  actionId?: number;
+  /** Filter by processing status. */
+  status?: CampaignPersonState;
+  /** Maximum number of results (default: 20). */
+  limit?: number;
+  /** Pagination offset (default: 0). */
+  offset?: number;
+}
+
+/**
  * Configuration for creating a new campaign.
  */
 export interface CampaignConfig {

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -54,6 +54,8 @@ export type {
   Campaign,
   CampaignAction,
   CampaignConfig,
+  CampaignPersonEntry,
+  CampaignPersonState,
   CampaignRunResult,
   CampaignState,
   ResultProfileData,
@@ -65,6 +67,7 @@ export type {
   ImportPeopleResult,
   CampaignStatus,
   CampaignSummary,
+  ListCampaignPeopleOptions,
   ListCampaignsOptions,
   RunnerState,
 } from "./campaign.js";

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -107,7 +107,8 @@ describe("createServer", () => {
     expect(names).toContain("campaign-exclude-list");
     expect(names).toContain("campaign-exclude-add");
     expect(names).toContain("campaign-exclude-remove");
+    expect(names).toContain("campaign-list-people");
     expect(names).toContain("get-errors");
-    expect(names).toHaveLength(33);
+    expect(names).toHaveLength(34);
   });
 });

--- a/packages/mcp/src/tools/campaign-list-people.test.ts
+++ b/packages/mcp/src/tools/campaign-list-people.test.ts
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return {
+    ...actual,
+    campaignListPeople: vi.fn(),
+  };
+});
+
+import {
+  AccountResolutionError,
+  ActionNotFoundError,
+  CampaignNotFoundError,
+  type CampaignListPeopleOutput,
+  campaignListPeople,
+} from "@lhremote/core";
+
+import { registerCampaignListPeople } from "./campaign-list-people.js";
+import { describeInfrastructureErrors } from "./testing/infrastructure-errors.js";
+import { createMockServer } from "./testing/mock-server.js";
+
+const SAMPLE_OUTPUT: CampaignListPeopleOutput = {
+  campaignId: 10,
+  people: [
+    {
+      personId: 100,
+      firstName: "Alice",
+      lastName: "Smith",
+      publicId: "alice-smith",
+      status: "queued",
+      currentActionId: 1,
+    },
+    {
+      personId: 200,
+      firstName: "Bob",
+      lastName: null,
+      publicId: null,
+      status: "successful",
+      currentActionId: 2,
+    },
+  ],
+  total: 2,
+  limit: 20,
+  offset: 0,
+};
+
+describe("registerCampaignListPeople", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("registers a tool named campaign-list-people", () => {
+    const { server } = createMockServer();
+    registerCampaignListPeople(server);
+
+    expect(server.tool).toHaveBeenCalledOnce();
+    expect(server.tool).toHaveBeenCalledWith(
+      "campaign-list-people",
+      expect.any(String),
+      expect.any(Object),
+      expect.any(Function),
+    );
+  });
+
+  it("returns people for a campaign", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignListPeople(server);
+    vi.mocked(campaignListPeople).mockResolvedValue(SAMPLE_OUTPUT);
+
+    const handler = getHandler("campaign-list-people");
+    const result = await handler({
+      campaignId: 10,
+      cdpPort: 9222,
+      limit: 20,
+      offset: 0,
+    });
+
+    expect(result).toEqual({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(SAMPLE_OUTPUT, null, 2),
+        },
+      ],
+    });
+  });
+
+  it("passes actionId and status to operation", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignListPeople(server);
+    vi.mocked(campaignListPeople).mockResolvedValue(SAMPLE_OUTPUT);
+
+    const handler = getHandler("campaign-list-people");
+    await handler({
+      campaignId: 10,
+      actionId: 42,
+      status: "queued",
+      limit: 20,
+      offset: 0,
+      cdpPort: 9222,
+    });
+
+    expect(campaignListPeople).toHaveBeenCalledWith(
+      expect.objectContaining({
+        campaignId: 10,
+        actionId: 42,
+        status: "queued",
+      }),
+    );
+  });
+
+  it("returns error for non-existent campaign", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignListPeople(server);
+
+    vi.mocked(campaignListPeople).mockRejectedValue(
+      new CampaignNotFoundError(999),
+    );
+
+    const handler = getHandler("campaign-list-people");
+    const result = await handler({
+      campaignId: 999,
+      cdpPort: 9222,
+      limit: 20,
+      offset: 0,
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "Campaign 999 not found.",
+        },
+      ],
+    });
+  });
+
+  it("returns error for non-existent action", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignListPeople(server);
+
+    vi.mocked(campaignListPeople).mockRejectedValue(
+      new ActionNotFoundError(999, 10),
+    );
+
+    const handler = getHandler("campaign-list-people");
+    const result = await handler({
+      campaignId: 10,
+      actionId: 999,
+      cdpPort: 9222,
+      limit: 20,
+      offset: 0,
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "Action 999 not found in campaign 10.",
+        },
+      ],
+    });
+  });
+
+  describeInfrastructureErrors(
+    registerCampaignListPeople,
+    "campaign-list-people",
+    () => ({ campaignId: 10, cdpPort: 9222, limit: 20, offset: 0 }),
+    (error) => vi.mocked(campaignListPeople).mockRejectedValue(error),
+    "Failed to list campaign people",
+  );
+
+  it("returns error when no accounts found", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignListPeople(server);
+
+    vi.mocked(campaignListPeople).mockRejectedValue(
+      new AccountResolutionError("no-accounts"),
+    );
+
+    const handler = getHandler("campaign-list-people");
+    const result = await handler({
+      campaignId: 10,
+      cdpPort: 9222,
+      limit: 20,
+      offset: 0,
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "No accounts found.",
+        },
+      ],
+    });
+  });
+
+  it("returns error when multiple accounts found", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignListPeople(server);
+
+    vi.mocked(campaignListPeople).mockRejectedValue(
+      new AccountResolutionError("multiple-accounts"),
+    );
+
+    const handler = getHandler("campaign-list-people");
+    const result = await handler({
+      campaignId: 10,
+      cdpPort: 9222,
+      limit: 20,
+      offset: 0,
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "Multiple accounts found. Cannot determine which instance to use.",
+        },
+      ],
+    });
+  });
+});

--- a/packages/mcp/src/tools/campaign-list-people.ts
+++ b/packages/mcp/src/tools/campaign-list-people.ts
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  ActionNotFoundError,
+  campaignListPeople,
+} from "@lhremote/core";
+import { z } from "zod";
+import { cdpConnectionSchema, mcpCatchAll, mcpError, mcpSuccess } from "../helpers.js";
+
+/** Register the {@link https://github.com/alexey-pelykh/lhremote#campaign-list-people | campaign-list-people} MCP tool. */
+export function registerCampaignListPeople(server: McpServer): void {
+  server.tool(
+    "campaign-list-people",
+    "List people assigned to a campaign with their processing status. Returns person details (name, LinkedIn public ID) and which action they are currently at.",
+    {
+      campaignId: z
+        .number()
+        .int()
+        .positive()
+        .describe("Campaign ID"),
+      actionId: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .describe("Filter to people in a specific action"),
+      status: z
+        .enum(["queued", "processed", "successful", "failed"])
+        .optional()
+        .describe("Filter by processing status"),
+      limit: z
+        .number()
+        .int()
+        .positive()
+        .optional()
+        .default(20)
+        .describe("Maximum number of results (default: 20)"),
+      offset: z
+        .number()
+        .int()
+        .nonnegative()
+        .optional()
+        .default(0)
+        .describe("Pagination offset (default: 0)"),
+      ...cdpConnectionSchema,
+    },
+    async ({ campaignId, actionId, status, limit, offset, cdpPort, cdpHost, allowRemote }) => {
+      try {
+        const result = await campaignListPeople({ campaignId, actionId, status, limit, offset, cdpPort, cdpHost, allowRemote });
+        return mcpSuccess(JSON.stringify(result, null, 2));
+      } catch (error) {
+        if (error instanceof ActionNotFoundError) {
+          return mcpError(`Action ${String(actionId)} not found in campaign ${String(campaignId)}.`);
+        }
+        return mcpCatchAll(error, "Failed to list campaign people");
+      }
+    },
+  );
+}

--- a/packages/mcp/src/tools/index.ts
+++ b/packages/mcp/src/tools/index.ts
@@ -12,6 +12,7 @@ import { registerCampaignExcludeRemove } from "./campaign-exclude-remove.js";
 import { registerCampaignExport } from "./campaign-export.js";
 import { registerCampaignGet } from "./campaign-get.js";
 import { registerCampaignList } from "./campaign-list.js";
+import { registerCampaignListPeople } from "./campaign-list-people.js";
 import { registerCampaignMoveNext } from "./campaign-move-next.js";
 import { registerCampaignRemoveAction } from "./campaign-remove-action.js";
 import { registerCampaignReorderActions } from "./campaign-reorder-actions.js";
@@ -47,6 +48,7 @@ export {
   registerCampaignExport,
   registerCampaignGet,
   registerCampaignList,
+  registerCampaignListPeople,
   registerCampaignMoveNext,
   registerCampaignRemoveAction,
   registerCampaignReorderActions,
@@ -83,6 +85,7 @@ export function registerAllTools(server: McpServer): void {
   registerCampaignExport(server);
   registerCampaignGet(server);
   registerCampaignList(server);
+  registerCampaignListPeople(server);
   registerCampaignMoveNext(server);
   registerCampaignRemoveAction(server);
   registerCampaignReorderActions(server);


### PR DESCRIPTION
## Summary

- Add `campaign-list-people` MCP tool, CLI command, and core operation to list people assigned to a campaign
- Support optional filtering by `actionId` and `status` (queued/processed/successful/failed), plus `limit`/`offset` pagination
- Return person records with `personId`, `firstName`, `lastName`, `publicId` (LinkedIn slug), `status`, and `currentActionId`

Closes #374

## Test plan

- [x] Unit tests for core operation (`campaign-list-people.test.ts`)
- [x] Unit tests for MCP tool registration and error handling (`campaign-list-people.test.ts`)
- [x] Unit tests for CLI handler with human-readable and JSON output (`campaign-list-people.test.ts`)
- [x] Updated program test to include new command (34 commands)
- [x] Updated server test to include new tool (34 tools)
- [x] All existing tests continue to pass
- [x] Build and lint pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)