### PR TITLE
Add query-profiles-bulk for batch profile lookups

### DIFF
--- a/packages/cli/src/handlers/index.ts
+++ b/packages/cli/src/handlers/index.ts
@@ -31,6 +31,7 @@ export { handleGetErrors } from "./get-errors.js";
 export { handleQueryMessages } from "./query-messages.js";
 export { handleQueryProfile } from "./query-profile.js";
 export { handleQueryProfiles } from "./query-profiles.js";
+export { handleQueryProfilesBulk } from "./query-profiles-bulk.js";
 export { handleScrapeMessagingHistory } from "./scrape-messaging-history.js";
 export { handleLaunchApp } from "./launch-app.js";
 export { handleListAccounts } from "./list-accounts.js";

--- a/packages/cli/src/handlers/query-profiles-bulk.test.ts
+++ b/packages/cli/src/handlers/query-profiles-bulk.test.ts
@@ -1,0 +1,291 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return {
+    ...actual,
+    DatabaseClient: vi.fn(),
+    ProfileRepository: vi.fn(),
+    discoverAllDatabases: vi.fn(),
+  };
+});
+
+import {
+  type Profile,
+  ProfileRepository,
+} from "@lhremote/core";
+
+import { handleQueryProfilesBulk } from "./query-profiles-bulk.js";
+import { mockDb, mockDiscovery } from "./testing/mock-helpers.js";
+
+const PROFILE_JANE: Profile = {
+  id: 1,
+  miniProfile: {
+    firstName: "Jane",
+    lastName: "Doe",
+    headline: "Engineering Manager at Acme",
+    avatar: null,
+  },
+  externalIds: [
+    { externalId: "jane-doe-12345", typeGroup: "public", isMemberId: false },
+  ],
+  currentPosition: { company: "Acme Corp", title: "Engineering Manager" },
+  education: [],
+  skills: [],
+  emails: [],
+};
+
+const PROFILE_BOB: Profile = {
+  id: 2,
+  miniProfile: {
+    firstName: "Bob",
+    lastName: null,
+    headline: "Developer",
+    avatar: null,
+  },
+  externalIds: [],
+  currentPosition: null,
+  education: [],
+  skills: [],
+  emails: [],
+};
+
+function mockRepo() {
+  vi.mocked(ProfileRepository).mockImplementation(function () {
+    return {
+      findByIds: vi.fn().mockImplementation((ids: number[]) =>
+        ids.map((id) => {
+          if (id === 1) return PROFILE_JANE;
+          if (id === 2) return PROFILE_BOB;
+          return null;
+        }),
+      ),
+      findByPublicIds: vi.fn().mockImplementation((slugs: string[]) =>
+        slugs.map((s) => {
+          if (s === "jane-doe-12345") return PROFILE_JANE;
+          return null;
+        }),
+      ),
+    } as unknown as ProfileRepository;
+  });
+}
+
+function setupSuccessPath() {
+  mockDiscovery();
+  mockDb();
+  mockRepo();
+}
+
+describe("handleQueryProfilesBulk", () => {
+  const originalExitCode = process.exitCode;
+
+  beforeEach(() => {
+    process.exitCode = undefined;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.exitCode = originalExitCode;
+    vi.restoreAllMocks();
+  });
+
+  it("sets exitCode 1 when no IDs provided", async () => {
+    const stderrSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockReturnValue(true);
+
+    await handleQueryProfilesBulk({});
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "At least one --person-id or --public-id must be provided.\n",
+    );
+  });
+
+  it("sets exitCode 1 when no databases found", async () => {
+    const stderrSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockReturnValue(true);
+
+    mockDiscovery(new Map());
+
+    await handleQueryProfilesBulk({ personId: [1] });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "No LinkedHelper databases found.\n",
+    );
+  });
+
+  it("prints JSON with --json", async () => {
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockReturnValue(true);
+
+    setupSuccessPath();
+
+    await handleQueryProfilesBulk({ personId: [1, 2], json: true });
+
+    expect(process.exitCode).toBeUndefined();
+    const output = stdoutSpy.mock.calls
+      .map((call) => String(call[0]))
+      .join("");
+    const parsed = JSON.parse(output);
+    expect(parsed.byPersonId).toHaveLength(2);
+    expect(parsed.byPersonId[0].id).toBe(1);
+    expect(parsed.byPersonId[1].id).toBe(2);
+  });
+
+  it("prints JSON with null for not-found IDs", async () => {
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockReturnValue(true);
+
+    setupSuccessPath();
+
+    await handleQueryProfilesBulk({ personId: [1, 999], json: true });
+
+    const output = stdoutSpy.mock.calls
+      .map((call) => String(call[0]))
+      .join("");
+    const parsed = JSON.parse(output);
+    expect(parsed.byPersonId[0].id).toBe(1);
+    expect(parsed.byPersonId[1]).toBeNull();
+  });
+
+  it("prints human-friendly output", async () => {
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockReturnValue(true);
+
+    setupSuccessPath();
+
+    await handleQueryProfilesBulk({ personId: [1, 2] });
+
+    expect(process.exitCode).toBeUndefined();
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      "Found 2 profile(s):\n\n",
+    );
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      "#1  Jane Doe -- Engineering Manager at Acme Corp\n",
+    );
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      "#2  Bob -- Developer\n",
+    );
+  });
+
+  it("shows not-found count in human-friendly output", async () => {
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockReturnValue(true);
+
+    setupSuccessPath();
+
+    await handleQueryProfilesBulk({ personId: [1, 999] });
+
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      "Found 1 profile(s), 1 not found:\n\n",
+    );
+  });
+
+  it("sets exitCode 1 when no profiles found at all", async () => {
+    const stderrSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockReturnValue(true);
+
+    mockDiscovery();
+    mockDb();
+    vi.mocked(ProfileRepository).mockImplementation(function () {
+      return {
+        findByIds: vi.fn().mockImplementation((ids: number[]) =>
+          ids.map(() => null),
+        ),
+        findByPublicIds: vi.fn().mockReturnValue([]),
+      } as unknown as ProfileRepository;
+    });
+
+    await handleQueryProfilesBulk({ personId: [999] });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("No profiles found.\n");
+  });
+
+  it("supports publicId lookups", async () => {
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockReturnValue(true);
+
+    setupSuccessPath();
+
+    await handleQueryProfilesBulk({
+      publicId: ["jane-doe-12345"],
+      json: true,
+    });
+
+    const output = stdoutSpy.mock.calls
+      .map((call) => String(call[0]))
+      .join("");
+    const parsed = JSON.parse(output);
+    expect(parsed.byPublicId).toHaveLength(1);
+    expect(parsed.byPublicId[0].id).toBe(1);
+  });
+
+  it("supports both personId and publicId together", async () => {
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockReturnValue(true);
+
+    setupSuccessPath();
+
+    await handleQueryProfilesBulk({
+      personId: [2],
+      publicId: ["jane-doe-12345"],
+      json: true,
+    });
+
+    const output = stdoutSpy.mock.calls
+      .map((call) => String(call[0]))
+      .join("");
+    const parsed = JSON.parse(output);
+    expect(parsed.byPersonId).toHaveLength(1);
+    expect(parsed.byPersonId[0].id).toBe(2);
+    expect(parsed.byPublicId).toHaveLength(1);
+    expect(parsed.byPublicId[0].id).toBe(1);
+  });
+
+  it("closes database after lookup", async () => {
+    vi.spyOn(process.stdout, "write").mockReturnValue(true);
+
+    mockDiscovery();
+    const { close } = mockDb();
+    mockRepo();
+
+    await handleQueryProfilesBulk({ personId: [1] });
+
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("sets exitCode 1 on unexpected database error", async () => {
+    const stderrSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockReturnValue(true);
+
+    mockDiscovery();
+    mockDb();
+    vi.mocked(ProfileRepository).mockImplementation(function () {
+      return {
+        findByIds: vi.fn().mockImplementation(() => {
+          throw new Error("database locked");
+        }),
+      } as unknown as ProfileRepository;
+    });
+
+    await handleQueryProfilesBulk({ personId: [1] });
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("database locked\n");
+  });
+});

