### PR TITLE
Bump claude-plugin version to 0.2.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "lhremote",
       "source": "./",
       "description": "LinkedHelper automation toolkit — MCP server and workflow guidance for Claude Code",
-      "version": "0.2.1",
+      "version": "0.2.2",
       "author": {
         "name": "Alexey Pelykh"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lhremote",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "LinkedHelper automation toolkit — MCP server and workflow guidance for Claude Code",
   "author": {
     "name": "Alexey Pelykh",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,7 @@ Do **not** add issue numbers (e.g. `(#12)`) to commit messages. GitHub links PRs
 - **Release**: GitHub Actions (`release.yml`) — triggered by GitHub Release publish
   - Validates (build+lint+test), stamps version from tag, publishes to npm (OIDC trusted publishing)
   - Concurrency group `release`, never cancels in-progress
+- **claude-plugin**: `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, and `server.json` versions must be bumped together on each release to stay consistent
 
 ## Task Tracking
 


### PR DESCRIPTION
## Summary

- Bump `.claude-plugin/plugin.json` and `.claude-plugin/marketplace.json` from 0.2.1 to 0.2.2, aligning with `server.json` (already at 0.2.2)
- Document in CLAUDE.md that all three version references must be bumped together on each release

Closes #426

## Test plan

- [x] Verify `plugin.json` version is `0.2.2`
- [x] Verify `marketplace.json` version is `0.2.2`
- [x] Verify `server.json` version is `0.2.2` (unchanged)
- [x] Verify CLAUDE.md documents co-versioning requirement
- [x] `pnpm lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)