### PR TITLE
Wire instance popup detection into health checker

### DIFF
--- a/packages/cli/src/handlers/get-errors.test.ts
+++ b/packages/cli/src/handlers/get-errors.test.ts
@@ -40,6 +40,7 @@ describe("handleGetErrors", () => {
       healthy: true,
       issues: [],
       popup: null,
+      instancePopups: [],
     };
 
     mockedGetErrors.mockResolvedValue(output);
@@ -63,6 +64,7 @@ describe("handleGetErrors", () => {
       healthy: true,
       issues: [],
       popup: null,
+      instancePopups: [],
     });
 
     await handleGetErrors({});
@@ -99,6 +101,7 @@ describe("handleGetErrors", () => {
         },
       ],
       popup: null,
+      instancePopups: [],
     });
 
     await handleGetErrors({});
@@ -126,6 +129,7 @@ describe("handleGetErrors", () => {
         },
       ],
       popup: null,
+      instancePopups: [],
     });
 
     await handleGetErrors({});
@@ -145,6 +149,7 @@ describe("handleGetErrors", () => {
       healthy: false,
       issues: [],
       popup: { blocked: true, message: "Network issue", closable: false },
+      instancePopups: [],
     });
 
     await handleGetErrors({});

--- a/packages/cli/src/handlers/get-errors.ts
+++ b/packages/cli/src/handlers/get-errors.ts
@@ -60,6 +60,15 @@ export async function handleGetErrors(options: {
         `Popup: ${result.popup.message ?? "blocking overlay"} (${closable})\n`,
       );
     }
