### PR TITLE
Add includePositions option to query-profile for career history

### DIFF
--- a/packages/cli/src/handlers/query-profile.test.ts
+++ b/packages/cli/src/handlers/query-profile.test.ts
@@ -35,15 +35,6 @@ const MOCK_PROFILE: Profile = {
     { externalId: "987654321", typeGroup: "member", isMemberId: true },
   ],
   currentPosition: { company: "Acme Corp", title: "Engineering Manager" },
-  positions: [
-    {
-      company: "Acme Corp",
-      title: "Engineering Manager",
-      startDate: "2020-01",
-      endDate: null,
-      isCurrent: true,
-    },
-  ],
   education: [
     {
       school: "MIT",
@@ -57,11 +48,35 @@ const MOCK_PROFILE: Profile = {
   emails: ["jane@acme.com"],
 };
 
-function mockRepo(profile: Profile = MOCK_PROFILE) {
+const MOCK_PROFILE_WITH_POSITIONS: Profile = {
+  ...MOCK_PROFILE,
+  positions: [
+    {
+      company: "Acme Corp",
+      title: "Engineering Manager",
+      startDate: "2020-01",
+      endDate: null,
+      isCurrent: true,
+    },
+    {
+      company: "Startup Inc",
+      title: "Senior Engineer",
+      startDate: "2018-06",
+      endDate: "2019-12",
+      isCurrent: false,
+    },
+  ],
+};
+
+function mockRepo(profile: Profile = MOCK_PROFILE, profileWithPositions: Profile = MOCK_PROFILE_WITH_POSITIONS) {
   vi.mocked(ProfileRepository).mockImplementation(function () {
     return {
-      findById: vi.fn().mockReturnValue(profile),
-      findByPublicId: vi.fn().mockReturnValue(profile),
+      findById: vi.fn().mockImplementation((_id: number, options?: { includePositions?: boolean }) =>
+        options?.includePositions ? profileWithPositions : profile,
+      ),
+      findByPublicId: vi.fn().mockImplementation((_slug: string, options?: { includePositions?: boolean }) =>
+        options?.includePositions ? profileWithPositions : profile,
+      ),
     } as unknown as ProfileRepository;
   });
 }
@@ -209,6 +224,56 @@ describe("handleQueryProfile", () => {
     expect(stdoutSpy).toHaveBeenCalledWith("Jane Doe (#12345)\n");
   });
 
+  it("prints positions when --include-positions is set", async () => {
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockReturnValue(true);
+
+    setupSuccessPath();
+
+    await handleQueryProfile({ personId: 12345, includePositions: true });
+
+    expect(process.exitCode).toBeUndefined();
+    expect(stdoutSpy).toHaveBeenCalledWith("\nPositions:\n");
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      "  Engineering Manager at Acme Corp (2020-01 – present)\n",
+    );
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      "  Senior Engineer at Startup Inc (2018-06 – 2019-12)\n",
+    );
+  });
+
+  it("does not print positions section by default", async () => {
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockReturnValue(true);
+
+    setupSuccessPath();
+
+    await handleQueryProfile({ personId: 12345 });
+
+    const calls = stdoutSpy.mock.calls.map((c) => String(c[0]));
+    expect(calls).not.toContainEqual(expect.stringContaining("Positions:"));
+  });
+
+  it("includes positions in JSON output when --include-positions is set", async () => {
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockReturnValue(true);
+
+    setupSuccessPath();
+
+    await handleQueryProfile({ personId: 12345, includePositions: true, json: true });
+
+    expect(process.exitCode).toBeUndefined();
+    const output = stdoutSpy.mock.calls
+      .map((call) => String(call[0]))
+      .join("");
+    const parsed = JSON.parse(output);
+    expect(parsed.positions).toHaveLength(2);
+    expect(parsed.positions[0].company).toBe("Acme Corp");
+  });
+
   it("handles profile with no headline or current position", async () => {
     const stdoutSpy = vi
       .spyOn(process.stdout, "write")
@@ -224,7 +289,6 @@ describe("handleQueryProfile", () => {
       },
       externalIds: [],
       currentPosition: null,
-      positions: [],
       education: [],
       skills: [],
       emails: [],

--- a/packages/cli/src/handlers/query-profile.ts
+++ b/packages/cli/src/handlers/query-profile.ts
@@ -14,9 +14,10 @@ import {
 export async function handleQueryProfile(options: {
   personId?: number;
   publicId?: string;
+  includePositions?: boolean;
   json?: boolean;
 }): Promise<void> {
-  const { personId, publicId } = options;
+  const { personId, publicId, includePositions } = options;
 
   if ((personId == null) === (publicId == null)) {
     process.stderr.write(
@@ -39,10 +40,11 @@ export async function handleQueryProfile(options: {
     const db = new DatabaseClient(dbPath);
     try {
       const repo = new ProfileRepository(db);
+      const findOptions = { includePositions: includePositions === true };
       found =
         personId != null
-          ? repo.findById(personId)
-          : repo.findByPublicId(publicId as string);
+          ? repo.findById(personId, findOptions)
+          : repo.findByPublicId(publicId as string, findOptions);
       break;
     } catch (error) {
       if (error instanceof ProfileNotFoundError) {
@@ -83,6 +85,17 @@ export async function handleQueryProfile(options: {
       ].filter(Boolean);
       if (parts.length > 0) {
         process.stdout.write(`\nCurrent: ${parts.join(" at ")}\n`);
+      }
+    }
+
+    if (found.positions && found.positions.length > 0) {
+      process.stdout.write("\nPositions:\n");
+      for (const pos of found.positions) {
+        const role = [pos.title, pos.company].filter(Boolean).join(" at ");
+        const dates = [pos.startDate ?? "?", pos.endDate ?? "present"].join(
+          " – ",
+        );
+        process.stdout.write(`  ${role} (${dates})\n`);
       }
     }
 

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -417,6 +417,7 @@ export function createProgram(): Command {
     .description("Look up a cached profile from the local database")
     .option("--person-id <id>", "Look up by internal person ID", parsePositiveInt)
     .option("--public-id <slug>", "Look up by LinkedIn public ID")
+    .option("--include-positions", "Include full position history (career history)")
     .option("--json", "Output as JSON")
     .action(handleQueryProfile);
 

--- a/packages/core/src/db/repositories/profile.integration.test.ts
+++ b/packages/core/src/db/repositories/profile.integration.test.ts
@@ -54,17 +54,8 @@ describe("ProfileRepository (integration)", () => {
       expect(profile.currentPosition?.company).toBe("Babbage Industries");
       expect(profile.currentPosition?.title).toBe("Lead Programmer");
 
-      // Position history with year-month formatting
-      expect(profile.positions.length).toBeGreaterThanOrEqual(2);
-      const currentPos = profile.positions.find((p) => p.isCurrent);
-      expect(currentPos?.company).toBe("Babbage Industries");
-      expect(currentPos?.startDate).toBe("2020-03");
-      expect(currentPos?.endDate).toBeNull();
-
-      const pastPos = profile.positions.find((p) => !p.isCurrent);
-      expect(pastPos?.company).toBe("Difference Engine Co");
-      expect(pastPos?.startDate).toBe("2015-09");
-      expect(pastPos?.endDate).toBe("2019-12");
+      // Positions omitted by default
+      expect(profile.positions).toBeUndefined();
 
       // Education with year-only formatting
       expect(profile.education.length).toBeGreaterThanOrEqual(1);
@@ -84,6 +75,22 @@ describe("ProfileRepository (integration)", () => {
       expect(profile.emails).toContain("ada@example.test");
     });
 
+    it("includes position history when includePositions is true", () => {
+      const profile = repo.findById(1, { includePositions: true });
+      const positions = profile.positions ?? [];
+
+      expect(positions.length).toBeGreaterThanOrEqual(2);
+      const currentPos = positions.find((p) => p.isCurrent);
+      expect(currentPos?.company).toBe("Babbage Industries");
+      expect(currentPos?.startDate).toBe("2020-03");
+      expect(currentPos?.endDate).toBeNull();
+
+      const pastPos = positions.find((p) => !p.isCurrent);
+      expect(pastPos?.company).toBe("Difference Engine Co");
+      expect(pastPos?.startDate).toBe("2015-09");
+      expect(pastPos?.endDate).toBe("2019-12");
+    });
+
     it("assembles a minimal profile without optional data", () => {
       const profile = repo.findById(2);
 
@@ -93,7 +100,7 @@ describe("ProfileRepository (integration)", () => {
       expect(profile.miniProfile.headline).toBeNull();
       expect(profile.miniProfile.avatar).toBeNull();
       expect(profile.currentPosition).toBeNull();
-      expect(profile.positions).toEqual([]);
+      expect(profile.positions).toBeUndefined();
       expect(profile.education).toEqual([]);
       expect(profile.skills).toEqual([]);
       expect(profile.emails).toEqual([]);
@@ -146,8 +153,8 @@ describe("ProfileRepository (integration)", () => {
     });
 
     it("current position and position history agree on current role", () => {
-      const profile = repo.findById(1);
-      const currentPos = profile.positions.find((p) => p.isCurrent);
+      const profile = repo.findById(1, { includePositions: true });
+      const currentPos = profile.positions?.find((p) => p.isCurrent);
 
       expect(profile.currentPosition).not.toBeNull();
       expect(currentPos).toBeDefined();

--- a/packages/core/src/db/repositories/profile.test.ts
+++ b/packages/core/src/db/repositories/profile.test.ts
@@ -38,7 +38,7 @@ describe("ProfileRepository", () => {
   });
 
   describe("findById", () => {
-    it("returns a fully assembled profile", () => {
+    it("returns a fully assembled profile without positions by default", () => {
       const profile = repo.findById(1);
 
       expect(profile.id).toBe(1);
@@ -71,21 +71,7 @@ describe("ProfileRepository", () => {
         title: "Lead Programmer",
       });
 
-      expect(profile.positions).toHaveLength(2);
-      expect(profile.positions).toContainEqual({
-        company: "Babbage Industries",
-        title: "Lead Programmer",
-        startDate: "2020-03",
-        endDate: null,
-        isCurrent: true,
-      });
-      expect(profile.positions).toContainEqual({
-        company: "Difference Engine Co",
-        title: "Junior Analyst",
-        startDate: "2015-09",
-        endDate: "2019-12",
-        isCurrent: false,
-      });
+      expect(profile.positions).toBeUndefined();
 
       expect(profile.education).toHaveLength(2);
       expect(profile.education).toContainEqual({
@@ -111,6 +97,26 @@ describe("ProfileRepository", () => {
       expect(profile.emails).toEqual(["ada@example.test"]);
     });
 
+    it("includes positions when includePositions is true", () => {
+      const profile = repo.findById(1, { includePositions: true });
+
+      expect(profile.positions).toHaveLength(2);
+      expect(profile.positions).toContainEqual({
+        company: "Babbage Industries",
+        title: "Lead Programmer",
+        startDate: "2020-03",
+        endDate: null,
+        isCurrent: true,
+      });
+      expect(profile.positions).toContainEqual({
+        company: "Difference Engine Co",
+        title: "Junior Analyst",
+        startDate: "2015-09",
+        endDate: "2019-12",
+        isCurrent: false,
+      });
+    });
+
     it("throws ProfileNotFoundError for a missing ID", () => {
       expect(() => repo.findById(999)).toThrow(ProfileNotFoundError);
       expect(() => repo.findById(999)).toThrow("Profile not found for id 999");
@@ -126,10 +132,16 @@ describe("ProfileRepository", () => {
       expect(profile.miniProfile.avatar).toBeNull();
       expect(profile.externalIds).toHaveLength(1);
       expect(profile.currentPosition).toBeNull();
-      expect(profile.positions).toEqual([]);
+      expect(profile.positions).toBeUndefined();
       expect(profile.education).toEqual([]);
       expect(profile.skills).toEqual([]);
       expect(profile.emails).toEqual([]);
+    });
+
+    it("returns empty positions array when includePositions is true but person has none", () => {
+      const profile = repo.findById(2, { includePositions: true });
+
+      expect(profile.positions).toEqual([]);
     });
 
     it("handles multiple emails", () => {

--- a/packages/core/src/db/repositories/profile.ts
+++ b/packages/core/src/db/repositories/profile.ts
@@ -9,6 +9,7 @@ import type {
   MiniProfile,
   Position,
   Profile,
+  ProfileFindOptions,
   ProfileSearchOptions,
   ProfileSearchResult,
   ProfileSummary,
@@ -205,10 +206,10 @@ export class ProfileRepository {
    *
    * @throws {ProfileNotFoundError} if no person exists with the given ID.
    */
-  findById(id: number): Profile {
+  findById(id: number, options?: ProfileFindOptions): Profile {
     const row = this.stmtPersonById.get(id) as { id: number } | undefined;
     if (!row) throw new ProfileNotFoundError(id);
-    return this.assembleProfile(row.id);
+    return this.assembleProfile(row.id, options);
   }
 
   /**
@@ -216,12 +217,12 @@ export class ProfileRepository {
    *
    * @throws {ProfileNotFoundError} if no person matches the public ID.
    */
-  findByPublicId(slug: string): Profile {
+  findByPublicId(slug: string, options?: ProfileFindOptions): Profile {
     const row = this.stmtPersonByPublicId.get(slug) as
       | { id: number }
       | undefined;
     if (!row) throw new ProfileNotFoundError(slug);
-    return this.assembleProfile(row.id);
+    return this.assembleProfile(row.id, options);
   }
 
   /**
@@ -270,7 +271,9 @@ export class ProfileRepository {
     return { profiles, total };
   }
 
-  private assembleProfile(personId: number): Profile {
+  private assembleProfile(personId: number, options?: ProfileFindOptions): Profile {
+    const { includePositions = false } = options ?? {};
+
     const miniRow = this.stmtMiniProfile.get(personId) as
       | MiniProfileRow
       | undefined;
@@ -298,15 +301,17 @@ export class ProfileRepository {
       ? { company: cpRow.company, title: cpRow.position }
       : null;
 
-    const positions: Position[] = (
-      this.stmtPositions.all(personId) as unknown as PositionRow[]
-    ).map((r) => ({
-      company: r.company_name,
-      title: r.title,
-      startDate: formatDate(r.start_year, r.start_month),
-      endDate: formatDate(r.end_year, r.end_month),
-      isCurrent: r.is_default != null,
-    }));
+    const positions: Position[] | undefined = includePositions
+      ? (
+          this.stmtPositions.all(personId) as unknown as PositionRow[]
+        ).map((r) => ({
+          company: r.company_name,
+          title: r.title,
+          startDate: formatDate(r.start_year, r.start_month),
+          endDate: formatDate(r.end_year, r.end_month),
+          isCurrent: r.is_default != null,
+        }))
+      : undefined;
 
     const education: Education[] = (
       this.stmtEducation.all(personId) as unknown as EducationRow[]
@@ -331,7 +336,7 @@ export class ProfileRepository {
       miniProfile,
       externalIds,
       currentPosition,
-      positions,
+      ...(positions !== undefined && { positions }),
       education,
       skills,
       emails,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -50,6 +50,7 @@ export type {
   PopupState,
   Position,
   Profile,
+  ProfileFindOptions,
   ProfileSearchOptions,
   ProfileSearchResult,
   ProfileSummary,

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -9,6 +9,7 @@ export type {
   MiniProfile,
   Position,
   Profile,
+  ProfileFindOptions,
   ProfileSearchOptions,
   ProfileSearchResult,
   ProfileSummary,

--- a/packages/core/src/types/profile.test.ts
+++ b/packages/core/src/types/profile.test.ts
@@ -13,7 +13,7 @@ import type {
 } from "./profile.js";
 
 describe("Profile types", () => {
-  it("should allow constructing a full Profile", () => {
+  it("should allow constructing a full Profile with positions", () => {
     const profile: Profile = {
       id: 1,
       miniProfile: {
@@ -53,10 +53,30 @@ describe("Profile types", () => {
     expect(profile.miniProfile.firstName).toBe("Jane");
     expect(profile.externalIds).toHaveLength(2);
     expect(profile.currentPosition?.company).toBe("Acme Corp");
-    expect(profile.positions[0]?.isCurrent).toBe(true);
+    expect(profile.positions?.[0]?.isCurrent).toBe(true);
     expect(profile.education[0]?.school).toBe("MIT");
     expect(profile.skills[0]?.name).toBe("TypeScript");
     expect(profile.emails[0]).toBe("jane@example.com");
+  });
+
+  it("should allow constructing a Profile without positions", () => {
+    const profile: Profile = {
+      id: 2,
+      miniProfile: {
+        firstName: "Bob",
+        lastName: null,
+        headline: null,
+        avatar: null,
+      },
+      externalIds: [],
+      currentPosition: null,
+      education: [],
+      skills: [],
+      emails: [],
+    };
+
+    expect(profile.id).toBe(2);
+    expect(profile.positions).toBeUndefined();
   });
 
   it("should allow nullable fields", () => {
@@ -91,7 +111,6 @@ describe("Profile types", () => {
       miniProfile: mini,
       externalIds: [],
       currentPosition: null,
-      positions: [],
       education: [],
       skills: [],
       emails: [],

--- a/packages/core/src/types/profile.ts
+++ b/packages/core/src/types/profile.ts
@@ -53,10 +53,18 @@ export interface Profile {
   miniProfile: MiniProfile;
   externalIds: ExternalId[];
   currentPosition: CurrentPosition | null;
-  positions: Position[];
+  positions?: Position[];
   education: Education[];
   skills: Skill[];
   emails: string[];
+}
+
+/**
+ * Options for looking up a single profile.
+ */
+export interface ProfileFindOptions {
+  /** When true, include full position history in the response (default: false) */
+  includePositions?: boolean;
 }
 
 /**

--- a/packages/e2e/src/app.e2e.test.ts
+++ b/packages/e2e/src/app.e2e.test.ts
@@ -549,7 +549,7 @@ describeE2E("App lifecycle", () => {
         .spyOn(process.stdout, "write")
         .mockReturnValue(true);
 
-      await handleQueryProfile({ publicId: "williamhgates", json: true });
+      await handleQueryProfile({ publicId: "williamhgates", includePositions: true, json: true });
 
       expect(process.exitCode).toBeUndefined();
       expect(stdoutSpy).toHaveBeenCalled();
@@ -826,7 +826,7 @@ describeE2E("App lifecycle", () => {
       registerQueryProfile(server);
 
       const handler = getHandler("query-profile");
-      const result = (await handler({ publicId: "williamhgates" })) as {
+      const result = (await handler({ publicId: "williamhgates", includePositions: true })) as {
         isError?: boolean;
         content: { type: string; text: string }[];
       };

--- a/packages/mcp/src/tools/query-profile.test.ts
+++ b/packages/mcp/src/tools/query-profile.test.ts
@@ -37,15 +37,6 @@ const MOCK_PROFILE: Profile = {
     { externalId: "987654321", typeGroup: "member", isMemberId: true },
   ],
   currentPosition: { company: "Acme Corp", title: "Engineering Manager" },
-  positions: [
-    {
-      company: "Acme Corp",
-      title: "Engineering Manager",
-      startDate: "2020-01",
-      endDate: null,
-      isCurrent: true,
-    },
-  ],
   education: [
     {
       school: "MIT",
@@ -59,6 +50,26 @@ const MOCK_PROFILE: Profile = {
   emails: ["jane@acme.com"],
 };
 
+const MOCK_PROFILE_WITH_POSITIONS: Profile = {
+  ...MOCK_PROFILE,
+  positions: [
+    {
+      company: "Acme Corp",
+      title: "Engineering Manager",
+      startDate: "2020-01",
+      endDate: null,
+      isCurrent: true,
+    },
+    {
+      company: "Startup Inc",
+      title: "Senior Engineer",
+      startDate: "2018-06",
+      endDate: "2019-12",
+      isCurrent: false,
+    },
+  ],
+};
+
 function mockDb() {
   const close = vi.fn();
   vi.mocked(DatabaseClient).mockImplementation(function () {
@@ -67,11 +78,15 @@ function mockDb() {
   return { close };
 }
 
-function mockRepo(profile: Profile = MOCK_PROFILE) {
+function mockRepo(profile: Profile = MOCK_PROFILE, profileWithPositions: Profile = MOCK_PROFILE_WITH_POSITIONS) {
   vi.mocked(ProfileRepository).mockImplementation(function () {
     return {
-      findById: vi.fn().mockReturnValue(profile),
-      findByPublicId: vi.fn().mockReturnValue(profile),
+      findById: vi.fn().mockImplementation((_id: number, options?: { includePositions?: boolean }) =>
+        options?.includePositions ? profileWithPositions : profile,
+      ),
+      findByPublicId: vi.fn().mockImplementation((_slug: string, options?: { includePositions?: boolean }) =>
+        options?.includePositions ? profileWithPositions : profile,
+      ),
     } as unknown as ProfileRepository;
   });
 }
@@ -150,6 +165,37 @@ describe("registerQueryProfile", () => {
         {
           type: "text",
           text: JSON.stringify(MOCK_PROFILE, null, 2),
+        },
+      ],
+    });
+  });
+
+  it("does not include positions by default", async () => {
+    const { server, getHandler } = createMockServer();
+    registerQueryProfile(server);
+    setupSuccessPath();
+
+    const handler = getHandler("query-profile");
+    const result = await handler({ personId: 1 });
+
+    const content = (result as { content: Array<{ text: string }> }).content;
+    const parsed = JSON.parse(content[0]?.text ?? "{}");
+    expect(parsed.positions).toBeUndefined();
+  });
+
+  it("includes positions when includePositions is true", async () => {
+    const { server, getHandler } = createMockServer();
+    registerQueryProfile(server);
+    setupSuccessPath();
+
+    const handler = getHandler("query-profile");
+    const result = await handler({ personId: 1, includePositions: true });
+
+    expect(result).toEqual({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(MOCK_PROFILE_WITH_POSITIONS, null, 2),
         },
       ],
     });

--- a/packages/mcp/src/tools/query-profile.ts
+++ b/packages/mcp/src/tools/query-profile.ts
@@ -29,8 +29,14 @@ export function registerQueryProfile(server: McpServer): void {
         .describe(
           "Look up by LinkedIn public ID (profile URL slug, e.g. jane-doe-12345)",
         ),
+      includePositions: z
+        .boolean()
+        .optional()
+        .describe(
+          "When true, include full position history (career history) in the response",
+        ),
     },
-    async ({ personId, publicId }) => {
+    async ({ personId, publicId, includePositions }) => {
       if ((personId == null) === (publicId == null)) {
         return mcpError(
           "Exactly one of personId or publicId must be provided.",
@@ -46,10 +52,11 @@ export function registerQueryProfile(server: McpServer): void {
         const db = new DatabaseClient(dbPath);
         try {
           const repo = new ProfileRepository(db);
+          const findOptions = { includePositions: includePositions === true };
           const profile =
             personId != null
-              ? repo.findById(personId)
-              : repo.findByPublicId(publicId as string);
+              ? repo.findById(personId, findOptions)
+              : repo.findByPublicId(publicId as string, findOptions);
 
           return mcpSuccess(JSON.stringify(profile, null, 2));
         } catch (error) {


### PR DESCRIPTION
## Summary

- Add optional `includePositions` parameter (default `false`) to the `query-profile` MCP tool and CLI command
- When enabled, includes full position history (company, title, startDate, endDate, isCurrent) in the response
- Make `positions` optional on the `Profile` type to keep the default response lightweight
- Add `ProfileFindOptions` type and thread through `ProfileRepository.findById()`/`findByPublicId()`
- Add `--include-positions` CLI flag with human-friendly career history display

Closes #377

## Test plan

- [x] Unit tests: `ProfileRepository` returns positions only when `includePositions: true`, undefined otherwise
- [x] Unit tests: MCP tool forwards `includePositions` to repository; tests for both modes
- [x] Unit tests: CLI handler displays "Positions:" section only when flag set; JSON includes positions
- [x] Integration tests: real SQLite fixture verified with and without `includePositions`
- [x] E2E tests: updated to pass `includePositions: true` where positions are expected
- [x] Lint passes across all packages
- [x] Build passes across all packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)