### PR TITLE
Add CollectionService wrapping LH collection IPC calls

### DIFF
--- a/packages/core/src/services/collection.test.ts
+++ b/packages/core/src/services/collection.test.ts
@@ -1,0 +1,269 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { CollectionBusyError, CollectionError } from "./errors.js";
+import { CollectionService } from "./collection.js";
+
+// Mock InstanceService
+const mockEvaluateUI = vi.fn();
+
+vi.mock("./instance.js", () => ({
+  InstanceService: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
+    this.evaluateUI = mockEvaluateUI;
+  }),
+}));
+
+import { InstanceService } from "./instance.js";
+
+/** LinkedIn people search URL for tests. */
+const SEARCH_URL =
+  "https://www.linkedin.com/search/results/people/?keywords=software%20engineer";
+
+/** LinkedIn company people URL for tests. */
+const ORG_PEOPLE_URL =
+  "https://www.linkedin.com/company/acme-corp/people/";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("CollectionService", () => {
+  let service: CollectionService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    const instance = new InstanceService(9223);
+    service = new CollectionService(instance);
+  });
+
+  describe("collect", () => {
+    it("calls canCollect, prepareCollecting, and collect via CDP", async () => {
+      mockEvaluateUI
+        .mockResolvedValueOnce("idle")  // getRunnerState
+        .mockResolvedValueOnce(true)    // canCollect
+        .mockResolvedValueOnce(true)    // prepareCollecting
+        .mockResolvedValueOnce(true);   // collect
+
+      await service.collect(SEARCH_URL, 1);
+
+      expect(mockEvaluateUI).toHaveBeenCalledTimes(4);
+
+      // 1. Runner state check
+      const stateExpr = mockEvaluateUI.mock.calls[0]?.[0] as string;
+      expect(stateExpr).toContain("mainWindowService.mainWindow.state");
+
+      // 2. canCollect
+      const canCollectExpr = mockEvaluateUI.mock.calls[1]?.[0] as string;
+      expect(canCollectExpr).toContain("canCollect");
+      expect(canCollectExpr).toContain("SearchPage");
+
+      // 3. prepareCollecting
+      const prepareExpr = mockEvaluateUI.mock.calls[2]?.[0] as string;
+      expect(prepareExpr).toContain("prepareCollecting");
+      expect(prepareExpr).toContain("SearchPage");
+      expect(prepareExpr).toContain("AutoCollectPeople");
+
+      // 4. collect
+      const collectExpr = mockEvaluateUI.mock.calls[3]?.[0] as string;
+      expect(collectExpr).toContain("mws.call('collect'");
+    });
+
+    it("passes limit, maxPages, pageSize to collect call", async () => {
+      mockEvaluateUI
+        .mockResolvedValueOnce("idle")
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(true);
+
+      await service.collect(SEARCH_URL, 1, {
+        limit: 100,
+        maxPages: 5,
+        pageSize: 25,
+      });
+
+      const collectExpr = mockEvaluateUI.mock.calls[3]?.[0] as string;
+      expect(collectExpr).toContain('"limit":100');
+      expect(collectExpr).toContain('"maxPages":5');
+      expect(collectExpr).toContain('"pageSize":25');
+    });
+
+    it("omits undefined options from collect call", async () => {
+      mockEvaluateUI
+        .mockResolvedValueOnce("idle")
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(true);
+
+      await service.collect(SEARCH_URL, 1, { limit: 50 });
+
+      const collectExpr = mockEvaluateUI.mock.calls[3]?.[0] as string;
+      expect(collectExpr).toContain('"limit":50');
+      expect(collectExpr).not.toContain("maxPages");
+      expect(collectExpr).not.toContain("pageSize");
+    });
+
+    it("detects OrganizationPeople source type from company URL", async () => {
+      mockEvaluateUI
+        .mockResolvedValueOnce("idle")
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(true);
+
+      await service.collect(ORG_PEOPLE_URL, 1);
+
+      const canCollectExpr = mockEvaluateUI.mock.calls[1]?.[0] as string;
+      expect(canCollectExpr).toContain("OrganizationPeople");
+
+      const prepareExpr = mockEvaluateUI.mock.calls[2]?.[0] as string;
+      expect(prepareExpr).toContain("OrganizationPeople");
+    });
+
+    it("throws CollectionError for unrecognized source URL", async () => {
+      const error = await service
+        .collect("https://www.linkedin.com/feed/", 1)
+        .catch((e: unknown) => e);
+
+      expect(error).toBeInstanceOf(CollectionError);
+      expect((error as CollectionError).message).toContain("Unrecognized source URL");
+
+      // No CDP calls should be made
+      expect(mockEvaluateUI).not.toHaveBeenCalled();
+    });
+
+    it("throws CollectionBusyError when runner is not idle", async () => {
+      mockEvaluateUI.mockResolvedValueOnce("campaigns");
+
+      await expect(
+        service.collect(SEARCH_URL, 1),
+      ).rejects.toThrow(CollectionBusyError);
+
+      // Only the runner state check should be made
+      expect(mockEvaluateUI).toHaveBeenCalledTimes(1);
+    });
+
+    it("includes runner state in CollectionBusyError", async () => {
+      mockEvaluateUI.mockResolvedValueOnce("campaigns");
+
+      try {
+        await service.collect(SEARCH_URL, 1);
+        expect.unreachable("should have thrown");
+      } catch (error) {
+        expect(error).toBeInstanceOf(CollectionBusyError);
+        expect((error as CollectionBusyError).runnerState).toBe("campaigns");
+      }
+    });
+
+    it("throws CollectionError when canCollect returns false", async () => {
+      mockEvaluateUI
+        .mockResolvedValueOnce("idle")
+        .mockResolvedValueOnce(false); // canCollect returns false
+
+      const error = await service.collect(SEARCH_URL, 1).catch((e: unknown) => e);
+      expect(error).toBeInstanceOf(CollectionError);
+      expect((error as CollectionError).message).toContain("not on a matching page");
+    });
+
+    it("throws CollectionError when prepareCollecting returns false", async () => {
+      mockEvaluateUI
+        .mockResolvedValueOnce("idle")
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(false); // prepareCollecting returns false
+
+      await expect(
+        service.collect(SEARCH_URL, 1),
+      ).rejects.toThrow(CollectionError);
+    });
+
+    it("throws CollectionError when collect returns false", async () => {
+      mockEvaluateUI
+        .mockResolvedValueOnce("idle")
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(false); // collect returns false
+
+      await expect(
+        service.collect(SEARCH_URL, 1),
+      ).rejects.toThrow(CollectionError);
+    });
+
+    it("wraps CDP errors in CollectionError for prepareCollecting", async () => {
+      mockEvaluateUI
+        .mockResolvedValueOnce("idle")
+        .mockResolvedValueOnce(true)
+        .mockRejectedValueOnce(new Error("CDP timeout"));
+
+      const error = await service.collect(SEARCH_URL, 1).catch((e: unknown) => e);
+      expect(error).toBeInstanceOf(CollectionError);
+      expect((error as CollectionError).message).toContain("Failed to prepare collection");
+      expect((error as CollectionError).cause).toBeInstanceOf(Error);
+    });
+
+    it("wraps CDP errors in CollectionError for collect", async () => {
+      mockEvaluateUI
+        .mockResolvedValueOnce("idle")
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(true)
+        .mockRejectedValueOnce(new Error("CDP timeout"));
+
+      const error = await service.collect(SEARCH_URL, 1).catch((e: unknown) => e);
+      expect(error).toBeInstanceOf(CollectionError);
+      expect((error as CollectionError).message).toContain("Failed to start collection");
+      expect((error as CollectionError).cause).toBeInstanceOf(Error);
+    });
+
+    it("does not wrap CollectionError from prepareCollecting", async () => {
+      mockEvaluateUI
+        .mockResolvedValueOnce("idle")
+        .mockResolvedValueOnce(true)
+        .mockResolvedValueOnce(false); // triggers CollectionError inside prepareCollecting
+
+      const error = await service.collect(SEARCH_URL, 1).catch((e: unknown) => e);
+      expect(error).toBeInstanceOf(CollectionError);
+      expect((error as CollectionError).message).toContain("prepareCollecting returned false");
+    });
+  });
+
+  describe("canCollect", () => {
+    it("calls canCollect IPC method via CDP", async () => {
+      mockEvaluateUI.mockResolvedValueOnce(true);
+
+      const result = await service.canCollect("SearchPage");
+
+      expect(result).toBe(true);
+      const expr = mockEvaluateUI.mock.calls[0]?.[0] as string;
+      expect(expr).toContain("canCollect");
+      expect(expr).toContain("SearchPage");
+    });
+
+    it("returns false when LinkedHelper reports false", async () => {
+      mockEvaluateUI.mockResolvedValueOnce(false);
+
+      const result = await service.canCollect("MyConnections");
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("getRunnerState", () => {
+    it("reads state from mainWindow.state via CDP", async () => {
+      mockEvaluateUI.mockResolvedValueOnce("idle");
+
+      const state = await service.getRunnerState();
+
+      expect(state).toBe("idle");
+      const expr = mockEvaluateUI.mock.calls[0]?.[0] as string;
+      expect(expr).toContain("mainWindowService.mainWindow.state");
+    });
+
+    it("returns non-idle states", async () => {
+      mockEvaluateUI.mockResolvedValueOnce("campaigns");
+
+      const state = await service.getRunnerState();
+
+      expect(state).toBe("campaigns");
+    });
+  });
+});

--- a/packages/core/src/services/collection.ts
+++ b/packages/core/src/services/collection.ts
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import type { SourceType } from "../types/index.js";
+import type { RunnerState } from "../types/index.js";
+import { errorMessage } from "../utils/error-message.js";
+import { detectSourceType } from "./source-type-registry.js";
+import type { InstanceService } from "./instance.js";
+import { CollectionBusyError, CollectionError } from "./errors.js";
+
+/**
+ * Options for initiating a collection operation.
+ */
+export interface CollectOptions {
+  /** Maximum number of profiles to collect. */
+  readonly limit?: number;
+  /** Maximum number of pages to process. */
+  readonly maxPages?: number;
+  /** Number of results per page. */
+  readonly pageSize?: number;
+}
+
+/**
+ * Manages people collection from LinkedIn pages via CDP.
+ *
+ * Collection uses the dedicated `prepareCollecting` → `collect` IPC
+ * entry point, which drives the LinkedHelper state machine through
+ * `idle → preparing-collecting → collecting → idle`.
+ *
+ * The {@link collect} method returns immediately — callers should poll
+ * the runner state (`mainWindow.state`) for progress.
+ */
+export class CollectionService {
+  private readonly instance: InstanceService;
+
+  constructor(instance: InstanceService) {
+    this.instance = instance;
+  }
+
+  /**
+   * Initiate people collection from a LinkedIn source URL.
+   *
+   * Validates that the source URL is a recognized LinkedIn page type,
+   * ensures the instance is idle, then calls `canCollect` →
+   * `prepareCollecting` → `collect` via CDP.
+   *
+   * Returns immediately after initiating collection — the actual
+   * collection runs asynchronously in LinkedHelper. Poll the runner
+   * state via {@link getRunnerState} for progress.
+   *
+   * @param sourceUrl - LinkedIn page URL to collect from (e.g., search results URL).
+   * @param campaignId - Campaign to associate the collection with.
+   * @param options - Collection parameters (limit, maxPages, pageSize).
+   * @throws {CollectionError} if the source URL is not recognized, canCollect returns false,
+   *   or the CDP calls fail.
+   * @throws {CollectionBusyError} if the instance is not idle.
+   */
+  async collect(
+    sourceUrl: string,
+    _campaignId: number,
+    options?: CollectOptions,
+  ): Promise<void> {
+    const sourceType = detectSourceType(sourceUrl);
+    if (!sourceType) {
+      throw new CollectionError(
+        `Unrecognized source URL: ${sourceUrl} — cannot determine LinkedIn page type`,
+      );
+    }
+
+    await this.ensureIdle();
+    await this.assertCanCollect(sourceType);
+
+    try {
+      await this.prepareCollecting(sourceType);
+    } catch (error) {
+      if (error instanceof CollectionError) throw error;
+      const message = errorMessage(error);
+      throw new CollectionError(
+        `Failed to prepare collection for ${sourceType}: ${message}`,
+        { cause: error },
+      );
+    }
+
+    try {
+      await this.startCollecting(options);
+    } catch (error) {
+      if (error instanceof CollectionError) throw error;
+      const message = errorMessage(error);
+      throw new CollectionError(
+        `Failed to start collection: ${message}`,
+        { cause: error },
+      );
+    }
+  }
+
+  /**
+   * Check whether collection is possible for a given source type.
+   *
+   * This is a page-state check — returns `true` only when the
+   * LinkedHelper browser is currently on a matching source page.
+   */
+  async canCollect(sourceType: SourceType): Promise<boolean> {
+    return this.instance.evaluateUI<boolean>(
+      `(async () => {
+        const mws = window.mainWindowService;
+        return await mws.call('canCollect', ${JSON.stringify(sourceType)});
+      })()`,
+    );
+  }
+
+  /**
+   * Get the current runner state from the LinkedHelper main window.
+   */
+  async getRunnerState(): Promise<RunnerState> {
+    return this.instance.evaluateUI<RunnerState>(
+      `window.mainWindowService.mainWindow.state`,
+      false,
+    );
+  }
+
+  /**
+   * Ensure the instance runner is idle.
+   *
+   * @throws {CollectionBusyError} if the runner is not idle.
+   */
+  private async ensureIdle(): Promise<void> {
+    const state = await this.getRunnerState();
+    if (state !== "idle") {
+      throw new CollectionBusyError(state);
+    }
+  }
+
+  /**
+   * Assert that `canCollect` returns `true` for the source type.
+   *
+   * @throws {CollectionError} if `canCollect` returns `false`.
+   */
+  private async assertCanCollect(sourceType: SourceType): Promise<void> {
+    const result = await this.canCollect(sourceType);
+    if (!result) {
+      throw new CollectionError(
+        `Cannot collect from ${sourceType} — the LinkedIn browser is not on a matching page`,
+      );
+    }
+  }
+
+  /**
+   * Call `prepareCollecting` to transition the state machine from
+   * `idle` to `preparing-collecting`.
+   *
+   * @throws {CollectionError} if the call returns `false`.
+   */
+  private async prepareCollecting(sourceType: SourceType): Promise<void> {
+    const result = await this.instance.evaluateUI<boolean>(
+      `(async () => {
+        const mws = window.mainWindowService;
+        return await mws.call('prepareCollecting', ${JSON.stringify({
+          type: sourceType,
+          actionType: "AutoCollectPeople",
+        })});
+      })()`,
+    );
+
+    if (!result) {
+      throw new CollectionError(
+        `prepareCollecting returned false for ${sourceType} — state machine did not transition`,
+      );
+    }
+  }
+
+  /**
+   * Call `collect` to start the actual collection process.
+   *
+   * @throws {CollectionError} if the call returns `false`.
+   */
+  private async startCollecting(options?: CollectOptions): Promise<void> {
+    const params: Record<string, number> = {};
+    if (options?.limit !== undefined) params.limit = options.limit;
+    if (options?.maxPages !== undefined) params.maxPages = options.maxPages;
+    if (options?.pageSize !== undefined) params.pageSize = options.pageSize;
+
+    const result = await this.instance.evaluateUI<boolean>(
+      `(async () => {
+        const mws = window.mainWindowService;
+        return await mws.call('collect', ${JSON.stringify(params)});
+      })()`,
+    );
+
+    if (!result) {
+      throw new CollectionError(
+        "collect returned false — state machine was not in collecting state",
+      );
+    }
+  }
+}

--- a/packages/core/src/services/errors.ts
+++ b/packages/core/src/services/errors.ts
@@ -152,6 +152,35 @@ export class ExtractionTimeoutError extends ServiceError {
 }
 
 /**
+ * Thrown when a collection operation fails during execution
+ * (canCollect, prepareCollecting, collect, or other CDP-based operations).
+ */
+export class CollectionError extends ServiceError {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = "CollectionError";
+  }
+}
+
+/**
+ * Thrown when a collection operation cannot proceed because the
+ * LinkedHelper instance is busy (running a campaign, another
+ * collection, or a single action).
+ */
+export class CollectionBusyError extends CollectionError {
+  readonly runnerState: string;
+
+  constructor(runnerState: string, options?: ErrorOptions) {
+    super(
+      `Cannot start collection — instance is busy (runner state: ${runnerState})`,
+      options,
+    );
+    this.name = "CollectionBusyError";
+    this.runnerState = runnerState;
+  }
+}
+
+/**
  * Thrown when a campaign operation fails during execution
  * (create, start, stop, or other CDP-based operations).
  */

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -30,12 +30,15 @@ export {
   type InstanceDatabaseContext,
 } from "./instance-context.js";
 export { detectSourceType, validateSourceType } from "./source-type-registry.js";
+export { CollectionService } from "./collection.js";
 export {
   ActionExecutionError,
   AppLaunchError,
   AppNotFoundError,
   CampaignExecutionError,
   CampaignTimeoutError,
+  CollectionBusyError,
+  CollectionError,
   ExtractionTimeoutError,
   InstanceNotRunningError,
   InvalidProfileUrlError,


### PR DESCRIPTION
## Summary

- Add `CollectionService` that wraps `canCollect` → `prepareCollecting` → `collect` CDP entry points (verified in #401)
- Add `CollectionError` and `CollectionBusyError` error types for collection-specific failure modes
- Validate source URLs via `detectSourceType()`, check runner idle state before initiating collection
- 17 unit tests with mocked CDP covering happy path, error cases, and parameter passing

Closes #403

## Test plan

- [x] Unit tests pass (`pnpm test` — 17 new tests in `collection.test.ts`)
- [x] Lint passes (`pnpm lint`)
- [ ] CI passes on all platforms (ubuntu/macos/windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)