### PR TITLE
Fix start-instance 'require is not defined' error

### DIFF
--- a/packages/core/src/cdp/client.ts
+++ b/packages/core/src/cdp/client.ts
@@ -135,17 +135,27 @@ export class CDPClient {
    *
    * @param expression  - JavaScript source to evaluate.
    * @param awaitPromise - Whether to await a Promise result (default `false`).
+   * @param contextId - Optional execution context ID. When provided the
+   *   expression runs in that context instead of the default (main world).
+   *   Use this to evaluate in the Electron preload context when
+   *   `nodeIntegration` is disabled in the renderer.
    * @returns The deserialized value from the remote context.
    */
   async evaluate<T = unknown>(
     expression: string,
     awaitPromise = false,
+    contextId?: number,
   ): Promise<T> {
-    const result = (await this.send("Runtime.evaluate", {
+    const params: Record<string, unknown> = {
       expression,
       awaitPromise,
       returnByValue: true,
-    })) as {
+    };
+    if (contextId !== undefined) {
+      params.contextId = contextId;
+    }
+
+    const result = (await this.send("Runtime.evaluate", params)) as {
       result?: { value?: unknown };
       exceptionDetails?: { exception?: { description?: string }; text?: string };
     };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -105,6 +105,7 @@ export {
   waitForInstanceShutdown,
   withDatabase,
   withInstanceDatabase,
+  NodeIntegrationUnavailableError,
   WrongPortError,
 } from "./services/index.js";
 

--- a/packages/core/src/services/errors.ts
+++ b/packages/core/src/services/errors.ts
@@ -109,6 +109,24 @@ export class WrongPortError extends ServiceError {
 }
 
 /**
+ * Thrown when the LinkedHelper launcher renderer does not provide
+ * a Node.js execution context (`require` is unavailable in all
+ * CDP execution contexts).
+ *
+ * This typically means LinkedHelper has changed its Electron
+ * configuration beyond what lhremote currently supports.
+ */
+export class NodeIntegrationUnavailableError extends ServiceError {
+  constructor() {
+    super(
+      "LinkedHelper launcher does not expose Node.js APIs (require is unavailable). " +
+        "This may indicate an unsupported LinkedHelper version.",
+    );
+    this.name = "NodeIntegrationUnavailableError";
+  }
+}
+
+/**
  * Thrown when a LinkedHelper action execution fails.
  */
 export class ActionExecutionError extends ServiceError {

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -44,6 +44,7 @@ export {
   InvalidProfileUrlError,
   LinkedHelperNotRunningError,
   LinkedHelperUnreachableError,
+  NodeIntegrationUnavailableError,
   ServiceError,
   StartInstanceError,
   UIBlockedError,

--- a/packages/core/src/services/launcher.test.ts
+++ b/packages/core/src/services/launcher.test.ts
@@ -5,9 +5,9 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
   LinkedHelperNotRunningError,
+  NodeIntegrationUnavailableError,
   ServiceError,
   StartInstanceError,
-  WrongPortError,
 } from "./errors.js";
 import { LauncherService } from "./launcher.js";
 
@@ -18,6 +18,9 @@ import { LauncherService } from "./launcher.js";
 const mockConnect = vi.fn();
 const mockDisconnect = vi.fn();
 const mockEvaluate = vi.fn();
+const mockSend = vi.fn();
+const mockOn = vi.fn();
+const mockOff = vi.fn();
 const mockIsConnected = vi.fn().mockReturnValue(true);
 
 vi.mock("../cdp/index.js", async (importOriginal) => {
@@ -27,6 +30,9 @@ vi.mock("../cdp/index.js", async (importOriginal) => {
       this.connect = mockConnect;
       this.disconnect = mockDisconnect;
       this.evaluate = mockEvaluate;
+      this.send = mockSend;
+      this.on = mockOn;
+      this.off = mockOff;
       Object.defineProperty(this, "isConnected", {
         get: mockIsConnected,
       });
@@ -48,10 +54,22 @@ afterEach(() => {
 describe("LauncherService", () => {
   let service: LauncherService;
 
+  /** Value returned by the next non-probe evaluate call. */
+  let nextEvaluateResult: unknown = undefined;
+
   beforeEach(() => {
     service = new LauncherService(9222);
     mockConnect.mockResolvedValue(undefined);
-    mockEvaluate.mockResolvedValue(undefined);
+    nextEvaluateResult = undefined;
+
+    // Default: require is available in the default context.
+    // The probe call returns true; all other calls return nextEvaluateResult.
+    mockEvaluate.mockImplementation((expression: string) => {
+      if (expression === "typeof require === 'function'") {
+        return Promise.resolve(true);
+      }
+      return Promise.resolve(nextEvaluateResult);
+    });
   });
 
   describe("connect", () => {
@@ -59,6 +77,14 @@ describe("LauncherService", () => {
       await service.connect();
 
       expect(service.isConnected).toBe(true);
+    });
+
+    it("probes for require availability during connect", async () => {
+      await service.connect();
+
+      expect(mockEvaluate).toHaveBeenCalledWith(
+        "typeof require === 'function'",
+      );
     });
 
     it("wraps CDPConnectionError into LinkedHelperNotRunningError", async () => {
@@ -79,6 +105,87 @@ describe("LauncherService", () => {
     });
   });
 
+  describe("connect with context fallback", () => {
+    it("falls back to preload context when default lacks require", async () => {
+      let probeCount = 0;
+      mockEvaluate.mockImplementation((expression: string, _await?: boolean, contextId?: number) => {
+        if (expression === "typeof require === 'function'") {
+          probeCount++;
+          // First probe (default context): no require
+          // Second probe (preload context id=2): has require
+          return Promise.resolve(probeCount >= 2 && contextId === 2);
+        }
+        return Promise.resolve(undefined);
+      });
+
+      mockOn.mockImplementation((event: string, handler: (params: unknown) => void) => {
+        if (event === "Runtime.executionContextCreated") {
+          handler({ context: { id: 1, auxData: { isDefault: true } } });
+          handler({ context: { id: 2, auxData: { isDefault: false } } });
+        }
+      });
+      mockSend.mockResolvedValue(undefined);
+
+      await service.connect();
+
+      expect(service.isConnected).toBe(true);
+      expect(mockSend).toHaveBeenCalledWith("Runtime.enable");
+      expect(mockSend).toHaveBeenCalledWith("Runtime.disable");
+    });
+
+    it("throws NodeIntegrationUnavailableError when no context has require", async () => {
+      mockEvaluate.mockImplementation((expression: string) => {
+        if (expression === "typeof require === 'function'") {
+          return Promise.resolve(false);
+        }
+        return Promise.resolve(undefined);
+      });
+
+      mockOn.mockImplementation((event: string, handler: (params: unknown) => void) => {
+        if (event === "Runtime.executionContextCreated") {
+          handler({ context: { id: 1, auxData: { isDefault: true } } });
+          handler({ context: { id: 2, auxData: { isDefault: false } } });
+        }
+      });
+      mockSend.mockResolvedValue(undefined);
+
+      await expect(service.connect()).rejects.toThrow(
+        NodeIntegrationUnavailableError,
+      );
+    });
+
+    it("uses preload context for subsequent evaluations", async () => {
+      const PRELOAD_CONTEXT_ID = 42;
+      let probeCount = 0;
+
+      mockEvaluate.mockImplementation((expression: string, _await?: boolean, contextId?: number) => {
+        if (expression === "typeof require === 'function'") {
+          probeCount++;
+          return Promise.resolve(probeCount >= 2 && contextId === PRELOAD_CONTEXT_ID);
+        }
+        return Promise.resolve(nextEvaluateResult);
+      });
+
+      mockOn.mockImplementation((event: string, handler: (params: unknown) => void) => {
+        if (event === "Runtime.executionContextCreated") {
+          handler({ context: { id: 1, auxData: { isDefault: true } } });
+          handler({ context: { id: PRELOAD_CONTEXT_ID, auxData: { isDefault: false } } });
+        }
+      });
+      mockSend.mockResolvedValue(undefined);
+
+      await service.connect();
+
+      nextEvaluateResult = [];
+      await service.listAccounts();
+
+      const calls = mockEvaluate.mock.calls;
+      const lastCall = calls[calls.length - 1];
+      expect(lastCall).toBeDefined();
+      expect(lastCall?.[2]).toBe(PRELOAD_CONTEXT_ID);
+    });
+  });
+
   describe("disconnect", () => {
     it("disconnects the CDPClient", async () => {
       await service.connect();
@@ -95,26 +202,28 @@ describe("LauncherService", () => {
   describe("startInstance", () => {
     it("evaluates the startInstance expression", async () => {
       await service.connect();
-      mockEvaluate.mockResolvedValue({ success: true });
+      nextEvaluateResult = { success: true };
 
       await service.startInstance(42);
 
       expect(mockEvaluate).toHaveBeenCalledWith(
         expect.stringContaining("startInstance"),
         true,
+        undefined,
       );
       expect(mockEvaluate).toHaveBeenCalledWith(
         expect.stringContaining("42"),
         true,
+        undefined,
       );
     });
 
     it("throws StartInstanceError on failure", async () => {
       await service.connect();
-      mockEvaluate.mockResolvedValue({
+      nextEvaluateResult = {
         success: false,
         error: "account is already running",
-      });
+      };
 
       await expect(service.startInstance(42)).rejects.toThrow(
         StartInstanceError,
@@ -138,6 +247,7 @@ describe("LauncherService", () => {
       expect(mockEvaluate).toHaveBeenCalledWith(
         expect.stringContaining("stopInstance"),
         true,
+        undefined,
       );
     });
 
@@ -149,7 +259,7 @@ describe("LauncherService", () => {
   describe("getInstanceStatus", () => {
     it("returns the instance status", async () => {
       await service.connect();
-      mockEvaluate.mockResolvedValue("running");
+      nextEvaluateResult = "running";
 
       const status = await service.getInstanceStatus(42);
 
@@ -158,7 +268,7 @@ describe("LauncherService", () => {
 
     it("returns stopped when status is null", async () => {
       await service.connect();
-      mockEvaluate.mockResolvedValue("stopped");
+      nextEvaluateResult = "stopped";
 
       const status = await service.getInstanceStatus(42);
 
@@ -169,10 +279,10 @@ describe("LauncherService", () => {
   describe("listAccounts", () => {
     it("returns parsed accounts", async () => {
       await service.connect();
-      mockEvaluate.mockResolvedValue([
+      nextEvaluateResult = [
         { id: 1, liId: 100, name: "Alice", email: "alice@test.com" },
         { id: 2, liId: 200, name: "Bob" },
-      ]);
+      ];
 
       const accounts = await service.listAccounts();
 
@@ -187,73 +297,25 @@ describe("LauncherService", () => {
 
     it("returns empty array when no accounts", async () => {
       await service.connect();
-      mockEvaluate.mockResolvedValue(null);
+      nextEvaluateResult = null;
 
       const accounts = await service.listAccounts();
 
       expect(accounts).toEqual([]);
     });
 
-    it("throws WrongPortError when require is not defined", async () => {
+    it("propagates CDPEvaluationErrors directly", async () => {
       await service.connect();
-      mockEvaluate.mockRejectedValue(
-        new CDPEvaluationError("ReferenceError: require is not defined"),
-      );
-
-      await expect(service.listAccounts()).rejects.toThrow(WrongPortError);
-      await expect(service.listAccounts()).rejects.toThrow(
-        /appears to be a LinkedHelper instance/,
-      );
-    });
-  });
-
-  describe("wrong port detection", () => {
-    it("throws WrongPortError from startInstance", async () => {
-      await service.connect();
-      mockEvaluate.mockRejectedValue(
-        new CDPEvaluationError("ReferenceError: require is not defined"),
-      );
-
-      await expect(service.startInstance(42)).rejects.toThrow(WrongPortError);
-    });
-
-    it("throws WrongPortError from stopInstance", async () => {
-      await service.connect();
-      mockEvaluate.mockRejectedValue(
-        new CDPEvaluationError("ReferenceError: require is not defined"),
-      );
-
-      await expect(service.stopInstance(42)).rejects.toThrow(WrongPortError);
-    });
-
-    it("throws WrongPortError from getInstanceStatus", async () => {
-      await service.connect();
-      mockEvaluate.mockRejectedValue(
-        new CDPEvaluationError("ReferenceError: require is not defined"),
-      );
-
-      await expect(service.getInstanceStatus(42)).rejects.toThrow(
-        WrongPortError,
-      );
-    });
-
-    it("does not catch unrelated CDPEvaluationErrors", async () => {
-      await service.connect();
-      mockEvaluate.mockRejectedValue(
-        new CDPEvaluationError("TypeError: Cannot read property 'get' of undefined"),
-      );
+      mockEvaluate.mockImplementation((expression: string) => {
+        if (expression === "typeof require === 'function'") {
+          return Promise.resolve(true);
+        }
+        return Promise.reject(
+          new CDPEvaluationError("TypeError: Cannot read property 'get' of undefined"),
+        );
+      });
 
       await expect(service.listAccounts()).rejects.toThrow(CDPEvaluationError);
-      await expect(service.listAccounts()).rejects.not.toThrow(WrongPortError);
-    });
-
-    it("includes the port number in the error message", async () => {
-      await service.connect();
-      mockEvaluate.mockRejectedValue(
-        new CDPEvaluationError("ReferenceError: require is not defined"),
-      );
-
-      await expect(service.listAccounts()).rejects.toThrow(/9222/);
     });
   });
 });

--- a/packages/core/src/services/launcher.ts
+++ b/packages/core/src/services/launcher.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-import { CDPClient, CDPConnectionError, CDPEvaluationError, findApp } from "../cdp/index.js";
+import { CDPClient, CDPConnectionError, findApp } from "../cdp/index.js";
 import { DEFAULT_CDP_PORT } from "../constants.js";
 import type {
   Account,
@@ -14,9 +14,9 @@ import type {
 import {
   LinkedHelperNotRunningError,
   LinkedHelperUnreachableError,
+  NodeIntegrationUnavailableError,
   ServiceError,
   StartInstanceError,
-  WrongPortError,
 } from "./errors.js";
 
 /**
@@ -31,6 +31,7 @@ export class LauncherService {
   private readonly host: string;
   private readonly allowRemote: boolean;
   private client: CDPClient | null = null;
+  private nodeContextId: number | undefined;
 
   constructor(
     port: number = DEFAULT_CDP_PORT,
@@ -61,6 +62,7 @@ export class LauncherService {
       throw error;
     }
     this.client = client;
+    this.nodeContextId = await this.resolveNodeContextId(client);
   }
 
   /**
@@ -69,6 +71,7 @@ export class LauncherService {
   disconnect(): void {
     this.client?.disconnect();
     this.client = null;
+    this.nodeContextId = undefined;
   }
 
   /**
@@ -279,16 +282,75 @@ export class LauncherService {
     expression: string,
     awaitPromise = false,
   ): Promise<T> {
+    return client.evaluate<T>(expression, awaitPromise, this.nodeContextId);
+  }
+
+  /**
+   * Discover which CDP execution context provides `require()`.
+   *
+   * With `nodeIntegration` enabled, the default (main world) context
+   * has `require()`.  When `nodeIntegration` is disabled (newer Electron
+   * configurations), the Electron preload script still runs with Node.js
+   * access in a separate isolated context.  This method probes all
+   * available contexts to find one where `require()` is available.
+   *
+   * @returns The `contextId` for the Node.js-capable context, or
+   *   `undefined` when the default context already has `require()`.
+   * @throws {NodeIntegrationUnavailableError} if no context provides
+   *   `require()`.
+   */
+  private async resolveNodeContextId(
+    client: CDPClient,
+  ): Promise<number | undefined> {
+    // Try the default context first (backward-compatible path).
     try {
-      return await client.evaluate<T>(expression, awaitPromise);
-    } catch (error) {
-      if (
-        error instanceof CDPEvaluationError &&
-        error.message.includes("require is not defined")
-      ) {
-        throw new WrongPortError(this.port);
-      }
-      throw error;
+      const hasRequire = await client.evaluate<boolean>(
+        "typeof require === 'function'",
+      );
+      if (hasRequire) return undefined;
+    } catch {
+      // Default context doesn't have require — probe other contexts.
     }
+
+    // Collect all execution contexts via Runtime.enable.
+    // CDP sends executionContextCreated events for existing contexts
+    // before resolving the enable response, so by the time `send`
+    // resolves all contexts have been collected.
+    interface ExecutionContext {
+      id: number;
+      auxData?: { isDefault?: boolean };
+    }
+    const contexts: ExecutionContext[] = [];
+    const handler = (params: unknown) => {
+      const { context } = params as { context: ExecutionContext };
+      contexts.push(context);
+    };
+
+    client.on("Runtime.executionContextCreated", handler);
+    try {
+      await client.send("Runtime.enable");
+    } finally {
+      client.off("Runtime.executionContextCreated", handler);
+    }
+
+    try {
+      for (const ctx of contexts) {
+        if (ctx.auxData?.isDefault) continue;
+        try {
+          const hasRequire = await client.evaluate<boolean>(
+            "typeof require === 'function'",
+            false,
+            ctx.id,
+          );
+          if (hasRequire) return ctx.id;
+        } catch {
+          // This context doesn't support require — try next.
+        }
+      }
+    } finally {
+      await client.send("Runtime.disable").catch(() => {});
+    }
+
+    throw new NodeIntegrationUnavailableError();
   }
 }


### PR DESCRIPTION
## Summary

- Resolves `start-instance` failure when LinkedHelper's Electron renderer has `nodeIntegration` disabled
- During `connect()`, probes all CDP execution contexts to find one with `require()` available — falls back from the default context to the Electron preload's isolated world
- Adds `NodeIntegrationUnavailableError` for clear diagnostics when no Node.js context exists
- Removes incorrect `WrongPortError` mapping that misattributed the `require is not defined` error

Closes #423

## Test plan

- [x] All 19 launcher unit tests pass (including 3 new context-fallback tests)
- [x] Lint clean
- [ ] E2E verification with LinkedHelper (local — requires app running)

🤖 Generated with [Claude Code](https://claude.com/claude-code)