### PR TITLE
Update documentation for v0.4.0, v0.5.0, and collections

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Add to your Claude Desktop configuration (`claude_desktop_config.json`):
 }
 ```
 
-Once configured, Claude can use all 32 tools directly. A typical workflow:
+Once configured, Claude can use all 44 tools directly. A typical workflow:
 
 1. **`find-app`** — Detect a running LinkedHelper instance (or **`launch-app`** to start one)
 2. **`list-accounts`** — See available LinkedIn accounts
@@ -77,7 +77,7 @@ The `lhremote` command provides the same functionality as the MCP server. Every 
 
 ```sh
 lhremote find-app [--json]
-lhremote launch-app [--cdp-port <port>]
+lhremote launch-app [--cdp-port <port>] [--force]
 lhremote quit-app [--cdp-port <port>]
 ```
 
@@ -99,11 +99,12 @@ lhremote campaign-get <campaignId> [--cdp-port <port>] [--json]
 lhremote campaign-export <campaignId> [--format yaml|json] [--output <path>] [--cdp-port <port>]
 lhremote campaign-update <campaignId> [--name <name>] [--description <text>] [--clear-description] [--cdp-port <port>] [--json]
 lhremote campaign-delete <campaignId> [--cdp-port <port>] [--json]
-lhremote campaign-start <campaignId> [--person-ids <ids>] [--person-ids-file <path>] [--cdp-port <port>] [--json]
+lhremote campaign-start <campaignId> --person-ids <ids> | --person-ids-file <path> [--cdp-port <port>] [--json]
 lhremote campaign-stop <campaignId> [--cdp-port <port>] [--json]
 lhremote campaign-status <campaignId> [--include-results] [--limit <n>] [--cdp-port <port>] [--json]
 lhremote campaign-statistics <campaignId> [--action-id <id>] [--max-errors <n>] [--cdp-port <port>] [--json]
-lhremote campaign-retry <campaignId> [--person-ids <ids>] [--person-ids-file <path>] [--cdp-port <port>] [--json]
+lhremote campaign-retry <campaignId> --person-ids <ids> | --person-ids-file <path> [--cdp-port <port>] [--json]
+lhremote campaign-list-people <campaignId> [--action-id <id>] [--status <status>] [--limit <n>] [--offset <n>] [--cdp-port <port>] [--json]
 ```
 
 ### Campaign Actions