--- a/packages/cli/src/handlers/query-profiles-bulk.ts
+++ b/packages/cli/src/handlers/query-profiles-bulk.ts
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import {
+  type Profile,
+  DatabaseClient,
+  discoverAllDatabases,
+  errorMessage,
+  ProfileRepository,
+} from "@lhremote/core";
+
+/** Handle the {@link https://github.com/alexey-pelykh/lhremote#profiles--messaging | query-profiles-bulk} CLI command. */
+export async function handleQueryProfilesBulk(options: {
+  personId?: number[];
+  publicId?: string[];
+  includePositions?: boolean;
+  json?: boolean;
+}): Promise<void> {
+  const personIds = options.personId ?? [];
+  const publicIds = options.publicId ?? [];
+
+  if (personIds.length === 0 && publicIds.length === 0) {
+    process.stderr.write(
+      "At least one --person-id or --public-id must be provided.\n",
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const databases = discoverAllDatabases();
+  if (databases.size === 0) {
+    process.stderr.write("No LinkedHelper databases found.\n");
+    process.exitCode = 1;
+    return;
+  }
+
+  const findOptions = { includePositions: options.includePositions === true };
+
+  const byPersonId = new Map<number, Profile>();
+  const byPublicId = new Map<string, Profile>();
+
+  for (const [, dbPath] of databases) {
+    const db = new DatabaseClient(dbPath);
+    try {
+      const repo = new ProfileRepository(db);
+
+      if (personIds.length > 0) {
+        const remaining = personIds.filter((id) => !byPersonId.has(id));
+        if (remaining.length > 0) {
+          const results = repo.findByIds(remaining, findOptions);
+          for (const [i, id] of remaining.entries()) {
+            const profile = results[i];
+            if (profile != null) {
+              byPersonId.set(id, profile);
+            }
+          }
+        }
+      }
+
+      if (publicIds.length > 0) {
+        const remaining = publicIds.filter((s) => !byPublicId.has(s));
+        if (remaining.length > 0) {
+          const results = repo.findByPublicIds(remaining, findOptions);
+          for (const [i, slug] of remaining.entries()) {
+            const profile = results[i];
+            if (profile != null) {
+              byPublicId.set(slug, profile);
+            }
+          }
+        }
+      }
+    } catch (error) {
+      const message = errorMessage(error);
+      process.stderr.write(`${message}\n`);
+      process.exitCode = 1;
+      return;
+    } finally {
+      db.close();
+    }
+  }
+
+  const result: {
+    byPersonId?: (Profile | null)[];
+    byPublicId?: (Profile | null)[];
+  } = {};
+
+  if (personIds.length > 0) {
+    result.byPersonId = personIds.map((id) => byPersonId.get(id) ?? null);
+  }
+  if (publicIds.length > 0) {
+    result.byPublicId = publicIds.map((s) => byPublicId.get(s) ?? null);
+  }
+
+  if (options.json) {
+    process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+  } else {
+    const allProfiles: (Profile | null)[] = [
+      ...(result.byPersonId ?? []),
+      ...(result.byPublicId ?? []),
+    ];
+
+    const found = allProfiles.filter((p): p is Profile => p != null);
+    const notFound = allProfiles.filter((p) => p == null).length;
+
+    if (found.length === 0) {
+      process.stderr.write("No profiles found.\n");
+      process.exitCode = 1;
+      return;
+    }
+
+    process.stdout.write(
+      `Found ${String(found.length)} profile(s)` +
+        (notFound > 0 ? `, ${String(notFound)} not found` : "") +
+        ":\n\n",
+    );
+
+    for (const profile of found) {
+      const name = [profile.miniProfile.firstName, profile.miniProfile.lastName]
+        .filter(Boolean)
+        .join(" ");
+
+      let line = `#${String(profile.id)}  ${name}`;
+      if (profile.currentPosition) {
+        const parts = [
+          profile.currentPosition.title,
+          profile.currentPosition.company,
+        ].filter(Boolean);
+        if (parts.length > 0) {
+          line += ` -- ${parts.join(" at ")}`;
+        }
+      } else if (profile.miniProfile.headline) {
+        line += ` -- ${profile.miniProfile.headline}`;
+      }
+      process.stdout.write(`${line}\n`);
+    }
+  }
+}

--- a/packages/cli/src/program.test.ts
+++ b/packages/cli/src/program.test.ts
@@ -72,7 +72,7 @@ describe("createProgram", () => {
     expect(commandNames).toContain("campaign-update-action");
     expect(commandNames).toContain("campaign-remove-people");
     expect(commandNames).toContain("get-errors");
-    expect(commandNames).toHaveLength(36);
+    expect(commandNames).toHaveLength(37);
   });
 
   describe("launch-app", () => {

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -38,6 +38,7 @@ import {
   handleQueryMessages,
   handleQueryProfile,
   handleQueryProfiles,
+  handleQueryProfilesBulk,
   handleScrapeMessagingHistory,
   handleQuitApp,
   handleStartInstance,
@@ -76,6 +77,16 @@ function parseNonNegativeInt(value: string): number {
     );
   }
   return n;
+}
+
+/** Collect repeatable positive integer values into an array. */
+function collectPositiveInt(value: string, previous: number[]): number[] {
+  return [...previous, parsePositiveInt(value)];
+}
+
+/** Collect repeatable string values into an array. */
+function collectString(value: string, previous: string[]): string[] {
+  return [...previous, value];
 }
 
 /**
@@ -470,6 +481,15 @@ export function createProgram(): Command {
     .option("--offset <n>", "Pagination offset (default: 0)", parseNonNegativeInt)
     .option("--json", "Output as JSON")
     .action(handleQueryProfiles);
+
+  program
+    .command("query-profiles-bulk")
+    .description("Look up multiple cached profiles from the local database in a single call")
+    .option("--person-id <id>", "Look up by internal person ID (repeatable)", collectPositiveInt, [])
+    .option("--public-id <slug>", "Look up by LinkedIn public ID (repeatable)", collectString, [])
+    .option("--include-positions", "Include full position history (career history)")
+    .option("--json", "Output as JSON")
+    .action(handleQueryProfilesBulk);
 
   program
     .command("scrape-messaging-history")

--- a/packages/core/src/db/repositories/profile.test.ts
+++ b/packages/core/src/db/repositories/profile.test.ts
@@ -178,6 +178,87 @@ describe("ProfileRepository", () => {
     });
   });
 
+  describe("findByIds", () => {
+    it("returns profiles in the same order as input IDs", () => {
+      const results = repo.findByIds([3, 1]);
+
+      expect(results).toHaveLength(2);
+      expect(results[0]?.id).toBe(3);
+      expect(results[0]?.miniProfile.firstName).toBe("Grace");
+      expect(results[1]?.id).toBe(1);
+      expect(results[1]?.miniProfile.firstName).toBe("Ada");
+    });
+
+    it("returns null for IDs that do not exist", () => {
+      const results = repo.findByIds([1, 999, 3]);
+
+      expect(results).toHaveLength(3);
+      expect(results[0]?.id).toBe(1);
+      expect(results[1]).toBeNull();
+      expect(results[2]?.id).toBe(3);
+    });
+
+    it("returns empty array for empty input", () => {
+      expect(repo.findByIds([])).toEqual([]);
+    });
+
+    it("passes includePositions option to assembled profiles", () => {
+      const results = repo.findByIds([1], { includePositions: true });
+
+      expect(results).toHaveLength(1);
+      expect(results[0]?.positions).toHaveLength(2);
+    });
+
+    it("returns all nulls when no IDs match", () => {
+      const results = repo.findByIds([900, 901]);
+
+      expect(results).toEqual([null, null]);
+    });
+  });
+
+  describe("findByPublicIds", () => {
+    it("returns profiles in the same order as input slugs", () => {
+      const results = repo.findByPublicIds([
+        "grace-hopper-test",
+        "ada-lovelace-test",
+      ]);
+
+      expect(results).toHaveLength(2);
+      expect(results[0]?.id).toBe(3);
+      expect(results[1]?.id).toBe(1);
+    });
+
+    it("returns null for slugs that do not exist", () => {
+      const results = repo.findByPublicIds([
+        "ada-lovelace-test",
+        "nonexistent",
+      ]);
+
+      expect(results).toHaveLength(2);
+      expect(results[0]?.id).toBe(1);
+      expect(results[1]).toBeNull();
+    });
+
+    it("returns empty array for empty input", () => {
+      expect(repo.findByPublicIds([])).toEqual([]);
+    });
+
+    it("passes includePositions option to assembled profiles", () => {
+      const results = repo.findByPublicIds(["ada-lovelace-test"], {
+        includePositions: true,
+      });
+
+      expect(results).toHaveLength(1);
+      expect(results[0]?.positions).toHaveLength(2);
+    });
+
+    it("returns all nulls when no slugs match", () => {
+      const results = repo.findByPublicIds(["no-one", "nobody"]);
+
+      expect(results).toEqual([null, null]);
+    });
+  });
+
   describe("search", () => {
     it("returns all profiles when no filters specified", () => {
       const result = repo.search({});

--- a/packages/core/src/db/repositories/profile.ts
+++ b/packages/core/src/db/repositories/profile.ts
@@ -87,6 +87,7 @@ function formatDate(
  * LinkedHelper's SQLite database.
  */
 export class ProfileRepository {
+  private readonly db;
   private readonly stmtPersonById;
   private readonly stmtPersonByPublicId;
   private readonly stmtMiniProfile;
@@ -102,6 +103,7 @@ export class ProfileRepository {
 
   constructor(client: DatabaseClient) {
     const { db } = client;
+    this.db = db;
 
     this.stmtPersonById = db.prepare(
       "SELECT id FROM people WHERE id = ?",
@@ -223,6 +225,55 @@ export class ProfileRepository {
       | undefined;
     if (!row) throw new ProfileNotFoundError(slug);
     return this.assembleProfile(row.id, options);
+  }
+
+  /**
+   * Looks up multiple profiles by their internal database IDs.
+   *
+   * Returns an array in the same order as the input IDs.
+   * Entries are `null` when no person exists with the given ID.
+   */
+  findByIds(ids: number[], options?: ProfileFindOptions): (Profile | null)[] {
+    if (ids.length === 0) return [];
+
+    const placeholders = ids.map(() => "?").join(", ");
+    const rows = this.db
+      .prepare(`SELECT id FROM people WHERE id IN (${placeholders})`)
+      .all(...ids) as { id: number }[];
+
+    const found = new Set(rows.map((r) => r.id));
+    return ids.map((id) =>
+      found.has(id) ? this.assembleProfile(id, options) : null,
+    );
+  }
+
+  /**
+   * Looks up multiple profiles by LinkedIn public IDs.
+   *
+   * Returns an array in the same order as the input slugs.
+   * Entries are `null` when no person matches the public ID.
+   */
+  findByPublicIds(
+    slugs: string[],
+    options?: ProfileFindOptions,
+  ): (Profile | null)[] {
+    if (slugs.length === 0) return [];
+
+    const placeholders = slugs.map(() => "?").join(", ");
+    const rows = this.db
+      .prepare(
+        `SELECT pei.external_id, p.id
+         FROM people p
+         JOIN person_external_ids pei ON p.id = pei.person_id
+         WHERE pei.type_group = 'public' AND pei.external_id IN (${placeholders})`,
+      )
+      .all(...slugs) as { external_id: string; id: number }[];
+
+    const slugToId = new Map(rows.map((r) => [r.external_id, r.id]));
+    return slugs.map((slug) => {
+      const personId = slugToId.get(slug);
+      return personId != null ? this.assembleProfile(personId, options) : null;
+    });
   }
 
   /**

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -111,6 +111,6 @@ describe("createServer", () => {
     expect(names).toContain("campaign-update-action");
     expect(names).toContain("campaign-remove-people");
     expect(names).toContain("get-errors");
-    expect(names).toHaveLength(36);
+    expect(names).toHaveLength(37);
   });
 });

--- a/packages/mcp/src/tools/index.ts
+++ b/packages/mcp/src/tools/index.ts
@@ -38,6 +38,7 @@ import { registerStopInstance } from "./stop-instance.js";
 import { registerQueryMessages } from "./query-messages.js";
 import { registerQueryProfile } from "./query-profile.js";
 import { registerQueryProfiles } from "./query-profiles.js";
+import { registerQueryProfilesBulk } from "./query-profiles-bulk.js";
 import { registerScrapeMessagingHistory } from "./scrape-messaging-history.js";
 
 export {
@@ -73,6 +74,7 @@ export {
   registerQueryMessages,
   registerQueryProfile,
   registerQueryProfiles,
+  registerQueryProfilesBulk,
   registerQuitApp,
   registerScrapeMessagingHistory,
   registerStartInstance,
@@ -111,6 +113,7 @@ export function registerAllTools(server: McpServer): void {
   registerQueryMessages(server);
   registerQueryProfile(server);
   registerQueryProfiles(server);
+  registerQueryProfilesBulk(server);
   registerScrapeMessagingHistory(server);
   registerCheckReplies(server);
   registerCheckStatus(server);

--- a/packages/mcp/src/tools/query-profiles-bulk.test.ts
+++ b/packages/mcp/src/tools/query-profiles-bulk.test.ts
@@ -1,0 +1,404 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return {
+    ...actual,
+    DatabaseClient: vi.fn(),
+    ProfileRepository: vi.fn(),
+    discoverAllDatabases: vi.fn(),
+  };
+});
+
+import {
+  type Profile,
+  DatabaseClient,
+  ProfileRepository,
+  discoverAllDatabases,
+} from "@lhremote/core";
+
+import { registerQueryProfilesBulk } from "./query-profiles-bulk.js";
+import { createMockServer } from "./testing/mock-server.js";
+
+const PROFILE_JANE: Profile = {
+  id: 1,
+  miniProfile: {
+    firstName: "Jane",
+    lastName: "Doe",
+    headline: "Engineering Manager",
+    avatar: null,
+  },
+  externalIds: [
+    { externalId: "jane-doe-12345", typeGroup: "public", isMemberId: false },
+  ],
+  currentPosition: { company: "Acme Corp", title: "Engineering Manager" },
+  education: [],
+  skills: [],
+  emails: [],
+};
+
+const PROFILE_BOB: Profile = {
+  id: 2,
+  miniProfile: {
+    firstName: "Bob",
+    lastName: "Smith",
+    headline: "Developer",
+    avatar: null,
+  },
+  externalIds: [
+    { externalId: "bob-smith-67890", typeGroup: "public", isMemberId: false },
+  ],
+  currentPosition: { company: "Beta Inc", title: "Developer" },
+  education: [],
+  skills: [],
+  emails: [],
+};
+
+const PROFILE_JANE_WITH_POSITIONS: Profile = {
+  ...PROFILE_JANE,
+  positions: [
+    {
+      company: "Acme Corp",
+      title: "Engineering Manager",
+      startDate: "2020-01",
+      endDate: null,
+      isCurrent: true,
+    },
+  ],
+};
+
+function mockDb() {
+  const close = vi.fn();
+  vi.mocked(DatabaseClient).mockImplementation(function () {
+    return { close, db: {} } as unknown as DatabaseClient;
+  });
+  return { close };
+}
+
+function setupSuccessPath() {
+  vi.mocked(discoverAllDatabases).mockReturnValue(
+    new Map([[1, "/path/to/db"]]),
+  );
+  mockDb();
+  vi.mocked(ProfileRepository).mockImplementation(function () {
+    return {
+      findByIds: vi.fn().mockImplementation((ids: number[]) =>
+        ids.map((id) => {
+          if (id === 1) return PROFILE_JANE;
+          if (id === 2) return PROFILE_BOB;
+          return null;
+        }),
+      ),
+      findByPublicIds: vi.fn().mockImplementation((slugs: string[]) =>
+        slugs.map((s) => {
+          if (s === "jane-doe-12345") return PROFILE_JANE;
+          if (s === "bob-smith-67890") return PROFILE_BOB;
+          return null;
+        }),
+      ),
+    } as unknown as ProfileRepository;
+  });
+}
+
+describe("registerQueryProfilesBulk", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("registers a tool named query-profiles-bulk", () => {
+    const { server } = createMockServer();
+    registerQueryProfilesBulk(server);
+
+    expect(server.tool).toHaveBeenCalledOnce();
+    expect(server.tool).toHaveBeenCalledWith(
+      "query-profiles-bulk",
+      expect.any(String),
+      expect.any(Object),
+      expect.any(Function),
+    );
+  });
+
+  it("returns profiles by personIds", async () => {
+    const { server, getHandler } = createMockServer();
+    registerQueryProfilesBulk(server);
+    setupSuccessPath();
+
+    const handler = getHandler("query-profiles-bulk");
+    const result = await handler({ personIds: [1, 2] });
+
+    const content = (result as { content: Array<{ text: string }> }).content;
+    const parsed = JSON.parse(content[0]?.text ?? "{}");
+    expect(parsed.byPersonId).toHaveLength(2);
+    expect(parsed.byPersonId[0].id).toBe(1);
+    expect(parsed.byPersonId[1].id).toBe(2);
+  });
+
+  it("returns profiles by publicIds", async () => {
+    const { server, getHandler } = createMockServer();
+    registerQueryProfilesBulk(server);
+    setupSuccessPath();
+
+    const handler = getHandler("query-profiles-bulk");
+    const result = await handler({
+      publicIds: ["jane-doe-12345", "bob-smith-67890"],
+    });
+
+    const content = (result as { content: Array<{ text: string }> }).content;
+    const parsed = JSON.parse(content[0]?.text ?? "{}");
+    expect(parsed.byPublicId).toHaveLength(2);
+    expect(parsed.byPublicId[0].id).toBe(1);
+    expect(parsed.byPublicId[1].id).toBe(2);
+  });
+
+  it("returns both personIds and publicIds when both provided", async () => {
+    const { server, getHandler } = createMockServer();
+    registerQueryProfilesBulk(server);
+    setupSuccessPath();
+
+    const handler = getHandler("query-profiles-bulk");
+    const result = await handler({
+      personIds: [1],
+      publicIds: ["bob-smith-67890"],
+    });
+
+    const content = (result as { content: Array<{ text: string }> }).content;
+    const parsed = JSON.parse(content[0]?.text ?? "{}");
+    expect(parsed.byPersonId).toHaveLength(1);
+    expect(parsed.byPersonId[0].id).toBe(1);
+    expect(parsed.byPublicId).toHaveLength(1);
+    expect(parsed.byPublicId[0].id).toBe(2);
+  });
+
+  it("returns null for IDs not found", async () => {
+    const { server, getHandler } = createMockServer();
+    registerQueryProfilesBulk(server);
+    setupSuccessPath();
+
+    const handler = getHandler("query-profiles-bulk");
+    const result = await handler({ personIds: [1, 999] });
+
+    const content = (result as { content: Array<{ text: string }> }).content;
+    const parsed = JSON.parse(content[0]?.text ?? "{}");
+    expect(parsed.byPersonId).toHaveLength(2);
+    expect(parsed.byPersonId[0].id).toBe(1);
+    expect(parsed.byPersonId[1]).toBeNull();
+  });
+
+  it("passes includePositions to repository", async () => {
+    const { server, getHandler } = createMockServer();
+    registerQueryProfilesBulk(server);
+    vi.mocked(discoverAllDatabases).mockReturnValue(
+      new Map([[1, "/path/to/db"]]),
+    );
+    mockDb();
+    vi.mocked(ProfileRepository).mockImplementation(function () {
+      return {
+        findByIds: vi.fn().mockImplementation((_ids: number[], options?: { includePositions?: boolean }) =>
+          options?.includePositions ? [PROFILE_JANE_WITH_POSITIONS] : [PROFILE_JANE],
+        ),
+        findByPublicIds: vi.fn().mockReturnValue([]),
+      } as unknown as ProfileRepository;
+    });
+
+    const handler = getHandler("query-profiles-bulk");
+    const result = await handler({
+      personIds: [1],
+      includePositions: true,
+    });
+
+    const content = (result as { content: Array<{ text: string }> }).content;
+    const parsed = JSON.parse(content[0]?.text ?? "{}");
+    expect(parsed.byPersonId[0].positions).toHaveLength(1);
+  });
+
+  it("returns error when neither personIds nor publicIds provided", async () => {
+    const { server, getHandler } = createMockServer();
+    registerQueryProfilesBulk(server);
+
+    const handler = getHandler("query-profiles-bulk");
+    const result = await handler({});
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "At least one of personIds or publicIds must be provided with at least one element.",
+        },
+      ],
+    });
+  });
+
+  it("returns error when both arrays are empty", async () => {
+    const { server, getHandler } = createMockServer();
+    registerQueryProfilesBulk(server);
+
+    const handler = getHandler("query-profiles-bulk");
+    const result = await handler({ personIds: [], publicIds: [] });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "At least one of personIds or publicIds must be provided with at least one element.",
+        },
+      ],
+    });
+  });
+
+  it("returns error when no databases found", async () => {
+    const { server, getHandler } = createMockServer();
+    registerQueryProfilesBulk(server);
+    vi.mocked(discoverAllDatabases).mockReturnValue(new Map());
+
+    const handler = getHandler("query-profiles-bulk");
+    const result = await handler({ personIds: [1] });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "No LinkedHelper databases found.",
+        },
+      ],
+    });
+  });
+
+  it("searches multiple databases and aggregates results", async () => {
+    const { server, getHandler } = createMockServer();
+    registerQueryProfilesBulk(server);
+    vi.mocked(discoverAllDatabases).mockReturnValue(
+      new Map([
+        [1, "/path/to/db1"],
+        [2, "/path/to/db2"],
+      ]),
+    );
+
+    const close = vi.fn();
+    vi.mocked(DatabaseClient).mockImplementation(function () {
+      return { close, db: {} } as unknown as DatabaseClient;
+    });
+
+    let callCount = 0;
+    vi.mocked(ProfileRepository).mockImplementation(function () {
+      callCount++;
+      if (callCount === 1) {
+        // First DB has Jane but not Bob
+        return {
+          findByIds: vi.fn().mockImplementation((ids: number[]) =>
+            ids.map((id) => (id === 1 ? PROFILE_JANE : null)),
+          ),
+          findByPublicIds: vi.fn().mockReturnValue([]),
+        } as unknown as ProfileRepository;
+      }
+      // Second DB has Bob
+      return {
+        findByIds: vi.fn().mockImplementation((ids: number[]) =>
+          ids.map((id) => (id === 2 ? PROFILE_BOB : null)),
+        ),
+        findByPublicIds: vi.fn().mockReturnValue([]),
+      } as unknown as ProfileRepository;
+    });
+
+    const handler = getHandler("query-profiles-bulk");
+    const result = await handler({ personIds: [1, 2] });
+
+    const content = (result as { content: Array<{ text: string }> }).content;
+    const parsed = JSON.parse(content[0]?.text ?? "{}");
+    expect(parsed.byPersonId).toHaveLength(2);
+    expect(parsed.byPersonId[0].id).toBe(1);
+    expect(parsed.byPersonId[1].id).toBe(2);
+    expect(close).toHaveBeenCalledTimes(2);
+  });
+
+  it("skips already-found IDs in subsequent databases", async () => {
+    const { server, getHandler } = createMockServer();
+    registerQueryProfilesBulk(server);
+    vi.mocked(discoverAllDatabases).mockReturnValue(
+      new Map([
+        [1, "/path/to/db1"],
+        [2, "/path/to/db2"],
+      ]),
+    );
+
+    mockDb();
+
+    const findByIdsSpy1 = vi.fn().mockReturnValue([PROFILE_JANE]);
+    const findByIdsSpy2 = vi.fn().mockReturnValue([]);
+
+    let callCount = 0;
+    vi.mocked(ProfileRepository).mockImplementation(function () {
+      callCount++;
+      return {
+        findByIds: callCount === 1 ? findByIdsSpy1 : findByIdsSpy2,
+        findByPublicIds: vi.fn().mockReturnValue([]),
+      } as unknown as ProfileRepository;
+    });
+
+    const handler = getHandler("query-profiles-bulk");
+    await handler({ personIds: [1] });
+
+    // First DB should be called with [1]
+    expect(findByIdsSpy1).toHaveBeenCalledWith([1], { includePositions: false });
+    // Second DB should NOT be called since profile 1 was already found
+    expect(findByIdsSpy2).not.toHaveBeenCalled();
+  });
+
+  it("closes database after successful lookup", async () => {
+    const { server, getHandler } = createMockServer();
+    registerQueryProfilesBulk(server);
+    vi.mocked(discoverAllDatabases).mockReturnValue(
+      new Map([[1, "/path/to/db"]]),
+    );
+    const { close } = mockDb();
+    vi.mocked(ProfileRepository).mockImplementation(function () {
+      return {
+        findByIds: vi.fn().mockReturnValue([PROFILE_JANE]),
+        findByPublicIds: vi.fn().mockReturnValue([]),
+      } as unknown as ProfileRepository;
+    });
+
+    const handler = getHandler("query-profiles-bulk");
+    await handler({ personIds: [1] });
+
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it("returns error on unexpected database failure", async () => {
+    const { server, getHandler } = createMockServer();
+    registerQueryProfilesBulk(server);
+    vi.mocked(discoverAllDatabases).mockReturnValue(
+      new Map([[1, "/path/to/db"]]),
+    );
+    mockDb();
+    vi.mocked(ProfileRepository).mockImplementation(function () {
+      return {
+        findByIds: vi.fn().mockImplementation(() => {
+          throw new Error("database locked");
+        }),
+      } as unknown as ProfileRepository;
+    });
+
+    const handler = getHandler("query-profiles-bulk");
+    const result = await handler({ personIds: [1] });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "Failed to query profiles: database locked",
+        },
+      ],
+    });
+  });
+});

--- a/packages/mcp/src/tools/query-profiles-bulk.ts
+++ b/packages/mcp/src/tools/query-profiles-bulk.ts
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import type { Profile } from "@lhremote/core";
+import {
+  DatabaseClient,
+  discoverAllDatabases,
+  ProfileRepository,
+} from "@lhremote/core";
+import { z } from "zod";
+import { mcpCatchAll, mcpError, mcpSuccess } from "../helpers.js";
+
+/** Register the {@link https://github.com/alexey-pelykh/lhremote#query-profiles-bulk | query-profiles-bulk} MCP tool. */
+export function registerQueryProfilesBulk(server: McpServer): void {
+  server.tool(
+    "query-profiles-bulk",
+    "Look up multiple cached LinkedIn profiles from the local database in a single call. Returns an array of profile records (null for IDs not found).",
+    {
+      personIds: z
+        .array(z.number().int().positive())
+        .optional()
+        .describe("Look up by internal person IDs"),
+      publicIds: z
+        .array(z.string())
+        .optional()
+        .describe(
+          "Look up by LinkedIn public IDs (profile URL slugs, e.g. jane-doe-12345)",
+        ),
+      includePositions: z
+        .boolean()
+        .optional()
+        .describe(
+          "When true, include full position history (career history) in each profile",
+        ),
+    },
+    async ({ personIds, publicIds, includePositions }) => {
+      const hasPersonIds = personIds != null && personIds.length > 0;
+      const hasPublicIds = publicIds != null && publicIds.length > 0;
+
+      if (!hasPersonIds && !hasPublicIds) {
+        return mcpError(
+          "At least one of personIds or publicIds must be provided with at least one element.",
+        );
+      }
+
+      const databases = discoverAllDatabases();
+      if (databases.size === 0) {
+        return mcpError("No LinkedHelper databases found.");
+      }
+
+      const findOptions = { includePositions: includePositions === true };
+
+      // Track results by key for deduplication across databases
+      const byPersonId = new Map<number, Profile>();
+      const byPublicId = new Map<string, Profile>();
+
+      for (const [, dbPath] of databases) {
+        const db = new DatabaseClient(dbPath);
+        try {
+          const repo = new ProfileRepository(db);
+
+          if (hasPersonIds) {
+            const remaining = personIds.filter((id) => !byPersonId.has(id));
+            if (remaining.length > 0) {
+              const results = repo.findByIds(remaining, findOptions);
+              for (const [i, id] of remaining.entries()) {
+                const profile = results[i];
+                if (profile != null) {
+                  byPersonId.set(id, profile);
+                }
+              }
+            }
+          }
+
+          if (hasPublicIds) {
+            const remaining = publicIds.filter((s) => !byPublicId.has(s));
+            if (remaining.length > 0) {
+              const results = repo.findByPublicIds(remaining, findOptions);
+              for (const [i, slug] of remaining.entries()) {
+                const profile = results[i];
+                if (profile != null) {
+                  byPublicId.set(slug, profile);
+                }
+              }
+            }
+          }
+        } catch (error) {
+          return mcpCatchAll(error, "Failed to query profiles");
+        } finally {
+          db.close();
+        }
+      }
+
+      const result: {
+        byPersonId?: (Profile | null)[];
+        byPublicId?: (Profile | null)[];
+      } = {};
+
+      if (hasPersonIds) {
+        result.byPersonId = personIds.map((id) => byPersonId.get(id) ?? null);
+      }
+      if (hasPublicIds) {
+        result.byPublicId = publicIds.map((s) => byPublicId.get(s) ?? null);
+      }
+
+      return mcpSuccess(JSON.stringify(result, null, 2));
+    },
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `query-profiles-bulk` MCP tool and CLI command for batch profile lookups by `personIds` and/or `publicIds`
- Supports `includePositions` option (leveraging the career history from #377)
- Returns ordered results with `null` entries for IDs not found
- Searches across all discovered LinkedHelper databases with deduplication

Closes #380

## Test plan

- [x] Unit tests for `ProfileRepository.findByIds` and `findByPublicIds` (in-memory SQLite)
- [x] Unit tests for MCP tool (10 test cases covering success, error, multi-DB, dedup)
- [x] Unit tests for CLI handler (10 test cases covering JSON/human output, errors)
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (771 core + 291 mcp tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)