### PR TITLE
(fix) core: respect force flag when connectable app exists

### DIFF
--- a/packages/core/src/services/app.test.ts
+++ b/packages/core/src/services/app.test.ts
@@ -265,6 +265,82 @@ describe("AppService", () => {
     });
   });
 
+  describe("launch with force", () => {
+    let mockedProcessKill: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+      mockedProcessKill = vi.fn().mockImplementation(
+        (_pid: number, signal: string | number) => {
+          if (signal === 0) throw new Error("ESRCH");
+        },
+      );
+      vi.stubGlobal("process", {
+        ...process,
+        platform: "darwin",
+        env: {},
+        kill: mockedProcessKill,
+      });
+      mockedFindApp.mockResolvedValue([]);
+    });
+
+    it("kills all processes when connectable app exists", async () => {
+      mockedFindApp.mockResolvedValue([
+        { pid: 111, cdpPort: 9222, connectable: true },
+        { pid: 222, cdpPort: null, connectable: false },
+      ]);
+      mockedAccessSync.mockReturnValue(undefined);
+      mockedGetPort.mockResolvedValue(54321);
+
+      const child = makeMockChild();
+      mockedSpawn.mockReturnValue(child);
+
+      const service = new AppService(undefined, { ...FAST_OPTIONS, force: true });
+      await service.launch();
+
+      expect(mockedProcessKill).toHaveBeenCalledWith(111, "SIGKILL");
+      expect(mockedProcessKill).toHaveBeenCalledWith(222, "SIGKILL");
+      expect(mockedSpawn).toHaveBeenCalled();
+      expect(service.cdpPort).toBe(54321);
+    });
+
+    it("kills unreachable processes before relaunching", async () => {
+      mockedFindApp.mockResolvedValue([
+        { pid: 333, cdpPort: null, connectable: false },
+      ]);
+      mockedAccessSync.mockReturnValue(undefined);
+      mockedGetPort.mockResolvedValue(54321);
+
+      const child = makeMockChild();
+      mockedSpawn.mockReturnValue(child);
+
+      const service = new AppService(undefined, { ...FAST_OPTIONS, force: true });
+      await service.launch();
+
+      expect(mockedProcessKill).toHaveBeenCalledWith(333, "SIGKILL");
+      expect(mockedSpawn).toHaveBeenCalled();
+    });
+
+    it("kills processes even when explicit port is already running", async () => {
+      mockedFindApp.mockResolvedValue([
+        { pid: 444, cdpPort: 9222, connectable: true },
+      ]);
+      mockedAccessSync.mockReturnValue(undefined);
+
+      const child = makeMockChild();
+      mockedSpawn.mockReturnValue(child);
+
+      const service = new AppService(9222, { ...FAST_OPTIONS, force: true });
+      await service.launch();
+
+      expect(mockedProcessKill).toHaveBeenCalledWith(444, "SIGKILL");
+      expect(mockedSpawn).toHaveBeenCalledWith(
+        expect.any(String),
+        ["--remote-debugging-port=9222"],
+        expect.any(Object),
+      );
+    });
+  });
+
   describe("quit", () => {
     beforeEach(() => {
       vi.stubGlobal("process", { ...process, platform: "darwin", env: {} });

--- a/packages/core/src/services/app.ts
+++ b/packages/core/src/services/app.ts
@@ -73,27 +73,24 @@ export class AppService {
    * @throws {AppLaunchError} if the process fails to start.
    */
   async launch(): Promise<void> {
-    if (this.assignedPort !== null && await this.isRunning()) {
+    if (this.assignedPort !== null && !this.force && await this.isRunning()) {
       return;
     }
 
     // Proactive conflict detection: check for existing LH processes
     const existingApps = await findApp();
     if (existingApps.length > 0) {
-      const connectable = existingApps.find((a) => a.connectable);
-      if (connectable) {
-        // Already running with CDP — use that port
-        this.assignedPort = connectable.cdpPort;
-        return;
-      }
-      // Running but CDP unreachable
       if (!this.force) {
+        const connectable = existingApps.find((a) => a.connectable);
+        if (connectable) {
+          // Already running with CDP — use that port
+          this.assignedPort = connectable.cdpPort;
+          return;
+        }
         throw new LinkedHelperUnreachableError(existingApps);
       }
-      // Force mode: kill existing processes before relaunching
-      for (const app of existingApps) {
-        process.kill(app.pid, "SIGKILL");
-      }
+      // Force mode: kill all existing processes before relaunching
+      await killProcesses(existingApps.map((a) => a.pid));
     }
 
     if (this.assignedPort === null) {
@@ -255,6 +252,33 @@ function waitForExit(child: ChildProcess, timeout: number): Promise<boolean> {
 
     child.on("exit", onExit);
   });
+}
+
+/**
+ * Send SIGKILL to each PID and wait for the processes to exit.
+ */
+async function killProcesses(pids: number[]): Promise<void> {
+  for (const pid of pids) {
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch {
+      // Process may have already exited
+    }
+  }
+
+  const deadline = Date.now() + QUIT_FORCE_TIMEOUT;
+  while (Date.now() < deadline) {
+    const alive = pids.filter((pid) => {
+      try {
+        process.kill(pid, 0);
+        return true;
+      } catch {
+        return false;
+      }
+    });
+    if (alive.length === 0) return;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
 }
 
 function assertFileExists(path: string): void {


### PR DESCRIPTION
## Summary

- `launch-app --force` was silently reusing an existing connectable process instead of killing it — the connectable-app early return short-circuited before force-kill logic could execute
- Additionally, SIGKILL was sent without waiting for processes to actually exit before spawning a new one
- Restructured `launch()` so `force:true` bypasses both early-return paths and added `killProcesses()` that SIGKILLs and polls until processes are confirmed dead

## Test plan

- [x] Unit tests: 3 new tests covering force + connectable, force + unreachable, force + explicit port
- [x] All 23 existing app.test.ts tests pass (no behavior change for non-force paths)
- [x] Lint passes
- [ ] E2E: manually verify `launch-app --force` kills existing processes

Closes #424

🤖 Generated with [Claude Code](https://claude.com/claude-code)