@@ -111,8 +112,9 @@ lhremote campaign-retry <campaignId> [--person-ids <ids>] [--person-ids-file <pa
 ```sh
 lhremote campaign-add-action <campaignId> --name <name> --action-type <type> [--description <text>] [--cool-down <ms>] [--max-results <n>] [--action-settings <json>] [--cdp-port <port>] [--json]
 lhremote campaign-remove-action <campaignId> <actionId> [--cdp-port <port>] [--json]
+lhremote campaign-update-action <campaignId> <actionId> [--name <name>] [--description <text>] [--clear-description] [--cool-down <ms>] [--max-results <n>] [--action-settings <json>] [--cdp-port <port>] [--json]
 lhremote campaign-reorder-actions <campaignId> --action-ids <ids> [--cdp-port <port>] [--json]
-lhremote campaign-move-next <campaignId> <actionId> [--person-ids <ids>] [--person-ids-file <path>] [--cdp-port <port>] [--json]
+lhremote campaign-move-next <campaignId> <actionId> --person-ids <ids> | --person-ids-file <path> [--cdp-port <port>] [--json]
 ```
 
 ### Campaign Targeting
@@ -121,23 +123,38 @@ lhremote campaign-move-next <campaignId> <actionId> [--person-ids <ids>] [--pers
 lhremote campaign-exclude-list <campaignId> [--action-id <id>] [--cdp-port <port>] [--json]
 lhremote campaign-exclude-add <campaignId> --person-ids <ids> | --person-ids-file <path> [--action-id <id>] [--cdp-port <port>] [--json]
 lhremote campaign-exclude-remove <campaignId> --person-ids <ids> | --person-ids-file <path> [--action-id <id>] [--cdp-port <port>] [--json]
+lhremote campaign-remove-people <campaignId> --person-ids <ids> | --person-ids-file <path> [--cdp-port <port>] [--json]
 lhremote import-people-from-urls <campaignId> --urls <urls> | --urls-file <path> [--cdp-port <port>] [--json]
+lhremote collect-people <campaignId> <sourceUrl> [--limit <n>] [--max-pages <n>] [--page-size <n>] [--source-type <type>] [--cdp-port <port>] [--json]
+```
+
+### Collections
+
+```sh
+lhremote list-collections [--json]
+lhremote create-collection <name> [--cdp-port <port>] [--json]
+lhremote delete-collection <collectionId> [--cdp-port <port>] [--json]
+lhremote add-people-to-collection <collectionId> --person-ids <ids> | --person-ids-file <path> [--cdp-port <port>] [--json]
+lhremote remove-people-from-collection <collectionId> --person-ids <ids> | --person-ids-file <path> [--cdp-port <port>] [--json]
+lhremote import-people-from-collection <collectionId> <campaignId> [--cdp-port <port>] [--json]
 ```
 
 ### Profiles & Messaging
 
 ```sh
-lhremote query-profile --person-id <id> | --public-id <slug> [--json]
-lhremote query-profiles [--query <text>] [--company <name>] [--limit <n>] [--offset <n>] [--json]
+lhremote query-profile --person-id <id> | --public-id <slug> [--include-positions] [--json]
+lhremote query-profiles [--query <text>] [--company <name>] [--include-history] [--limit <n>] [--offset <n>] [--json]
+lhremote query-profiles-bulk --person-id <id>... | --public-id <slug>... [--include-positions] [--json]
 lhremote query-messages [--person-id <id>] [--chat-id <id>] [--search <text>] [--limit <n>] [--offset <n>] [--json]
 lhremote check-replies [--since <timestamp>] [--cdp-port <port>] [--json]
-lhremote scrape-messaging-history [--cdp-port <port>] [--json]
+lhremote scrape-messaging-history --person-ids <ids> | --person-ids-file <path> [--cdp-port <port>] [--json]
 ```
 
 ### Utilities
 
 ```sh
 lhremote describe-actions [--category <category>] [--type <type>] [--json]
+lhremote get-errors [--cdp-port <port>] [--json]
 ```
 
 ## MCP Tools
@@ -169,6 +186,7 @@ Launch the LinkedHelper application with remote debugging enabled.
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `cdpPort` | number | No | auto-select | CDP port to use |
+| `force` | boolean | No | false | Kill existing LinkedHelper processes before launching |
 
 #### `quit-app`
 
@@ -227,12 +245,12 @@ List existing campaigns with summary statistics.
 
 #### `campaign-create`
 
-Create a new campaign from YAML or JSON configuration. Provide exactly one of `yamlConfig` or `jsonConfig`.
+Create a new campaign from YAML or JSON configuration.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `yamlConfig` | string | No | — | YAML campaign configuration |
-| `jsonConfig` | string | No | — | JSON campaign configuration |
+| `config` | string | Yes | — | Campaign configuration in YAML or JSON format |
+| `format` | string | No | yaml | Configuration format (`yaml` or `json`) |
 | `cdpPort` | number | No | 9222 | CDP port |
 
 #### `campaign-get`
@@ -276,12 +294,12 @@ Delete (archive) a campaign.
 
 #### `campaign-start`
 
-Start a campaign with specified target persons.
+Start a campaign with specified target persons. Returns immediately (async execution).
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `campaignId` | number | Yes | — | Campaign ID |
-| `personIds` | number[] | No | — | Person IDs to target |
+| `personIds` | number[] | Yes | — | Person IDs to target |
 | `cdpPort` | number | No | 9222 | CDP port |
 
 #### `campaign-stop`
@@ -322,7 +340,7 @@ Reset specified people for re-run in a campaign.
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `campaignId` | number | Yes | — | Campaign ID |
-| `personIds` | number[] | No | — | Person IDs to retry |
+| `personIds` | number[] | Yes | — | Person IDs to retry |
 | `cdpPort` | number | No | 9222 | CDP port |
 
 ### Campaign Actions
@@ -352,6 +370,21 @@ Remove an action from a campaign's action chain.
 | `actionId` | number | Yes | — | Action ID to remove |
 | `cdpPort` | number | No | 9222 | CDP port |
 
+#### `campaign-update-action`
+
+Update an existing action's configuration in a campaign. Only provided fields are changed.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `campaignId` | number | Yes | — | Campaign ID |
+| `actionId` | number | Yes | — | Action ID to update |
+| `name` | string | No | — | New display name |
+| `description` | string \| null | No | — | New description (null to clear) |
+| `coolDown` | number | No | — | Milliseconds between executions |
+| `maxActionResultsPerIteration` | number | No | — | Max results per iteration (-1 for unlimited) |
+| `actionSettings` | string | No | — | Action-specific settings as JSON (merged with existing) |
+| `cdpPort` | number | No | 9222 | CDP port |
+
 #### `campaign-reorder-actions`
 
 Reorder actions in a campaign's action chain.
@@ -370,7 +403,7 @@ Move people from one action to the next in a campaign.
 |-----------|------|----------|---------|-------------|
 | `campaignId` | number | Yes | — | Campaign ID |
 | `actionId` | number | Yes | — | Action ID to move people from |
-| `personIds` | number[] | No | — | Person IDs to move |
+| `personIds` | number[] | Yes | — | Person IDs to move |
 | `cdpPort` | number | No | 9222 | CDP port |
 
 ### Campaign Targeting
@@ -407,6 +440,29 @@ Remove people from a campaign or action exclude list.
 | `actionId` | number | No | — | Action ID (for action-level list) |
 | `cdpPort` | number | No | 9222 | CDP port |
 
+#### `campaign-list-people`
+
+List people assigned to a campaign with their processing status.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `campaignId` | number | Yes | — | Campaign ID |
+| `actionId` | number | No | — | Filter to a specific action |
+| `status` | string | No | — | Filter by status (`queued`, `processed`, `successful`, `failed`) |
+| `limit` | number | No | 20 | Max results |
+| `offset` | number | No | 0 | Pagination offset |
+| `cdpPort` | number | No | 9222 | CDP port |
+
+#### `campaign-remove-people`
+
+Remove people from a campaign's target list entirely. This is the inverse of `import-people-from-urls`.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `campaignId` | number | Yes | — | Campaign ID |
+| `personIds` | number[] | Yes | — | Person IDs to remove |
+| `cdpPort` | number | No | 9222 | CDP port |
+
 #### `import-people-from-urls`
 
 Import LinkedIn profile URLs into a campaign action target list. Idempotent — previously imported URLs are skipped.
@@ -415,6 +471,78 @@ Import LinkedIn profile URLs into a campaign action target list. Idempotent — 
 |-----------|------|----------|---------|-------------|
 | `campaignId` | number | Yes | — | Campaign ID |
 | `urls` | string[] | Yes | — | LinkedIn profile URLs |
+| `cdpPort` | number | No | 9222 | CDP port |
+
+#### `collect-people`
+
+Collect people from a LinkedIn page into a campaign. Detects the source type from the URL automatically.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `campaignId` | number | Yes | — | Campaign ID to collect into |
+| `sourceUrl` | string | Yes | — | LinkedIn page URL (search results, company people, group members) |
+| `limit` | number | No | — | Max profiles to collect |
+| `maxPages` | number | No | — | Max pages to process |
+| `pageSize` | number | No | — | Results per page |
+| `sourceType` | string | No | — | Explicit source type (bypasses URL detection) |
+| `cdpPort` | number | No | 9222 | CDP port |
+
+### Collections
+
+#### `list-collections`
+
+List all LinkedHelper collections (Lists) with people counts.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `cdpPort` | number | No | 9222 | CDP port |
+
+#### `create-collection`
+
+Create a new named LinkedHelper collection (List).
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `name` | string | Yes | — | Name for the new collection |
+| `cdpPort` | number | No | 9222 | CDP port |
+
+#### `delete-collection`
+
+Delete a LinkedHelper collection (List) and all its people associations.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `collectionId` | number | Yes | — | Collection ID to delete |
+| `cdpPort` | number | No | 9222 | CDP port |
+
+#### `add-people-to-collection`
+
+Add people to a LinkedHelper collection. Idempotent — adding an already-present person is a no-op.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `collectionId` | number | Yes | — | Collection ID |
+| `personIds` | number[] | Yes | — | Person IDs to add |
+| `cdpPort` | number | No | 9222 | CDP port |
+
+#### `remove-people-from-collection`
+
+Remove people from a LinkedHelper collection.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `collectionId` | number | Yes | — | Collection ID |
+| `personIds` | number[] | Yes | — | Person IDs to remove |
+| `cdpPort` | number | No | 9222 | CDP port |
+
+#### `import-people-from-collection`
+
+Import all people from a LinkedHelper collection into a campaign. Large sets are automatically chunked.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `collectionId` | number | Yes | — | Collection ID to import from |
+| `campaignId` | number | Yes | — | Campaign ID to import into |
 | `cdpPort` | number | No | 9222 | CDP port |
 
 ### Profiles & Messaging
@@ -427,6 +555,7 @@ Look up a cached LinkedIn profile from the local database by person ID or public
 |-----------|------|----------|---------|-------------|
 | `personId` | number | No | — | Internal person ID |
 | `publicId` | string | No | — | LinkedIn public ID (URL slug) |
+| `includePositions` | boolean | No | false | Include full position history (career history) |
 
 #### `query-profiles`
 
@@ -436,8 +565,19 @@ Search for profiles in the local database with name, headline, or company filter
 |-----------|------|----------|---------|-------------|
 | `query` | string | No | — | Search name or headline |
 | `company` | string | No | — | Filter by company |
+| `includeHistory` | boolean | No | false | Also search past positions (company history), not just current |
 | `limit` | number | No | 20 | Max results |
 | `offset` | number | No | 0 | Pagination offset |
+
+#### `query-profiles-bulk`
+
+Look up multiple cached LinkedIn profiles in a single call.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `personIds` | number[] | No | — | Look up by internal person IDs |
+| `publicIds` | string[] | No | — | Look up by LinkedIn public IDs (URL slugs) |
+| `includePositions` | boolean | No | false | Include full position history |
 
 #### `query-messages`
 
@@ -462,10 +602,11 @@ Check for new message replies from LinkedIn.
 
 #### `scrape-messaging-history`
 
-Scrape all messaging history from LinkedIn into the local database. This is a long-running operation that navigates LinkedIn's messaging interface.
+Scrape messaging history from LinkedIn for specified people into the local database. This is a long-running operation that may take several minutes.
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
+| `personIds` | number[] | Yes | — | Person IDs whose messaging history should be scraped |
 | `cdpPort` | number | No | 9222 | CDP port |
 
 ### Utilities
@@ -478,6 +619,14 @@ List available LinkedHelper action types with descriptions and configuration sch
 |-----------|------|----------|---------|-------------|
 | `category` | string | No | — | Filter by category (`people`, `messaging`, `engagement`, `crm`, `workflow`) |
 | `actionType` | string | No | — | Get details for a specific action type |
+
+#### `get-errors`
+
+Query current LinkedHelper UI errors, dialogs, and blocking popups.
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `cdpPort` | number | No | 9222 | CDP port |
 
 ## Known Limitations
 
@@ -494,6 +643,12 @@ List available LinkedHelper action types with descriptions and configuration sch
 **Error**: `LinkedHelper is not running (no CDP endpoint at port 9222)`
 
 **Solution**: Use `launch-app` to start LinkedHelper, or start it manually. lhremote communicates with LinkedHelper via the Chrome DevTools Protocol (CDP), which requires the application to be running.
+
+### LinkedHelper is unreachable
+
+**Error**: `LinkedHelper processes detected but CDP endpoint is unreachable`
+
+**Solution**: LinkedHelper is running but its CDP port is not responding. This typically means a stale or zombie process. Use `launch-app --force` to kill stale processes and relaunch, or manually restart LinkedHelper.
 
 ### Application binary not found
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -67,16 +67,16 @@ gets full access to every registered tool.
 
 #### Tool Surface
 
-32 tools are registered via `registerAllTools()` in
+44 tools are registered via `registerAllTools()` in
 `packages/mcp/src/tools/index.ts`. They fall into three risk tiers:
 
 | Tier | Tools |
 |------|-------|
-| **Read-only** (no side effects) | `check-status`, `find-app`, `list-accounts`, `query-profile`, `query-profiles`, `query-messages`, `campaign-get`, `campaign-list`, `campaign-export`, `campaign-statistics`, `campaign-status`, `campaign-exclude-list`, `describe-actions`, `check-replies` |
-| **State-changing** (modifies LinkedHelper state) | `launch-app`, `quit-app`, `start-instance`, `stop-instance`, `campaign-create`, `campaign-update`, `campaign-start`, `campaign-stop`, `campaign-retry`, `campaign-move-next`, `campaign-add-action`, `campaign-remove-action`, `campaign-reorder-actions`, `campaign-exclude-add`, `campaign-exclude-remove`, `import-people-from-urls`, `scrape-messaging-history` |
-| **Destructive** (permanent data loss) | `campaign-delete` |
+| **Read-only** (no side effects) | `check-status`, `find-app`, `list-accounts`, `query-profile`, `query-profiles`, `query-profiles-bulk`, `query-messages`, `campaign-get`, `campaign-list`, `campaign-export`, `campaign-statistics`, `campaign-status`, `campaign-exclude-list`, `campaign-list-people`, `list-collections`, `describe-actions`, `check-replies`, `get-errors` |
+| **State-changing** (modifies LinkedHelper state) | `launch-app`, `quit-app`, `start-instance`, `stop-instance`, `campaign-create`, `campaign-update`, `campaign-start`, `campaign-stop`, `campaign-retry`, `campaign-move-next`, `campaign-add-action`, `campaign-remove-action`, `campaign-update-action`, `campaign-reorder-actions`, `campaign-exclude-add`, `campaign-exclude-remove`, `campaign-remove-people`, `import-people-from-urls`, `import-people-from-collection`, `collect-people`, `create-collection`, `add-people-to-collection`, `remove-people-from-collection`, `scrape-messaging-history` |
+| **Destructive** (permanent data loss) | `campaign-delete`, `delete-collection` |
 
-All 32 tools are available to any connected MCP client with equal
+All 44 tools are available to any connected MCP client with equal
 privilege. There is no per-tool access control or rate limiting.
 
 #### Prompt Injection Risk
@@ -92,7 +92,7 @@ natural-language interpretation layer.
 
 When `--allow-remote` is enabled, MCP tools connect to CDP endpoints on
 remote hosts. This extends the trust boundary from localhost to the
-network for **all 32 tools** — a remote MCP client gains the same tool
+network for **all 44 tools** — a remote MCP client gains the same tool
 access as a local one, over an unauthenticated CDP connection.
 
 ### Recommendations
@@ -103,7 +103,7 @@ access as a local one, over an unauthenticated CDP connection.
 - **Do not use `--allow-remote`** unless you understand the implications
   and have secured the network path (e.g., mutual TLS via a reverse proxy).
 - **Do not grant MCP access to untrusted AI agents.** Any MCP client
-  that can spawn `lhremote mcp` receives full access to all 32 tools,
+  that can spawn `lhremote mcp` receives full access to all 44 tools,
   including destructive operations.
 - **Review agent tool calls for destructive operations.** When using an
   AI agent as the MCP client, monitor its actions — especially

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -54,10 +54,11 @@ lhremote check-replies --since 2025-01-01T00:00:00Z
 | Account & Instance | `list-accounts`, `start-instance`, `stop-instance`, `check-status` |
 | Campaigns | `campaign-list`, `campaign-create`, `campaign-get`, `campaign-export`, `campaign-update`, `campaign-delete`, `campaign-start`, `campaign-stop` |
 | Campaign Status | `campaign-status`, `campaign-statistics`, `campaign-retry` |
-| Campaign Actions | `campaign-add-action`, `campaign-remove-action`, `campaign-reorder-actions`, `campaign-move-next` |
-| Campaign Targeting | `campaign-exclude-list`, `campaign-exclude-add`, `campaign-exclude-remove`, `import-people-from-urls` |
-| Profiles & Messaging | `query-profile`, `query-profiles`, `query-messages`, `check-replies`, `scrape-messaging-history` |
-| Utilities | `describe-actions` |
+| Campaign Actions | `campaign-add-action`, `campaign-remove-action`, `campaign-update-action`, `campaign-reorder-actions`, `campaign-move-next` |
+| Campaign Targeting | `campaign-exclude-list`, `campaign-exclude-add`, `campaign-exclude-remove`, `campaign-list-people`, `campaign-remove-people`, `import-people-from-urls`, `collect-people` |
+| Collections | `list-collections`, `create-collection`, `delete-collection`, `add-people-to-collection`, `remove-people-from-collection`, `import-people-from-collection` |
+| Profiles & Messaging | `query-profile`, `query-profiles`, `query-profiles-bulk`, `query-messages`, `check-replies`, `scrape-messaging-history` |
+| Utilities | `describe-actions`, `get-errors` |
 
 See the [root README](https://github.com/alexey-pelykh/lhremote#cli-usage) for full command-line usage.
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -34,6 +34,8 @@ npm install @lhremote/core
 | `CampaignRepository` | Campaign CRUD and action-chain management |
 | `ProfileRepository` | Profile lookups and search |
 | `MessageRepository` | Messaging history queries |
+| `CampaignStatisticsRepository` | Campaign execution statistics queries |
+| `CollectionListRepository` | Collection (List) CRUD and people management |
 | `DatabaseClient` | SQLite database connection management |
 | `discoverDatabase` / `discoverAllDatabases` | Locate LinkedHelper database files on disk |
 
@@ -65,7 +67,40 @@ npm install @lhremote/core
 
 | Export | Description |
 |--------|-------------|
+| `campaignCreate` | Create a new campaign from parsed configuration |
+| `campaignGet` | Get detailed campaign information |
+| `campaignList` | List existing campaigns |
+| `campaignUpdate` | Update a campaign's name/description |
+| `campaignDelete` | Delete (archive) a campaign |
+| `campaignExport` | Export campaign configuration |
+| `campaignStart` | Start a campaign with target persons |
+| `campaignStop` | Stop a running campaign |
+| `campaignRetry` | Reset specified people for re-run |
+| `campaignMoveNext` | Move people from one action to the next |
 | `campaignStatus` | Retrieve campaign status with statistics and action details |
+| `campaignStatistics` | Get per-action statistics |
+| `campaignAddAction` | Add an action to a campaign |
+| `campaignRemoveAction` | Remove an action from a campaign |
+| `campaignUpdateAction` | Update an existing action's configuration |
+| `campaignReorderActions` | Reorder actions in a campaign |
+| `campaignExcludeList` | View the exclude list for a campaign or action |
+| `campaignExcludeAdd` | Add people to an exclude list |
+| `campaignExcludeRemove` | Remove people from an exclude list |
+| `campaignListPeople` | List people assigned to a campaign |
+| `campaignRemovePeople` | Remove people from a campaign target list |
+| `importPeopleFromUrls` | Import LinkedIn profile URLs into a campaign |
+| `collectPeople` | Collect people from a LinkedIn page into a campaign |
+| `queryProfilesBulk` | Look up multiple profiles in a single call |
+| `queryMessages` | Query messaging history |
+| `checkReplies` | Check for new message replies |
+| `scrapeMessagingHistory` | Scrape messaging history from LinkedIn |
+| `getErrors` | Query current UI errors and dialogs |
+| `listCollections` | List all LinkedHelper collections |
+| `createCollection` | Create a new collection |
+| `deleteCollection` | Delete a collection |
+| `addPeopleToCollection` | Add people to a collection |
+| `removePeopleFromCollection` | Remove people from a collection |
+| `importPeopleFromCollection` | Import collection people into a campaign |
 
 ### Constants & Utilities
 
@@ -106,6 +141,10 @@ npm install @lhremote/core
 | `CDPError` | General CDP protocol error |
 | `CDPEvaluationError` | CDP JavaScript evaluation failed |
 | `CDPTimeoutError` | CDP operation timed out |
+| `LinkedHelperUnreachableError` | LinkedHelper processes detected but CDP endpoint unreachable |
+| `CollectionError` | General collection operation error |
+| `CollectionBusyError` | Collection operation blocked (LinkedHelper busy) |
+| `UIBlockedError` | LinkedHelper UI blocked by dialog or popup |
 
 ## Usage
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -2,7 +2,7 @@
 
 MCP server for [lhremote](https://github.com/alexey-pelykh/lhremote) — LinkedHelper automation toolkit.
 
-This package exposes the full LinkedHelper automation surface as a [Model Context Protocol](https://modelcontextprotocol.io) server. AI assistants (Claude, etc.) connect over stdio and use the 32 registered tools to control LinkedHelper.
+This package exposes the full LinkedHelper automation surface as a [Model Context Protocol](https://modelcontextprotocol.io) server. AI assistants (Claude, etc.) connect over stdio and use the 44 registered tools to control LinkedHelper.
 
 Built on [`@lhremote/core`](../core).
 
@@ -52,10 +52,11 @@ await runStdioServer();
 | Account & Instance | `list-accounts`, `start-instance`, `stop-instance`, `check-status` |
 | Campaigns | `campaign-list`, `campaign-create`, `campaign-get`, `campaign-export`, `campaign-update`, `campaign-delete`, `campaign-start`, `campaign-stop` |
 | Campaign Status | `campaign-status`, `campaign-statistics`, `campaign-retry` |
-| Campaign Actions | `campaign-add-action`, `campaign-remove-action`, `campaign-reorder-actions`, `campaign-move-next` |
-| Campaign Targeting | `campaign-exclude-list`, `campaign-exclude-add`, `campaign-exclude-remove`, `import-people-from-urls` |
-| Profiles & Messaging | `query-profile`, `query-profiles`, `query-messages`, `check-replies`, `scrape-messaging-history` |
-| Utilities | `describe-actions` |
+| Campaign Actions | `campaign-add-action`, `campaign-remove-action`, `campaign-update-action`, `campaign-reorder-actions`, `campaign-move-next` |
+| Campaign Targeting | `campaign-exclude-list`, `campaign-exclude-add`, `campaign-exclude-remove`, `campaign-list-people`, `campaign-remove-people`, `import-people-from-urls`, `collect-people` |
+| Collections | `list-collections`, `create-collection`, `delete-collection`, `add-people-to-collection`, `remove-people-from-collection`, `import-people-from-collection` |
+| Profiles & Messaging | `query-profile`, `query-profiles`, `query-profiles-bulk`, `query-messages`, `check-replies`, `scrape-messaging-history` |
+| Utilities | `describe-actions`, `get-errors` |
 
 See the [root README](https://github.com/alexey-pelykh/lhremote#mcp-tools) for parameter details on each tool.
 


### PR DESCRIPTION
## Summary

- Update all user-facing docs to reflect the current **44-tool** surface (was documented as 32)
- Add parameter tables and CLI usage for **12 new tools**: `campaign-update-action`, `campaign-list-people`, `campaign-remove-people`, `collect-people`, `query-profiles-bulk`, `get-errors`, and 6 collection management tools (`list-collections`, `create-collection`, `delete-collection`, `add-people-to-collection`, `remove-people-from-collection`, `import-people-from-collection`)
- Fix inaccurate parameter docs: `campaign-create` (config/format params), `campaign-start`/`campaign-retry`/`campaign-move-next`/`scrape-messaging-history` (`personIds` now required)
- Add missing parameters: `launch-app` `force`, `query-profile` `includePositions`, `query-profiles` `includeHistory`
- Update `SECURITY.md` tool risk tiers with all new tools classified
- Add `LinkedHelperUnreachableError` to troubleshooting section
- Update `packages/core/README.md` with missing operations, data access, and error type exports

### Files changed

| File | Changes |
|------|---------|
| `README.md` | Tool count, CLI usage, MCP parameter tables, troubleshooting |
| `SECURITY.md` | Tool count (32→44), risk tier classification |
| `packages/mcp/README.md` | Tool count, registered tools table |
| `packages/cli/README.md` | Commands table |
| `packages/core/README.md` | Operations, data access, error types |

## Test plan

- [ ] Verify all documented parameter names match actual MCP tool schemas
- [ ] Verify CLI usage examples are syntactically correct
- [ ] Verify internal links resolve correctly
- [ ] Confirm tool count (44) matches `registerAllTools()` in `packages/mcp/src/tools/index.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)