### PR TITLE
(docs) mcp-skill: add search URL reference, rate limiting, and bulk import guidance

### DIFF
--- a/skills/lhremote-mcp/SKILL.md
+++ b/skills/lhremote-mcp/SKILL.md
@@ -70,6 +70,14 @@ actions:
 
 Use `import-people-from-urls` with LinkedIn profile URLs. This is idempotent — re-importing the same person is a no-op.
 
+For bulk imports (1000+ URLs), use the CLI instead of the MCP tool:
+
+```bash
+npx lhremote import-people-from-urls <campaignId> --urls-file <path> --cdp-port <port>
+```
+
+URL file: one LinkedIn profile URL per line. Get `cdp-port` from `find-app` output.
+
 **Step 4 — Start execution:**
 
 `campaign-start` requires both `campaignId` and `personIds` (the internal IDs, not LinkedIn URLs). It returns immediately — execution is asynchronous.
@@ -143,3 +151,148 @@ Use `describe-actions` to get full schemas. The available action types are:
 | `DataEnrichment` | crm | Enrich profile data |
 | `ScrapeMessagingHistory` | messaging | Scrape messaging history |
 | `Waiter` | workflow | Wait for a configured delay |
+
+## Building LinkedIn Search URLs for Import
+
+To populate a campaign with targets, you need LinkedIn profile URLs. The most common source is LinkedIn's people search. You can construct search URLs programmatically and then use LinkedHelper or browser automation to collect the resulting profile URLs for import.
+
+### Basic People Search URL
+
+Base: `https://www.linkedin.com/search/results/people/?`
+
+Parameters are appended as `&key=value`. Faceted filters use URL-encoded JSON arrays of strings.
+
+### Encoding Rule
+
+All faceted parameters (except `keywords`, `firstName`, `lastName`, `title`) use URL-encoded JSON arrays:
+
+```
+["12345"]       → %5B%2212345%22%5D
+["12345","678"] → %5B%2212345%22%2C%22678%22%5D
+```
+
+Characters: `[` → `%5B`, `]` → `%5D`, `"` → `%22`, `,` → `%2C`
+
+### Parameter Reference
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `keywords` | Plain text | Free-text search across all profile fields. Supports Boolean: `AND`, `OR`, `NOT`, `"exact phrase"`, `(grouping)` |
+| `network` | JSON array | Connection degree: `"F"` (1st), `"S"` (2nd), `"O"` (3rd+) |
+| `geoUrn` | JSON array | Location IDs (see geo table below) |
+| `currentCompany` | JSON array | Company IDs for current employer |
+| `pastCompany` | JSON array | Company IDs for previous employers |
+| `school` | JSON array | Educational institution IDs |
+| `industry` | JSON array | Industry code IDs |
+| `profileLanguage` | JSON array | ISO 639-1 codes: `"en"`, `"fr"`, `"de"`, `"es"` |
+| `serviceCategory` | JSON array | Service category IDs (for freelancers) |
+| `firstName` | Plain text | First name filter |
+| `lastName` | Plain text | Last name filter |
+| `title` | Plain text | Job title filter. Supports Boolean |
+| `connectionOf` | JSON array | Profile hash — search within someone's connections |
+
+### Common Geo URN IDs
+
+| Location | ID |
+|----------|-----|
+| United States | 103644278 |
+| Canada | 101174742 |
+| United Kingdom | 101165590 |
+| France | 105015875 |
+| Germany | 101282230 |
+| Spain | 105646813 |
+| Italy | 103350119 |
+| Netherlands | 102890719 |
+| Switzerland | 106693272 |
+| India | 102713980 |
+| Australia | 101452733 |
+| Brazil | 106057199 |
+| Japan | 101355337 |
+| SF Bay Area | 90000084 |
+
+### Discovering IDs
+
+To find IDs for companies, schools, industries, or locations not listed above:
+
+1. **URL inspection**: Apply the filter in LinkedIn's UI, then read the ID from the browser URL bar
+2. **Company page trick**: Visit a company page → click "See all jobs" → the URL contains `f_C=<companyId>`
+3. **Network tab**: Open browser DevTools → Network tab → type in a filter box → inspect the typeahead XHR request for the returned IDs
+
+### Example URLs
+
+**2nd-degree connections at Microsoft in SF Bay Area with "Senior Engineer" title:**
+
+```
+https://www.linkedin.com/search/results/people/?currentCompany=%5B%221035%22%5D&geoUrn=%5B%2290000084%22%5D&network=%5B%22S%22%5D&title=Senior%20Engineer&origin=FACETED_SEARCH
+```
+
+**French-speaking software industry professionals:**
+
+```
+https://www.linkedin.com/search/results/people/?industry=%5B%224%22%5D&profileLanguage=%5B%22fr%22%5D&origin=FACETED_SEARCH
+```
+
+**Boolean keyword search for founders or CEOs in Germany:**
+
+```
+https://www.linkedin.com/search/results/people/?keywords=founder%20OR%20CEO&geoUrn=%5B%22101282230%22%5D&origin=FACETED_SEARCH
+```
+
+### Sales Navigator Search URLs
+
+Sales Navigator uses a different base URL and encoding:
+
+- **Lead search**: `https://www.linkedin.com/sales/search/people?query=...`
+- **Account search**: `https://www.linkedin.com/sales/search/company?query=...`
+
+The `query` parameter uses a proprietary nested list syntax:
+
+```
+query=(filters:List((type:REGION,values:List((id:105015875,text:France,selectionType:INCLUDED)))))
+```
+
+This gets percent-encoded in the URL. Each filter has `type`, `id`, `text`, and `selectionType` (`INCLUDED` or `EXCLUDED`).
+
+Common Sales Navigator filter types and IDs:
+
+| Filter Type | Example IDs |
+|-------------|-------------|
+| `FUNCTION` | 8 (Engineering), 13 (IT), 19 (Product Management) |
+| `SENIORITY_LEVEL` | 220 (Director), 300 (VP), 310 (CXO), 320 (Owner/Partner) |
+| `REGION` | Same geo IDs as basic search |
+| `INDUSTRY` | Same industry IDs as basic search |
+| `CURRENT_COMPANY` | Company IDs (may use `urn:li:organization:<id>` format) |
+| `COMPANY_HEADCOUNT` | B (1-10), C (11-50), D (51-200), E (201-500), F (501-1000), G (1001-5000) |
+
+### Search-to-Import Workflow
+
+```
+1. Build search URL  → construct URL with desired filters
+2. Open in browser   → navigate to URL (requires authenticated LinkedIn session)
+3. Collect profiles  → use LinkedHelper's built-in search collection or browser automation
+4. Import to campaign → import-people-from-urls (MCP or CLI)
+5. Start campaign    → campaign-start with imported person IDs
+```
+
+LinkedIn limits search results to ~2,500 per query. For larger target lists, split the search into smaller segments (e.g., by sub-region or industry) so each sub-query stays under the limit.
+
+## Rate Limiting
+
+LinkedIn enforces undisclosed rate limits. Exceeding them triggers warnings or account restrictions that are difficult to reverse.
+
+| Parameter | Recommended |
+|-----------|-------------|
+| Daily safe volume | 100–200 visits/day |
+| Conservative start | 50/day, scale up after validation |
+| Cooldown between visits | 60s minimum |
+
+Start conservative. LinkedIn warnings are easier to prevent than to recover from. Configure `cooldownMs` (60000–90000) and `maxActionsPerRun` (5–10) on campaign actions accordingly.
+
+## Common Pitfalls
+
+| Pitfall | Correct Approach |
+|---------|------------------|
+| Hardcoding CDP port | Read from `find-app` or `launch-app` output each session — the port is dynamic |
+| Skipping startup sequence | Always: `launch-app` → `start-instance` → operate |
+| Bulk import via MCP tool for large lists | Use CLI with `--urls-file` for 1000+ URLs |
+| Starting at maximum rate | Start at 50/day, scale after confirming no LinkedIn warnings |


### PR DESCRIPTION
## Summary

- Add LinkedIn search URL construction reference (basic search + Sales Navigator) with parameter tables, geo IDs, encoding rules, and examples
- Add rate limiting guidance with conservative daily volume recommendations
- Add bulk CLI import note for 1000+ URL lists (`--urls-file`)
- Add common pitfalls table

## Test plan

- [ ] Verify markdown renders correctly on GitHub
- [ ] Spot-check LinkedIn search URL examples in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)