### PR TITLE
Fix query-messages integration test flakiness on Ubuntu CI

### DIFF
--- a/packages/cli/src/handlers/query-messages.integration.test.ts
+++ b/packages/cli/src/handlers/query-messages.integration.test.ts
@@ -1,16 +1,35 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
+import { copyFileSync, unlinkSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const FIXTURE_PATH = join(
+const FIXTURE_ORIGIN = join(
   __dirname,
   "../../../core/src/db/testing/fixture.db",
 );
+
+/**
+ * Per-suite copy of the fixture database.
+ * Avoids SQLite file-locking contention when multiple vitest
+ * workers open the same DB file in parallel.
+ */
+let fixturePath: string;
 
 vi.mock("@lhremote/core", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@lhremote/core")>();
@@ -27,10 +46,23 @@ import { handleQueryMessages } from "./query-messages.js";
 describe("handleQueryMessages (integration)", () => {
   const originalExitCode = process.exitCode;
 
+  beforeAll(() => {
+    fixturePath = join(tmpdir(), `lhremote-fixture-${randomUUID()}.db`);
+    copyFileSync(FIXTURE_ORIGIN, fixturePath);
+  });
+
+  afterAll(() => {
+    try {
+      unlinkSync(fixturePath);
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
   beforeEach(() => {
     process.exitCode = undefined;
     vi.mocked(discoverAllDatabases).mockReturnValue(
-      new Map([[1, FIXTURE_PATH]]),
+      new Map([[1, fixturePath]]),
     );
   });
 

--- a/packages/mcp/src/tools/query-messages.integration.test.ts
+++ b/packages/mcp/src/tools/query-messages.integration.test.ts
@@ -1,16 +1,35 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
+import { copyFileSync, unlinkSync } from "node:fs";
+import { randomUUID } from "node:crypto";
+import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const FIXTURE_PATH = join(
+const FIXTURE_ORIGIN = join(
   __dirname,
   "../../../core/src/db/testing/fixture.db",
 );
+
+/**
+ * Per-suite copy of the fixture database.
+ * Avoids SQLite file-locking contention when multiple vitest
+ * workers open the same DB file in parallel.
+ */
+let fixturePath: string;
 
 vi.mock("@lhremote/core", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@lhremote/core")>();
@@ -36,7 +55,7 @@ import { createMockServer } from "./testing/mock-server.js";
  * This replaces the mock so the MCP tool handler exercises real DB queries.
  */
 function fixtureQueryMessages(input: QueryMessagesInput) {
-  const client = new DatabaseClient(FIXTURE_PATH);
+  const client = new DatabaseClient(fixturePath);
   try {
     const repo = new MessageRepository(client);
     const limit = input.limit ?? 20;
@@ -64,6 +83,19 @@ function fixtureQueryMessages(input: QueryMessagesInput) {
 }
 
 describe("registerQueryMessages (integration)", () => {
+  beforeAll(() => {
+    fixturePath = join(tmpdir(), `lhremote-fixture-${randomUUID()}.db`);
+    copyFileSync(FIXTURE_ORIGIN, fixturePath);
+  });
+
+  afterAll(() => {
+    try {
+      unlinkSync(fixturePath);
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
   beforeEach(() => {
     vi.mocked(queryMessages).mockImplementation(async (input) =>
       fixtureQueryMessages(input),


### PR DESCRIPTION
## Summary
- Copy `fixture.db` to a unique temp file per test suite in MCP and CLI `query-messages.integration.test.ts`, preventing SQLite file-locking contention when multiple vitest workers access the same file in parallel
- Matches the isolation pattern already used by core's `openFixture()` helper

## Root Cause
The default vitest configuration runs test files in parallel across worker threads. Both MCP and CLI integration tests opened `packages/core/src/db/testing/fixture.db` directly at its original path. On Linux, concurrent SQLite access (even read-only with WAL mode) can cause `SQLITE_BUSY` errors due to shared memory (`-shm`/`-wal`) file contention.

## Test plan
- [x] `pnpm lint` passes
- [x] MCP tests: 60 files passed
- [x] CLI tests: 59 files passed
- [ ] CI passes on Ubuntu/macOS/Windows matrix

Closes #477

🤖 Generated with [Claude Code](https://claude.com/claude-code)