### PR TITLE
Navigate LinkedIn webview to source URL before collection

### DIFF
--- a/packages/core/src/services/collection.test.ts
+++ b/packages/core/src/services/collection.test.ts
@@ -8,10 +8,12 @@ import { CollectionService } from "./collection.js";
 
 // Mock InstanceService
 const mockEvaluateUI = vi.fn();
+const mockNavigateLinkedIn = vi.fn().mockResolvedValue(undefined);
 
 vi.mock("./instance.js", () => ({
   InstanceService: vi.fn().mockImplementation(function (this: Record<string, unknown>) {
     this.evaluateUI = mockEvaluateUI;
+    this.navigateLinkedIn = mockNavigateLinkedIn;
   }),
 }));
 
@@ -40,7 +42,7 @@ describe("CollectionService", () => {
   });
 
   describe("collect", () => {
-    it("calls canCollect, prepareCollecting, and collect via CDP", async () => {
+    it("navigates, then calls canCollect, prepareCollecting, and collect via CDP", async () => {
       mockEvaluateUI
         .mockResolvedValueOnce("idle")  // getRunnerState
         .mockResolvedValueOnce(true)    // canCollect
@@ -48,6 +50,9 @@ describe("CollectionService", () => {
         .mockResolvedValueOnce(true);   // collect
 
       await service.collect(SEARCH_URL, 1);
+
+      // Navigation via LinkedIn webview
+      expect(mockNavigateLinkedIn).toHaveBeenCalledWith(SEARCH_URL);
 
       expect(mockEvaluateUI).toHaveBeenCalledTimes(4);
 
@@ -164,6 +169,22 @@ describe("CollectionService", () => {
       const error = await service.collect(SEARCH_URL, 1).catch((e: unknown) => e);
       expect(error).toBeInstanceOf(CollectionError);
       expect((error as CollectionError).message).toContain("not on a matching page");
+
+      // Navigation should have been attempted before canCollect
+      expect(mockNavigateLinkedIn).toHaveBeenCalledWith(SEARCH_URL);
+    });
+
+    it("throws CollectionError when navigation fails", async () => {
+      mockEvaluateUI.mockResolvedValueOnce("idle"); // getRunnerState
+      mockNavigateLinkedIn.mockRejectedValueOnce(new Error("Page.navigate timeout"));
+
+      const error = await service.collect(SEARCH_URL, 1).catch((e: unknown) => e);
+      expect(error).toBeInstanceOf(CollectionError);
+      expect((error as CollectionError).message).toContain("Failed to navigate to source URL");
+      expect((error as CollectionError).cause).toBeInstanceOf(Error);
+
+      // canCollect should not be called after navigation failure
+      expect(mockEvaluateUI).toHaveBeenCalledTimes(1);
     });
 
     it("throws CollectionError when prepareCollecting returns false", async () => {

--- a/packages/core/src/services/collection.ts
+++ b/packages/core/src/services/collection.ts
@@ -68,6 +68,18 @@ export class CollectionService {
     }
 
     await this.ensureIdle();
+
+    try {
+      await this.instance.navigateLinkedIn(sourceUrl);
+    } catch (error) {
+      if (error instanceof CollectionError) throw error;
+      const message = errorMessage(error);
+      throw new CollectionError(
+        `Failed to navigate to source URL: ${message}`,
+        { cause: error },
+      );
+    }
+
     await this.assertCanCollect(sourceType);
 
     try {

--- a/packages/core/src/services/instance.test.ts
+++ b/packages/core/src/services/instance.test.ts
@@ -272,6 +272,55 @@ describe("InstanceService", () => {
     });
   });
 
+  describe("navigateLinkedIn", () => {
+    it("enables Page domain, navigates, waits for load, then disables", async () => {
+      mockedDiscoverTargets.mockResolvedValue([LINKEDIN_TARGET, UI_TARGET]);
+      await service.connect();
+
+      const liClient = getClientMocks("LI1");
+
+      await service.navigateLinkedIn("https://www.linkedin.com/search/results/people/");
+
+      expect(liClient.send).toHaveBeenCalledWith("Page.enable");
+      expect(liClient.navigate).toHaveBeenCalledWith(
+        "https://www.linkedin.com/search/results/people/",
+      );
+      expect(liClient.waitForEvent).toHaveBeenCalledWith("Page.loadEventFired");
+      expect(liClient.send).toHaveBeenCalledWith("Page.disable");
+    });
+
+    it("disables Page domain even when navigation fails", async () => {
+      mockedDiscoverTargets.mockResolvedValue([LINKEDIN_TARGET, UI_TARGET]);
+      await service.connect();
+
+      const liClient = getClientMocks("LI1");
+      liClient.navigate.mockRejectedValueOnce(new Error("navigation failed"));
+
+      await expect(
+        service.navigateLinkedIn("https://www.linkedin.com/search/results/people/"),
+      ).rejects.toThrow("navigation failed");
+
+      expect(liClient.send).toHaveBeenCalledWith("Page.disable");
+    });
+
+    it("does not use the UI client", async () => {
+      mockedDiscoverTargets.mockResolvedValue([LINKEDIN_TARGET, UI_TARGET]);
+      await service.connect();
+
+      await service.navigateLinkedIn("https://www.linkedin.com/search/results/people/");
+
+      const uiClient = getClientMocks("UI1");
+      expect(uiClient.navigate).not.toHaveBeenCalled();
+      expect(uiClient.send).not.toHaveBeenCalled();
+    });
+
+    it("throws ServiceError when not connected", async () => {
+      await expect(
+        service.navigateLinkedIn("https://www.linkedin.com/search/results/people/"),
+      ).rejects.toThrow(ServiceError);
+    });
+  });
+
   describe("evaluateUI", () => {
     it("evaluates expression on the UI client only", async () => {
       mockedDiscoverTargets.mockResolvedValue([LINKEDIN_TARGET, UI_TARGET]);

--- a/packages/core/src/services/instance.ts
+++ b/packages/core/src/services/instance.ts
@@ -200,6 +200,28 @@ export class InstanceService {
     }
   }
 
+  /**
+   * Navigate the LinkedIn webview to the given URL.
+   *
+   * Enables the CDP Page domain so that `Page.loadEventFired` events
+   * are delivered, navigates, and waits for the load event before
+   * returning.  This ensures the webview is on the expected page
+   * before downstream operations like `canCollect` are called.
+   *
+   * @throws {ServiceError} if the client is not connected.
+   */
+  async navigateLinkedIn(url: string): Promise<void> {
+    const client = this.ensureLinkedInClient();
+    await client.send("Page.enable");
+    try {
+      const loadPromise = client.waitForEvent("Page.loadEventFired");
+      await client.navigate(url);
+      await loadPromise;
+    } finally {
+      await client.send("Page.disable").catch(() => {});
+    }
+  }
+
   /** Whether both clients are currently connected. */
   get isConnected(): boolean {
     return (
@@ -208,6 +230,13 @@ export class InstanceService {
       this.uiClient !== null &&
       this.uiClient.isConnected
     );
+  }
+
+  private ensureLinkedInClient(): CDPClient {
+    if (!this.linkedInClient) {
+      throw new ServiceError("InstanceService is not connected (LinkedIn target)");
+    }
+    return this.linkedInClient;
   }
 
   private ensureUiClient(): CDPClient {

--- a/packages/core/src/services/launcher.test.ts
+++ b/packages/core/src/services/launcher.test.ts
@@ -8,6 +8,7 @@ import {
   NodeIntegrationUnavailableError,
   ServiceError,
   StartInstanceError,
+  WrongPortError,
 } from "./errors.js";
 import { LauncherService } from "./launcher.js";
 
@@ -297,7 +298,7 @@ describe("LauncherService", () => {
 
     it("returns empty array when no accounts", async () => {
       await service.connect();
-      nextEvaluateResult = null;
+      nextEvaluateResult = [];
 
       const accounts = await service.listAccounts();
 
@@ -311,11 +312,18 @@ describe("LauncherService", () => {
           return Promise.resolve(true);
         }
         return Promise.reject(
-          new CDPEvaluationError("TypeError: Cannot read property 'get' of undefined"),
+          new CDPEvaluationError("ReferenceError: remote is not defined"),
         );
       });
 
       await expect(service.listAccounts()).rejects.toThrow(CDPEvaluationError);
+    });
+
+    it("throws WrongPortError when electronStore is not available", async () => {
+      await service.connect();
+      nextEvaluateResult = null;
+
+      await expect(service.listAccounts()).rejects.toThrow(WrongPortError);
     });
   });
 });

--- a/packages/core/src/services/launcher.ts
+++ b/packages/core/src/services/launcher.ts
@@ -17,6 +17,7 @@ import {
   NodeIntegrationUnavailableError,
   ServiceError,
   StartInstanceError,
+  WrongPortError,
 } from "./errors.js";
 
 /**
@@ -163,12 +164,13 @@ export class LauncherService {
   async listAccounts(): Promise<Account[]> {
     const client = this.ensureConnected();
 
-    const accounts = await this.launcherEvaluate<Account[]>(
+    const accounts = await this.launcherEvaluate<Account[] | null>(
       client,
       `(() => {
         const remote = require('@electron/remote');
         const mainWindow = remote.getGlobal('mainWindow');
-        const store = mainWindow.electronStore;
+        const store = mainWindow?.electronStore;
+        if (!store) return null;
         const passwords = store.get('linkedInPasswords') ?? {};
         return Object.keys(passwords)
           .map(k => {
@@ -187,7 +189,11 @@ export class LauncherService {
       })()`,
     );
 
-    return accounts ?? [];
+    if (accounts === null) {
+      throw new WrongPortError(this.port);
+    }
+
+    return accounts;
   }
 
   /**


### PR DESCRIPTION
## Summary

- **Bug A fix**: `collect-people` now navigates the LinkedIn webview to the source URL via CDP before calling `canCollect`, ensuring LinkedHelper's internal page state matches the requested source type
- **Bug B fix**: Guards `listAccounts()` against missing `electronStore` and throws `WrongPortError` instead of a cryptic TypeError when using the instance port

## Changes

- `InstanceService.navigateLinkedIn(url)` — new method that enables CDP Page domain, navigates, waits for `Page.loadEventFired`, then disables
- `CollectionService.collect()` — calls `navigateLinkedIn(sourceUrl)` between `ensureIdle()` and `assertCanCollect()`
- `LauncherService.listAccounts()` — guards `electronStore` access with optional chaining and returns `null` when not a launcher target, which triggers `WrongPortError`

## Test plan

- [x] `instance.test.ts` — 4 new tests for `navigateLinkedIn` (success, cleanup on failure, no UI client usage, not-connected error)
- [x] `collection.test.ts` — updated call sequence test, added navigation failure test and navigation-before-canCollect assertion
- [x] `launcher.test.ts` — updated empty-accounts test, added `WrongPortError` test for null electronStore
- [x] All 69 affected tests pass
- [x] Lint passes
- [ ] E2E test with real LinkedHelper (local)

Closes #425

🤖 Generated with [Claude Code](https://claude.com/claude-code)