+
+    // Instance popups
+    if (result.instancePopups.length > 0) {
+      process.stdout.write(`Instance popups: ${String(result.instancePopups.length)}\n`);
+      for (const popup of result.instancePopups) {
+        const desc = popup.description ? ` — ${popup.description}` : "";
+        process.stdout.write(`  ${popup.title}${desc}\n`);
+      }
+    }
   } catch (error) {
     const message = errorMessage(error);
     process.stderr.write(`${message}\n`);

--- a/packages/core/src/operations/get-errors.test.ts
+++ b/packages/core/src/operations/get-errors.test.ts
@@ -32,6 +32,7 @@ describe("getErrors", () => {
       healthy: true,
       issues: [],
       popup: null,
+      instancePopups: [],
     };
 
     const mockLauncher = {
@@ -49,6 +50,7 @@ describe("getErrors", () => {
     expect(result.accountId).toBe(1);
     expect(result.issues).toEqual([]);
     expect(result.popup).toBeNull();
+    expect(result.instancePopups).toEqual([]);
   });
 
   it("returns blocked status with dialog issues", async () => {
@@ -70,6 +72,7 @@ describe("getErrors", () => {
         },
       ],
       popup: null,
+      instancePopups: [],
     };
 
     const mockLauncher = {
@@ -95,6 +98,7 @@ describe("getErrors", () => {
       healthy: false,
       issues: [],
       popup: { blocked: true, message: "Network issue", closable: false },
+      instancePopups: [],
     };
 
     const mockLauncher = {
@@ -123,6 +127,7 @@ describe("getErrors", () => {
         healthy: true,
         issues: [],
         popup: null,
+        instancePopups: [],
       }),
     };
     vi.mocked(LauncherService).mockImplementation(function () {

--- a/packages/core/src/services/errors.ts
+++ b/packages/core/src/services/errors.ts
@@ -272,6 +272,10 @@ export class UIBlockedError extends ServiceError {
       reasons.push(`Popup: ${health.popup.message ?? "blocking overlay active"}`);
     }
 
+    for (const instancePopup of health.instancePopups) {
+      reasons.push(`Instance popup: ${instancePopup.title}${instancePopup.description ? ` — ${instancePopup.description}` : ""}`);
+    }
+
     super(
       `LinkedHelper UI is blocked — ${reasons.join("; ")}`,
       options,

--- a/packages/core/src/services/instance-context.test.ts
+++ b/packages/core/src/services/instance-context.test.ts
@@ -24,7 +24,7 @@ import { discoverInstancePort } from "../cdp/index.js";
 import { DatabaseClient, discoverDatabase } from "../db/index.js";
 import { InstanceService } from "./instance.js";
 import { LauncherService } from "./launcher.js";
-import { InstanceNotRunningError } from "./errors.js";
+import { InstanceNotRunningError, UIBlockedError } from "./errors.js";
 import { withDatabase, withInstanceDatabase } from "./instance-context.js";
 
 const mockedDiscoverInstancePort = vi.mocked(discoverInstancePort);
@@ -49,6 +49,7 @@ function createMockInstance(overrides: Partial<InstanceService> = {}) {
     connect: vi.fn().mockResolvedValue(undefined),
     disconnect: vi.fn(),
     setHealthChecker: vi.fn(),
+    getInstancePopups: vi.fn().mockResolvedValue([]),
     ...overrides,
   } as unknown as InstanceService;
   mockedInstanceService.mockImplementation(function () {
@@ -65,12 +66,20 @@ function createMockLauncher() {
       healthy: true,
       issues: [],
       popup: null,
+      instancePopups: [],
     }),
   } as unknown as LauncherService;
   mockedLauncherService.mockImplementation(function () {
     return launcher;
   });
   return launcher;
+}
+
+function extractHealthChecker(mockInstance: InstanceService): () => Promise<void> {
+  const calls = vi.mocked(mockInstance.setHealthChecker).mock.calls;
+  const firstCall = calls[0];
+  if (!firstCall) throw new Error("setHealthChecker was not called");
+  return firstCall[0] as () => Promise<void>;
 }
 
 describe("withDatabase", () => {
@@ -289,5 +298,89 @@ describe("withInstanceDatabase", () => {
     await withInstanceDatabase(9222, 42, () => undefined);
 
     expect(mockedInstanceService).toHaveBeenCalledWith(55123, undefined);
+  });
+
+  it("health checker calls getInstancePopups alongside launcher health", async () => {
+    const mockInstance = createMockInstance();
+    const mockLauncher = createMockLauncher();
+    createMockDb();
+    mockedDiscoverInstancePort.mockResolvedValue(55123);
+    mockedDiscoverDatabase.mockReturnValue("/path/to/db.db");
+
+    await withInstanceDatabase(9222, 42, () => undefined);
+
+    // Extract and invoke the registered health checker
+    const healthChecker = extractHealthChecker(mockInstance);
+
+    await healthChecker();
+
+    expect(vi.mocked(mockLauncher.checkUIHealth)).toHaveBeenCalledWith(42);
+    expect(vi.mocked(mockInstance.getInstancePopups)).toHaveBeenCalledOnce();
+  });
+
+  it("health checker throws UIBlockedError when instance popups detected", async () => {
+    const mockInstance = createMockInstance({
+      getInstancePopups: vi.fn().mockResolvedValue([
+        { title: "Failed to initialize UI", description: "Error details", closable: false },
+      ]),
+    });
+    createMockLauncher();
+    createMockDb();
+    mockedDiscoverInstancePort.mockResolvedValue(55123);
+    mockedDiscoverDatabase.mockReturnValue("/path/to/db.db");
+
+    await withInstanceDatabase(9222, 42, () => undefined);
+
+    const healthChecker = extractHealthChecker(mockInstance);
+
+    await expect(healthChecker()).rejects.toThrow(UIBlockedError);
+    await expect(healthChecker()).rejects.toThrow("Instance popup: Failed to initialize UI");
+  });
+
+  it("health checker throws UIBlockedError with both launcher issues and instance popups", async () => {
+    const mockInstance = createMockInstance({
+      getInstancePopups: vi.fn().mockResolvedValue([
+        { title: "Error popup", closable: true },
+      ]),
+    });
+    const mockLauncher = createMockLauncher();
+    vi.mocked(mockLauncher.checkUIHealth).mockResolvedValue({
+      healthy: false,
+      issues: [
+        {
+          type: "dialog",
+          id: "d1",
+          data: { id: "d1", options: { message: "Dialog message", controls: [] } },
+        },
+      ],
+      popup: null,
+      instancePopups: [],
+    });
+    createMockDb();
+    mockedDiscoverInstancePort.mockResolvedValue(55123);
+    mockedDiscoverDatabase.mockReturnValue("/path/to/db.db");
+
+    await withInstanceDatabase(9222, 42, () => undefined);
+
+    const healthChecker = extractHealthChecker(mockInstance);
+
+    const error = await healthChecker().catch((e: unknown) => e) as UIBlockedError;
+    expect(error).toBeInstanceOf(UIBlockedError);
+    expect(error.message).toContain("Dialog: Dialog message");
+    expect(error.message).toContain("Instance popup: Error popup");
+  });
+
+  it("health checker passes when no launcher issues and no instance popups", async () => {
+    const mockInstance = createMockInstance();
+    createMockLauncher();
+    createMockDb();
+    mockedDiscoverInstancePort.mockResolvedValue(55123);
+    mockedDiscoverDatabase.mockReturnValue("/path/to/db.db");
+
+    await withInstanceDatabase(9222, 42, () => undefined);
+
+    const healthChecker = extractHealthChecker(mockInstance);
+
+    await expect(healthChecker()).resolves.toBeUndefined();
   });
 });

--- a/packages/core/src/services/instance-context.ts
+++ b/packages/core/src/services/instance-context.ts
@@ -3,6 +3,7 @@
 
 import { DatabaseClient, type DatabaseClientOptions, discoverDatabase } from "../db/index.js";
 import { discoverInstancePort } from "../cdp/index.js";
+import type { UIHealthStatus } from "../types/index.js";
 import { InstanceService } from "./instance.js";
 import { LauncherService } from "./launcher.js";
 import { InstanceNotRunningError, UIBlockedError } from "./errors.js";
@@ -90,7 +91,15 @@ export async function withInstanceDatabase<T>(
       await launcher.connect();
       const connectedLauncher = launcher;
       instance.setHealthChecker(async () => {
-        const health = await connectedLauncher.checkUIHealth(accountId);
+        const [launcherHealth, instancePopups] = await Promise.all([
+          connectedLauncher.checkUIHealth(accountId),
+          instance.getInstancePopups(),
+        ]);
+        const health: UIHealthStatus = {
+          ...launcherHealth,
+          instancePopups: [...launcherHealth.instancePopups, ...instancePopups],
+          healthy: launcherHealth.healthy && instancePopups.length === 0,
+        };
         if (!health.healthy) {
           throw new UIBlockedError(health);
         }

--- a/packages/core/src/services/launcher.ts
+++ b/packages/core/src/services/launcher.ts
@@ -268,7 +268,7 @@ export class LauncherService {
 
     const healthy = issues.length === 0 && (popup === null || !popup.blocked);
 
-    return { healthy, issues, popup };
+    return { healthy, issues, popup, instancePopups: [] };
   }
 
   /** Whether the service is currently connected to the launcher. */

--- a/packages/core/src/types/ui-health.ts
+++ b/packages/core/src/types/ui-health.ts
@@ -72,4 +72,6 @@ export interface UIHealthStatus {
   readonly issues: readonly InstanceIssue[];
   /** Current popup overlay state, or `null` if no popup is present. */
   readonly popup: PopupState | null;
+  /** Popups detected in the instance UI DOM. */
+  readonly instancePopups: readonly InstancePopup[];
 }

--- a/packages/mcp/src/tools/get-errors.test.ts
+++ b/packages/mcp/src/tools/get-errors.test.ts
@@ -49,6 +49,7 @@ describe("registerGetErrors", () => {
       healthy: true,
       issues: [],
       popup: null,
+      instancePopups: [],
     };
 
     mockedGetErrors.mockResolvedValue(output);
@@ -76,6 +77,7 @@ describe("registerGetErrors", () => {
         },
       ],
       popup: null,
+      instancePopups: [],
     };
 
     mockedGetErrors.mockResolvedValue(output);
@@ -119,6 +121,7 @@ describe("registerGetErrors", () => {
       healthy: true,
       issues: [],
       popup: null,
+      instancePopups: [],
     });
 
     const handler = getHandler("get-errors");


### PR DESCRIPTION
## Summary

- Add `instancePopups` field to `UIHealthStatus` type
- Enhance health checker in `withInstanceDatabase` to call `instance.getInstancePopups()` alongside launcher health check, merging results into a unified health status
- Update `UIBlockedError` to include instance popup text in error messages
- Add instance popup display to CLI `get-errors` handler

Closes #437

## Test plan

- [x] Health checker calls `getInstancePopups` alongside launcher health — verified via unit test
- [x] `UIBlockedError` thrown when instance popups detected — verified via unit test
- [x] Both launcher issues and instance popups reported together — verified via unit test
- [x] No regression when no instance popups present — verified via unit test
- [x] All 1209 existing tests pass
- [x] Lint clean across all packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)