### PR TITLE
Update MCP skill with collection workflow and source type reference

### DIFF
--- a/skills/lhremote-mcp/SKILL.md
+++ b/skills/lhremote-mcp/SKILL.md
@@ -38,12 +38,48 @@ launch-app → start-instance → [work] → stop-instance → quit-app
 - Most tools require a running instance (they will error if not started)
 - `stop-instance` and `quit-app` are separate — stop the instance before quitting the app
 
+### Collection Workflow (Primary)
+
+The primary way to populate a campaign with targets. Discovers sources from LinkedIn pages, collects people automatically, and monitors progress:
+
+```
+[build search URL] → collect-people → campaign-status → campaign-start
+```
+
+**Step 1 — Build a source URL:**
+
+Construct a LinkedIn page URL to collect from. See [Building LinkedIn Search URLs](#building-linkedin-search-urls-for-import) for search URL construction, or use any supported source page (company people, group members, event attendees, etc.). See [Source Type Reference](#source-type-reference) for the full list.
+
+**Step 2 — Collect people into a campaign:**
+
+`collect-people` accepts a LinkedIn page URL and campaign ID. The source type is auto-detected from the URL. Collection runs asynchronously — the call returns immediately.
+
+```
+collect-people(campaignId, sourceUrl)
+```
+
+Optional parameters:
+- `limit` — Maximum profiles to collect
+- `maxPages` — Maximum pages to process
+- `pageSize` — Results per page
+- `sourceType` — Explicit source type to bypass URL auto-detection
+
+**Step 3 — Monitor collection progress:**
+
+Poll `campaign-status` to track collection progress. The campaign's people list grows as profiles are collected.
+
+**Step 4 — Start the campaign:**
+
+Once collection is complete (or enough people are collected), use `campaign-start` with the collected `personIds`.
+
+**Collection rate limiting:** Collection respects LinkedHelper's internal pacing. For large source pages (1000+ results), use `limit` or `maxPages` to control scope. Only one collection can run at a time per instance — attempting a second returns a `CollectionBusyError`.
+
 ### Campaign Creation & Execution
 
 Full workflow for creating and running a campaign:
 
 ```
-describe-actions → campaign-create → import-people-from-urls → campaign-start → campaign-status / campaign-statistics
+describe-actions → campaign-create → [populate targets] → campaign-start → campaign-status / campaign-statistics
 ```
 
 **Step 1 — Discover action types:**
@@ -66,11 +102,17 @@ actions:
       message: "Hi {firstName}, I'd like to connect!"
 ```
 
-**Step 3 — Import targets:**
+**Step 3 — Populate targets:**
 
-Use `import-people-from-urls` with LinkedIn profile URLs. This is idempotent — re-importing the same person is a no-op.
+Three methods for adding people to a campaign:
 
-For bulk imports (1000+ URLs), use the CLI instead of the MCP tool:
+| Method | Tool | Best For |
+|--------|------|----------|
+| **Collection** (recommended) | `collect-people` | Automated discovery from LinkedIn pages |
+| **From Lists** | `import-people-from-collection` | Reusing curated people sets across campaigns |
+| **Direct URL import** | `import-people-from-urls` | Known LinkedIn profile URLs |
+
+For `import-people-from-urls`: This is idempotent — re-importing the same person is a no-op. For bulk imports (1000+ URLs), use the CLI instead:
 
 ```bash
 npx lhremote import-people-from-urls <campaignId> --urls-file <path> --cdp-port <port>
@@ -95,6 +137,40 @@ Campaigns contain ordered action chains. Manage them with:
 - `campaign-remove-action` — Remove by action ID
 - `campaign-reorder-actions` — Reorder by providing action IDs in desired order
 - `campaign-move-next` — Advance specific persons to the next action
+
+### Lists Management
+
+LinkedHelper collections (Lists) are reusable sets of people that persist across campaigns. Use them to curate target audiences and import into multiple campaigns.
+
+**CRUD operations:**
+
+```
+create-collection → add-people-to-collection → [use in campaigns] → delete-collection
+```
+
+- **`create-collection`** — Create a named List. Returns the new `collectionId`.
+- **`list-collections`** — List all named Lists with people counts.
+- **`delete-collection`** — Delete a List and all its people associations. Does not delete the people themselves.
+- **`add-people-to-collection`** — Add people by `personIds`. Idempotent — adding an already-present person is a no-op.
+- **`remove-people-from-collection`** — Remove people by `personIds`.
+
+**Import into campaign:**
+
+`import-people-from-collection` reads all LinkedIn profile URLs from a List and feeds them into a campaign. Large sets are automatically chunked.
+
+```
+import-people-from-collection(collectionId, campaignId)
+```
+
+**Typical workflow:**
+
+```
+1. Create a List                → create-collection("Senior Engineers SF")
+2. Collect into it              → collect-people(campaignId, sourceUrl) or add-people-to-collection
+3. Review/curate                → list-collections to verify counts
+4. Import into campaign         → import-people-from-collection(collectionId, campaignId)
+5. Reuse for another campaign   → import-people-from-collection(collectionId, anotherCampaignId)
+```
 
 ### Messaging Workflow
 
@@ -131,6 +207,8 @@ Profile and message queries work against the local LinkedHelper database — no 
 | "No accounts found" / "Multiple accounts" | Account resolution failed | Use `list-accounts`, then pass explicit `accountId` |
 | "Campaign not found" | Invalid campaign ID | Use `campaign-list` to find valid IDs |
 | "Campaign start timed out" | LinkedHelper unresponsive | Check `check-status`, retry |
+| "Cannot collect — instance is busy" | Another collection in progress | Wait for current collection to finish, then retry |
+| "Collection failed" | Source URL invalid or unsupported | Check URL against source type reference, try explicit `sourceType` |
 
 ## Action Type Reference
 
@@ -151,6 +229,43 @@ Use `describe-actions` to get full schemas. The available action types are:
 | `DataEnrichment` | crm | Enrich profile data |
 | `ScrapeMessagingHistory` | messaging | Scrape messaging history |
 | `Waiter` | workflow | Wait for a configured delay |
+
+## Source Type Reference
+
+`collect-people` auto-detects the source type from the URL. You can also pass `sourceType` explicitly.
+
+### Free Tier (LinkedIn Basic)
+
+| Source Type | URL Pattern | Description |
+|-------------|-------------|-------------|
+| `SearchPage` | `/search/results/people/` | People search results |
+| `MyConnections` | `/mynetwork/invite-connect/connections/` | Your connections list |
+| `Alumni` | `/school/{id}/people/` | School alumni page |
+| `OrganizationPeople` | `/company/{id}/people/` | Company people page |
+| `Group` | `/groups/{id}/members/` | Group members |
+| `Event` | `/events/{id}/attendees/` | Event attendees |
+| `LWVYPP` | `/me/profile-views/` | Who viewed your profile |
+| `SentInvitationPage` | `/mynetwork/invitation-manager/sent/` | Sent connection invitations |
+| `FollowersPage` | `/me/my-network/followers/` | Your followers |
+| `FollowingPage` | `/me/my-network/following/` | People you follow |
+
+### Sales Navigator Tier
+
+| Source Type | URL Pattern | Description |
+|-------------|-------------|-------------|
+| `SNSearchPage` | `/sales/search/people` | Sales Navigator people search |
+| `SNListPage` | `/sales/lists/people/` | Sales Navigator saved lists (people) |
+| `SNOrgsPage` | `/sales/search/company` | Sales Navigator company search |
+| `SNOrgsListsPage` | `/sales/lists/company/` | Sales Navigator saved lists (companies) |
+
+### Recruiter Tier
+
+| Source Type | URL Pattern | Description |
+|-------------|-------------|-------------|
+| `TSearchPage` | `/talent/search/` | Recruiter search |
+| `TProjectPage` | `/talent/projects/` | Recruiter projects |
+| `RSearchPage` | `/recruiter/search/` | Recruiter Lite search |
+| `RProjectPage` | `/recruiter/projects/` | Recruiter Lite projects |
 
 ## Building LinkedIn Search URLs for Import
 
@@ -264,14 +379,24 @@ Common Sales Navigator filter types and IDs:
 | `CURRENT_COMPANY` | Company IDs (may use `urn:li:organization:<id>` format) |
 | `COMPANY_HEADCOUNT` | B (1-10), C (11-50), D (51-200), E (201-500), F (501-1000), G (1001-5000) |
 
-### Search-to-Import Workflow
+### Search-to-Campaign Workflow
 
 ```
-1. Build search URL  → construct URL with desired filters
-2. Open in browser   → navigate to URL (requires authenticated LinkedIn session)
-3. Collect profiles  → use LinkedHelper's built-in search collection or browser automation
-4. Import to campaign → import-people-from-urls (MCP or CLI)
-5. Start campaign    → campaign-start with imported person IDs
+1. Build search URL    → construct URL with desired filters (see above)
+2. Collect into campaign → collect-people(campaignId, sourceUrl) — automated, no browser needed
+3. Monitor progress    → poll campaign-status until collection completes
+4. Start campaign      → campaign-start with collected person IDs
+```
+
+This replaces the manual browser-based workflow. `collect-people` handles page navigation and profile extraction internally.
+
+**Alternative (manual URL import):**
+
+If you already have a list of LinkedIn profile URLs from another source:
+
+```
+1. Import to campaign → import-people-from-urls (MCP or CLI)
+2. Start campaign     → campaign-start with imported person IDs
 ```
 
 LinkedIn limits search results to ~2,500 per query. For larger target lists, split the search into smaller segments (e.g., by sub-region or industry) so each sub-query stays under the limit.
@@ -279,6 +404,8 @@ LinkedIn limits search results to ~2,500 per query. For larger target lists, spl
 ## Rate Limiting
 
 LinkedIn enforces undisclosed rate limits. Exceeding them triggers warnings or account restrictions that are difficult to reverse.
+
+### Campaign Actions
 
 | Parameter | Recommended |
 |-----------|-------------|
@@ -288,6 +415,17 @@ LinkedIn enforces undisclosed rate limits. Exceeding them triggers warnings or a
 
 Start conservative. LinkedIn warnings are easier to prevent than to recover from. Configure `cooldownMs` (60000–90000) and `maxActionsPerRun` (5–10) on campaign actions accordingly.
 
+### Collection Operations
+
+| Parameter | Recommended |
+|-----------|-------------|
+| Profiles per collection run | Use `limit` to cap at 1000 per run |
+| Pages per run | Use `maxPages` to limit pagination depth |
+| Concurrent collections | 1 (enforced — `CollectionBusyError` if exceeded) |
+| Between collection runs | Wait for one to complete before starting another |
+
+Collection uses LinkedHelper's internal pacing. For large source pages, limit scope with `limit` or `maxPages` rather than collecting everything at once.
+
 ## Common Pitfalls
 
 | Pitfall | Correct Approach |
@@ -296,3 +434,6 @@ Start conservative. LinkedIn warnings are easier to prevent than to recover from
 | Skipping startup sequence | Always: `launch-app` → `start-instance` → operate |
 | Bulk import via MCP tool for large lists | Use CLI with `--urls-file` for 1000+ URLs |
 | Starting at maximum rate | Start at 50/day, scale after confirming no LinkedIn warnings |
+| Starting a second collection while one runs | Wait for the first to complete — only one collection per instance |
+| Collecting without `limit` on large searches | Use `limit` or `maxPages` to control scope on searches with 1000+ results |
+| Using `import-people-from-urls` when `collect-people` works | Prefer `collect-people` — it handles page navigation and extraction automatically |


### PR DESCRIPTION
## Summary

- Add "Collection Workflow (Primary)" section documenting the `collect-people` flow as the primary campaign population path
- Add source type reference table with all 18 types organized by tier (Free/Sales Navigator/Recruiter)
- Add Lists management section documenting CRUD operations and campaign import
- Update Campaign Creation workflow to show three population methods (collection, lists, URL import)
- Update Search-to-Campaign workflow to use `collect-people` instead of manual browser collection
- Add collection-specific rate limiting guidance, error patterns, and common pitfalls

Closes #406

## Test plan

- [ ] Verify all 18 source types match `packages/core/src/types/collection.ts`
- [ ] Verify all 7 collection/list tool names match MCP tool registrations
- [ ] Verify markdown renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)