### PR TITLE
DOM automation primitives: scroll, click, type, wait-for-element

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -342,8 +342,14 @@ export {
   type ResolveLinkedInEntityOutput,
 } from "./operations/index.js";
 
-// LinkedIn DOM selectors
+// LinkedIn DOM automation & selectors
 export {
+  click,
+  scrollTo,
+  typeText,
+  type TypeMethod,
+  waitForElement,
+  type WaitForElementOptions,
   COMMENT_INPUT,
   COMMENT_SUBMIT_BUTTON,
   FEED_POST_CONTAINER,

--- a/packages/core/src/linkedin/__tests__/dom-automation.integration.test.ts
+++ b/packages/core/src/linkedin/__tests__/dom-automation.integration.test.ts
@@ -1,0 +1,197 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { CDPClient } from "../../cdp/client.js";
+import { CDPEvaluationError, CDPTimeoutError } from "../../cdp/errors.js";
+import {
+  launchChromium,
+  type ChromiumInstance,
+} from "../../cdp/testing/launch-chromium.js";
+import { click, scrollTo, typeText, waitForElement } from "../dom-automation.js";
+
+/**
+ * Helper to clear document body and create elements without innerHTML
+ * (which is blocked by Chromium's Trusted Types policy).
+ */
+async function resetBody(client: CDPClient): Promise<void> {
+  await client.evaluate(
+    `while (document.body.firstChild) document.body.removeChild(document.body.firstChild)`,
+  );
+}
+
+describe("DOM automation (integration)", () => {
+  let chromium: ChromiumInstance;
+  let client: CDPClient;
+
+  beforeAll(async () => {
+    chromium = await launchChromium();
+  }, 30_000);
+
+  afterAll(async () => {
+    await chromium.close();
+  });
+
+  beforeEach(async () => {
+    client = new CDPClient(chromium.port);
+    await client.connect();
+    await resetBody(client);
+  });
+
+  afterEach(() => {
+    client.disconnect();
+  });
+
+  // ── waitForElement ──────────────────────────────────────────────
+
+  describe("waitForElement", () => {
+    it("should resolve immediately when element already exists", async () => {
+      await client.evaluate(`(() => {
+        const el = document.createElement('div');
+        el.id = 'existing';
+        el.textContent = 'Hello';
+        document.body.appendChild(el);
+      })()`);
+
+      await waitForElement(client, "#existing", { timeout: 2000 });
+    });
+
+    it("should resolve when element appears after a delay", async () => {
+      await client.evaluate(`
+        setTimeout(() => {
+          const el = document.createElement('div');
+          el.id = 'delayed';
+          document.body.appendChild(el);
+        }, 200);
+      `);
+
+      await waitForElement(client, "#delayed", { timeout: 5000 });
+    });
+
+    it("should reject with CDPTimeoutError when element never appears", async () => {
+      await expect(
+        waitForElement(client, "#nonexistent", { timeout: 500 }),
+      ).rejects.toThrow(CDPTimeoutError);
+    });
+  });
+
+  // ── click ───────────────────────────────────────────────────────
+
+  describe("click", () => {
+    it("should click the element via JS .click()", async () => {
+      await client.evaluate(`(() => {
+        const btn = document.createElement('button');
+        btn.id = 'btn';
+        btn.textContent = 'Click me';
+        document.body.appendChild(btn);
+        window.__clicked = false;
+        btn.addEventListener('click', () => { window.__clicked = true; });
+      })()`);
+
+      await click(client, "#btn");
+
+      const clicked = await client.evaluate<boolean>("window.__clicked");
+      expect(clicked).toBe(true);
+    });
+
+    it("should throw CDPEvaluationError when element not found", async () => {
+      await expect(click(client, "#missing")).rejects.toThrow(
+        CDPEvaluationError,
+      );
+    });
+  });
+
+  // ── scrollTo ────────────────────────────────────────────────────
+
+  describe("scrollTo", () => {
+    it("should scroll the element into view", async () => {
+      await client.evaluate(`(() => {
+        document.body.style.margin = '0';
+        document.body.style.height = '3000px';
+        const el = document.createElement('div');
+        el.id = 'bottom';
+        el.textContent = 'Bottom';
+        el.style.position = 'absolute';
+        el.style.top = '2500px';
+        document.body.appendChild(el);
+      })()`);
+
+      // Verify element is initially below the viewport
+      const beforeY = await client.evaluate<number>(
+        `document.getElementById('bottom').getBoundingClientRect().top`,
+      );
+      expect(beforeY).toBeGreaterThan(600);
+
+      await scrollTo(client, "#bottom");
+
+      // Verify element is now within the viewport
+      const afterRect = await client.evaluate<{ top: number; bottom: number }>(
+        `(() => {
+          const r = document.getElementById('bottom').getBoundingClientRect();
+          return { top: r.top, bottom: r.bottom };
+        })()`,
+      );
+      const viewportHeight = await client.evaluate<number>(
+        "window.innerHeight",
+      );
+      expect(afterRect.top).toBeGreaterThanOrEqual(0);
+      expect(afterRect.top).toBeLessThan(viewportHeight);
+    });
+
+    it("should throw CDPEvaluationError when element not found", async () => {
+      await expect(scrollTo(client, "#missing")).rejects.toThrow(
+        CDPEvaluationError,
+      );
+    });
+  });
+
+  // ── typeText ────────────────────────────────────────────────────
+
+  describe("typeText", () => {
+    it("should type characters one-by-one into an input", async () => {
+      await client.evaluate(`(() => {
+        const input = document.createElement('input');
+        input.id = 'input';
+        input.type = 'text';
+        document.body.appendChild(input);
+        window.__inputEvents = 0;
+        input.addEventListener('keydown', () => { window.__inputEvents++; });
+      })()`);
+
+      await typeText(client, "#input", "hello");
+
+      const value = await client.evaluate<string>(
+        `document.getElementById('input').value`,
+      );
+      expect(value).toBe("hello");
+
+      // Each character should have triggered a keydown event
+      const eventCount = await client.evaluate<number>(
+        "window.__inputEvents",
+      );
+      expect(eventCount).toBe(5);
+    });
+
+    it("should type into a contenteditable element", async () => {
+      await client.evaluate(`(() => {
+        const editor = document.createElement('div');
+        editor.id = 'editor';
+        editor.contentEditable = 'true';
+        document.body.appendChild(editor);
+      })()`);
+
+      await typeText(client, "#editor", "abc");
+
+      const text = await client.evaluate<string>(
+        `document.getElementById('editor').textContent`,
+      );
+      expect(text).toBe("abc");
+    });
+
+    it("should throw CDPEvaluationError when element not found", async () => {
+      await expect(
+        typeText(client, "#missing", "text"),
+      ).rejects.toThrow(CDPEvaluationError);
+    });
+  });
+});

--- a/packages/core/src/linkedin/dom-automation.ts
+++ b/packages/core/src/linkedin/dom-automation.ts
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import type { CDPClient } from "../cdp/client.js";
+import { CDPEvaluationError, CDPTimeoutError } from "../cdp/errors.js";
+import { delay } from "../utils/delay.js";
+
+/** Default timeout for DOM operations (ms). */
+const DEFAULT_TIMEOUT = 30_000;
+
+/** Default polling interval for waitForElement (ms). */
+const DEFAULT_POLL_INTERVAL = 100;
+
+/** Minimum delay between keystrokes (ms). */
+const MIN_KEYSTROKE_DELAY = 50;
+
+/** Maximum delay between keystrokes (ms). */
+const MAX_KEYSTROKE_DELAY = 150;
+
+/** Options for {@link waitForElement}. */
+export interface WaitForElementOptions {
+  /** Maximum time to wait in ms (default: 30 000). */
+  timeout?: number;
+  /** Polling interval in ms (default: 100). */
+  pollInterval?: number;
+}
+
+/** Text input method for {@link typeText}. */
+export type TypeMethod = "type";
+
+/**
+ * Poll the DOM until an element matching the selector appears.
+ *
+ * @param client   - Connected CDP client targeting the page.
+ * @param selector - CSS selector to query.
+ * @param options  - Timeout and polling interval.
+ * @throws {CDPTimeoutError} If the element does not appear within the timeout.
+ */
+export async function waitForElement(
+  client: CDPClient,
+  selector: string,
+  options?: WaitForElementOptions,
+): Promise<void> {
+  const timeout = options?.timeout ?? DEFAULT_TIMEOUT;
+  const pollInterval = options?.pollInterval ?? DEFAULT_POLL_INTERVAL;
+  const deadline = Date.now() + timeout;
+
+  while (Date.now() < deadline) {
+    const found = await client.evaluate<boolean>(
+      `document.querySelector(${JSON.stringify(selector)}) !== null`,
+    );
+    if (found) return;
+    await delay(pollInterval);
+  }
+
+  throw new CDPTimeoutError(
+    `Timed out waiting for element "${selector}" after ${timeout.toString()}ms`,
+  );
+}
+
+/**
+ * Scroll the page until the target element is visible in the viewport.
+ *
+ * The element must already exist in the DOM.  Use {@link waitForElement}
+ * first if it may not be present yet.
+ *
+ * @param client   - Connected CDP client targeting the page.
+ * @param selector - CSS selector for the element to scroll to.
+ * @throws {CDPEvaluationError} If the element is not found.
+ */
+export async function scrollTo(
+  client: CDPClient,
+  selector: string,
+): Promise<void> {
+  const scrolled = await client.evaluate<boolean>(
+    `(() => {
+      const el = document.querySelector(${JSON.stringify(selector)});
+      if (!el) return false;
+      el.scrollIntoView({ behavior: "instant", block: "center" });
+      return true;
+    })()`,
+  );
+
+  if (!scrolled) {
+    throw new CDPEvaluationError(
+      `Element "${selector}" not found for scrollTo`,
+    );
+  }
+}
+
+/**
+ * Click an element via its JavaScript `.click()` method.
+ *
+ * Uses JS `.click()` rather than `Input.dispatchMouseEvent` because the
+ * latter does not reliably trigger handlers on LinkedIn's React components.
+ *
+ * @param client   - Connected CDP client targeting the page.
+ * @param selector - CSS selector for the element to click.
+ * @throws {CDPEvaluationError} If the element is not found.
+ */
+export async function click(
+  client: CDPClient,
+  selector: string,
+): Promise<void> {
+  const clicked = await client.evaluate<boolean>(
+    `(() => {
+      const el = document.querySelector(${JSON.stringify(selector)});
+      if (!el) return false;
+      el.click();
+      return true;
+    })()`,
+  );
+
+  if (!clicked) {
+    throw new CDPEvaluationError(
+      `Element "${selector}" not found for click`,
+    );
+  }
+}
+
+/**
+ * Type text into a focused element character-by-character.
+ *
+ * The element is focused first, then each character is dispatched via
+ * CDP `Input.dispatchKeyEvent` with randomised inter-keystroke delays
+ * (50–150 ms) to approximate human typing cadence.
+ *
+ * @param client   - Connected CDP client targeting the page.
+ * @param selector - CSS selector for the input element.
+ * @param text     - The string to type.
+ * @param method   - Input method (default: `"type"`).
+ * @throws {CDPEvaluationError} If the element is not found.
+ */
+export async function typeText(
+  client: CDPClient,
+  selector: string,
+  text: string,
+  method: TypeMethod = "type",
+): Promise<void> {
+  const focused = await client.evaluate<boolean>(
+    `(() => {
+      const el = document.querySelector(${JSON.stringify(selector)});
+      if (!el) return false;
+      el.focus();
+      return true;
+    })()`,
+  );
+
+  if (!focused) {
+    throw new CDPEvaluationError(
+      `Element "${selector}" not found for typeText`,
+    );
+  }
+
+  switch (method) {
+    case "type":
+      for (const char of text) {
+        await client.send("Input.dispatchKeyEvent", {
+          type: "keyDown",
+          key: char,
+          text: char,
+        });
+        await client.send("Input.dispatchKeyEvent", {
+          type: "keyUp",
+          key: char,
+        });
+
+        const keystrokeDelay =
+          MIN_KEYSTROKE_DELAY +
+          Math.random() * (MAX_KEYSTROKE_DELAY - MIN_KEYSTROKE_DELAY);
+        await delay(keystrokeDelay);
+      }
+      break;
+  }
+}

--- a/packages/core/src/linkedin/index.ts
+++ b/packages/core/src/linkedin/index.ts
@@ -2,6 +2,15 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 export {
+  click,
+  scrollTo,
+  typeText,
+  type TypeMethod,
+  waitForElement,
+  type WaitForElementOptions,
+} from "./dom-automation.js";
+
+export {
   COMMENT_INPUT,
   COMMENT_SUBMIT_BUTTON,
   FEED_POST_CONTAINER,


### PR DESCRIPTION
## Summary
- Add `waitForElement(client, selector, options?)` — polls DOM until element appears, throws `CDPTimeoutError` on timeout
- Add `scrollTo(client, selector)` — scrolls element into viewport via `scrollIntoView`
- Add `click(client, selector)` — JS `.click()` (not `Input.dispatchMouseEvent`, which doesn't work on LinkedIn's React components)
- Add `typeText(client, selector, text, method?)` — dispatches CDP `Input.dispatchKeyEvent` character-by-character with randomized 50–150ms inter-keystroke delays
- Integration tests against headless Chromium for all primitives (10 tests)
- Exports from `@lhremote/core` barrel

## Test plan
- [x] `pnpm lint` passes
- [x] All 10 integration tests pass (`dom-automation.integration.test.ts`)
- [x] CI validates on ubuntu/macos/windows matrix

Closes #446

🤖 Generated with [Claude Code](https://claude.com/claude-code)