### PR TITLE
Enhance get-errors to include instance UI popups

### DIFF
--- a/packages/cli/src/handlers/get-errors.test.ts
+++ b/packages/cli/src/handlers/get-errors.test.ts
@@ -74,6 +74,7 @@ describe("handleGetErrors", () => {
     expect(stdoutSpy).toHaveBeenCalledWith("Account: 1\n");
     expect(stdoutSpy).toHaveBeenCalledWith("Issues: none\n");
     expect(stdoutSpy).toHaveBeenCalledWith("Popup: none\n");
+    expect(stdoutSpy).toHaveBeenCalledWith("Instance popups: none\n");
   });
 
   it("prints dialog issues", async () => {
@@ -156,6 +157,33 @@ describe("handleGetErrors", () => {
 
     expect(stdoutSpy).toHaveBeenCalledWith(
       "Popup: Network issue (unclosable)\n",
+    );
+  });
+
+  it("prints instance popups", async () => {
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockReturnValue(true);
+
+    mockedGetErrors.mockResolvedValue({
+      accountId: 1,
+      healthy: false,
+      issues: [],
+      popup: null,
+      instancePopups: [
+        { title: "Failed to initialize UI", description: "AsyncHandlerError: liAccount not initialized", closable: true },
+        { title: "Connection lost", closable: false },
+      ],
+    });
+
+    await handleGetErrors({});
+
+    expect(stdoutSpy).toHaveBeenCalledWith("Instance popups: 2\n");
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      "  Failed to initialize UI — AsyncHandlerError: liAccount not initialized (closable)\n",
+    );
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      "  Connection lost (unclosable)\n",
     );
   });
 

--- a/packages/cli/src/handlers/get-errors.ts
+++ b/packages/cli/src/handlers/get-errors.ts
@@ -61,12 +61,17 @@ export async function handleGetErrors(options: {
       );
     }
 
-    // Instance popups
-    if (result.instancePopups.length > 0) {
-      process.stdout.write(`Instance popups: ${String(result.instancePopups.length)}\n`);
-      for (const popup of result.instancePopups) {
-        const desc = popup.description ? ` — ${popup.description}` : "";
-        process.stdout.write(`  ${popup.title}${desc}\n`);
+    // Instance UI popups
+    if (result.instancePopups.length === 0) {
+      process.stdout.write("Instance popups: none\n");
+    } else {
+      process.stdout.write(
+        `Instance popups: ${String(result.instancePopups.length)}\n`,
+      );
+      for (const p of result.instancePopups) {
+        const closable = p.closable ? "closable" : "unclosable";
+        const desc = p.description ? ` — ${p.description}` : "";
+        process.stdout.write(`  ${p.title}${desc} (${closable})\n`);
       }
     }
   } catch (error) {

--- a/packages/core/src/operations/get-errors.test.ts
+++ b/packages/core/src/operations/get-errors.test.ts
@@ -11,7 +11,17 @@ vi.mock("../services/launcher.js", () => ({
   LauncherService: vi.fn(),
 }));
 
+vi.mock("../cdp/index.js", () => ({
+  discoverTargets: vi.fn(),
+}));
+
+vi.mock("../services/instance.js", () => ({
+  InstanceService: vi.fn(),
+}));
+
+import { discoverTargets } from "../cdp/index.js";
 import { resolveAccount } from "../services/account-resolution.js";
+import { InstanceService } from "../services/instance.js";
 import { LauncherService } from "../services/launcher.js";
 import type { UIHealthStatus } from "../types/index.js";
 import { getErrors } from "./get-errors.js";
@@ -19,30 +29,29 @@ import { getErrors } from "./get-errors.js";
 describe("getErrors", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default: no instance targets
+    vi.mocked(discoverTargets).mockResolvedValue([]);
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
 
-  it("returns healthy status when no issues or popups", async () => {
-    vi.mocked(resolveAccount).mockResolvedValue(1);
-
-    const health: UIHealthStatus = {
-      healthy: true,
-      issues: [],
-      popup: null,
-      instancePopups: [],
-    };
-
-    const mockLauncher = {
+  function mockLauncher(health: UIHealthStatus) {
+    const mock = {
       connect: vi.fn().mockResolvedValue(undefined),
       disconnect: vi.fn(),
       checkUIHealth: vi.fn().mockResolvedValue(health),
     };
     vi.mocked(LauncherService).mockImplementation(function () {
-      return mockLauncher as unknown as LauncherService;
+      return mock as unknown as LauncherService;
     });
+    return mock;
+  }
+
+  it("returns healthy status when no issues, popups, or instance popups", async () => {
+    vi.mocked(resolveAccount).mockResolvedValue(1);
+    mockLauncher({ healthy: true, issues: [], popup: null, instancePopups: [] });
 
     const result = await getErrors({ cdpPort: 9222 });
 
@@ -55,8 +64,7 @@ describe("getErrors", () => {
 
   it("returns blocked status with dialog issues", async () => {
     vi.mocked(resolveAccount).mockResolvedValue(1);
-
-    const health: UIHealthStatus = {
+    mockLauncher({
       healthy: false,
       issues: [
         {
@@ -73,15 +81,6 @@ describe("getErrors", () => {
       ],
       popup: null,
       instancePopups: [],
-    };
-
-    const mockLauncher = {
-      connect: vi.fn().mockResolvedValue(undefined),
-      disconnect: vi.fn(),
-      checkUIHealth: vi.fn().mockResolvedValue(health),
-    };
-    vi.mocked(LauncherService).mockImplementation(function () {
-      return mockLauncher as unknown as LauncherService;
     });
 
     const result = await getErrors({ cdpPort: 9222 });
@@ -93,21 +92,11 @@ describe("getErrors", () => {
 
   it("returns blocked status with popup overlay", async () => {
     vi.mocked(resolveAccount).mockResolvedValue(1);
-
-    const health: UIHealthStatus = {
+    mockLauncher({
       healthy: false,
       issues: [],
       popup: { blocked: true, message: "Network issue", closable: false },
       instancePopups: [],
-    };
-
-    const mockLauncher = {
-      connect: vi.fn().mockResolvedValue(undefined),
-      disconnect: vi.fn(),
-      checkUIHealth: vi.fn().mockResolvedValue(health),
-    };
-    vi.mocked(LauncherService).mockImplementation(function () {
-      return mockLauncher as unknown as LauncherService;
     });
 
     const result = await getErrors({ cdpPort: 9222 });
@@ -119,20 +108,7 @@ describe("getErrors", () => {
 
   it("passes connection options to resolveAccount", async () => {
     vi.mocked(resolveAccount).mockResolvedValue(1);
-
-    const mockLauncher = {
-      connect: vi.fn().mockResolvedValue(undefined),
-      disconnect: vi.fn(),
-      checkUIHealth: vi.fn().mockResolvedValue({
-        healthy: true,
-        issues: [],
-        popup: null,
-        instancePopups: [],
-      }),
-    };
-    vi.mocked(LauncherService).mockImplementation(function () {
-      return mockLauncher as unknown as LauncherService;
-    });
+    mockLauncher({ healthy: true, issues: [], popup: null, instancePopups: [] });
 
     await getErrors({
       cdpPort: 1234,
@@ -149,17 +125,17 @@ describe("getErrors", () => {
   it("disconnects launcher even on error", async () => {
     vi.mocked(resolveAccount).mockResolvedValue(1);
 
-    const mockLauncher = {
+    const mock = {
       connect: vi.fn().mockResolvedValue(undefined),
       disconnect: vi.fn(),
       checkUIHealth: vi.fn().mockRejectedValue(new Error("CDP failure")),
     };
     vi.mocked(LauncherService).mockImplementation(function () {
-      return mockLauncher as unknown as LauncherService;
+      return mock as unknown as LauncherService;
     });
 
     await expect(getErrors({ cdpPort: 9222 })).rejects.toThrow("CDP failure");
-    expect(mockLauncher.disconnect).toHaveBeenCalledOnce();
+    expect(mock.disconnect).toHaveBeenCalledOnce();
   });
 
   it("propagates resolveAccount errors", async () => {
@@ -170,5 +146,109 @@ describe("getErrors", () => {
     await expect(getErrors({ cdpPort: 9222 })).rejects.toThrow(
       "connection refused",
     );
+  });
+
+  it("includes instance popups when instance is running", async () => {
+    vi.mocked(resolveAccount).mockResolvedValue(1);
+    mockLauncher({ healthy: true, issues: [], popup: null, instancePopups: [] });
+
+    vi.mocked(discoverTargets).mockResolvedValue([
+      { id: "t1", type: "page", title: "LinkedIn", url: "https://www.linkedin.com/feed/", description: "", devtoolsFrontendUrl: "", webSocketDebuggerUrl: "" },
+      { id: "t2", type: "page", title: "LH", url: "file:///index.html", description: "", devtoolsFrontendUrl: "", webSocketDebuggerUrl: "" },
+    ]);
+
+    const mockInstance = {
+      connect: vi.fn().mockResolvedValue(undefined),
+      disconnect: vi.fn(),
+      getInstancePopups: vi.fn().mockResolvedValue([
+        { title: "Failed to initialize UI", description: "AsyncHandlerError", closable: true },
+      ]),
+    };
+    vi.mocked(InstanceService).mockImplementation(function () {
+      return mockInstance as unknown as InstanceService;
+    });
+
+    const result = await getErrors({ cdpPort: 9222 });
+
+    expect(result.instancePopups).toHaveLength(1);
+    expect(result.instancePopups[0]?.title).toBe("Failed to initialize UI");
+    expect(result.healthy).toBe(false);
+  });
+
+  it("marks unhealthy when instance popups are present even if launcher is healthy", async () => {
+    vi.mocked(resolveAccount).mockResolvedValue(1);
+    mockLauncher({ healthy: true, issues: [], popup: null, instancePopups: [] });
+
+    vi.mocked(discoverTargets).mockResolvedValue([
+      { id: "t1", type: "page", title: "LinkedIn", url: "https://www.linkedin.com/feed/", description: "", devtoolsFrontendUrl: "", webSocketDebuggerUrl: "" },
+      { id: "t2", type: "page", title: "LH", url: "file:///index.html", description: "", devtoolsFrontendUrl: "", webSocketDebuggerUrl: "" },
+    ]);
+
+    const mockInstance = {
+      connect: vi.fn().mockResolvedValue(undefined),
+      disconnect: vi.fn(),
+      getInstancePopups: vi.fn().mockResolvedValue([
+        { title: "Error popup", closable: false },
+      ]),
+    };
+    vi.mocked(InstanceService).mockImplementation(function () {
+      return mockInstance as unknown as InstanceService;
+    });
+
+    const result = await getErrors({ cdpPort: 9222 });
+
+    expect(result.healthy).toBe(false);
+    expect(result.instancePopups).toHaveLength(1);
+  });
+
+  it("returns empty instancePopups when instance is not running", async () => {
+    vi.mocked(resolveAccount).mockResolvedValue(1);
+    mockLauncher({ healthy: true, issues: [], popup: null, instancePopups: [] });
+
+    // Only launcher target, no instance targets
+    vi.mocked(discoverTargets).mockResolvedValue([
+      { id: "t1", type: "page", title: "Launcher", url: "file:///launcher.html", description: "", devtoolsFrontendUrl: "", webSocketDebuggerUrl: "" },
+    ]);
+
+    const result = await getErrors({ cdpPort: 9222 });
+
+    expect(result.instancePopups).toEqual([]);
+    expect(result.healthy).toBe(true);
+  });
+
+  it("returns empty instancePopups when target discovery fails", async () => {
+    vi.mocked(resolveAccount).mockResolvedValue(1);
+    mockLauncher({ healthy: true, issues: [], popup: null, instancePopups: [] });
+
+    vi.mocked(discoverTargets).mockRejectedValue(new Error("connection reset"));
+
+    const result = await getErrors({ cdpPort: 9222 });
+
+    expect(result.instancePopups).toEqual([]);
+    expect(result.healthy).toBe(true);
+  });
+
+  it("disconnects instance service even when getInstancePopups fails", async () => {
+    vi.mocked(resolveAccount).mockResolvedValue(1);
+    mockLauncher({ healthy: true, issues: [], popup: null, instancePopups: [] });
+
+    vi.mocked(discoverTargets).mockResolvedValue([
+      { id: "t1", type: "page", title: "LinkedIn", url: "https://www.linkedin.com/feed/", description: "", devtoolsFrontendUrl: "", webSocketDebuggerUrl: "" },
+      { id: "t2", type: "page", title: "LH", url: "file:///index.html", description: "", devtoolsFrontendUrl: "", webSocketDebuggerUrl: "" },
+    ]);
+
+    const mockInstance = {
+      connect: vi.fn().mockResolvedValue(undefined),
+      disconnect: vi.fn(),
+      getInstancePopups: vi.fn().mockRejectedValue(new Error("DOM error")),
+    };
+    vi.mocked(InstanceService).mockImplementation(function () {
+      return mockInstance as unknown as InstanceService;
+    });
+
+    const result = await getErrors({ cdpPort: 9222 });
+
+    expect(result.instancePopups).toEqual([]);
+    expect(mockInstance.disconnect).toHaveBeenCalledOnce();
   });
 });

--- a/packages/core/src/operations/get-errors.ts
+++ b/packages/core/src/operations/get-errors.ts
@@ -1,8 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-import type { UIHealthStatus } from "../types/index.js";
+import type { InstancePopup, UIHealthStatus } from "../types/index.js";
+import { discoverTargets } from "../cdp/index.js";
 import { resolveAccount } from "../services/account-resolution.js";
+import { InstanceService } from "../services/instance.js";
 import { LauncherService } from "../services/launcher.js";
 import { DEFAULT_CDP_PORT } from "../constants.js";
 import type { ConnectionOptions } from "./types.js";
@@ -17,14 +19,20 @@ export type GetErrorsInput = ConnectionOptions;
  */
 export interface GetErrorsOutput extends UIHealthStatus {
   readonly accountId: number;
+  /** Popups detected in the instance UI DOM (behind the LinkedIn webview). */
+  readonly instancePopups: readonly InstancePopup[];
 }
 
 /**
  * Query the current error/dialog/popup state of a LinkedHelper instance.
  *
  * Connects to the launcher, resolves the account, and returns the
- * aggregated UI health status including active instance issues and
- * popup overlay state.
+ * aggregated UI health status including active instance issues,
+ * popup overlay state, and instance UI popups.
+ *
+ * Instance popups are detected on a best-effort basis: if the instance
+ * is not running or the UI target is unavailable, the operation still
+ * succeeds and returns an empty `instancePopups` array.
  */
 export async function getErrors(
   input: GetErrorsInput,
@@ -39,11 +47,58 @@ export async function getErrors(
   const accountId = await resolveAccount(cdpPort, cdpOptions);
 
   const launcher = new LauncherService(cdpPort, cdpOptions);
+  let health: UIHealthStatus;
   try {
     await launcher.connect();
-    const health = await launcher.checkUIHealth(accountId);
-    return { accountId, ...health };
+    health = await launcher.checkUIHealth(accountId);
   } finally {
     launcher.disconnect();
+  }
+
+  // Best-effort: detect instance UI popups if the instance is running.
+  const instancePopups = await detectInstancePopups(
+    cdpPort,
+    input.cdpHost,
+    cdpOptions,
+  );
+
+  const healthy =
+    health.healthy && instancePopups.length === 0;
+
+  return { accountId, ...health, healthy, instancePopups };
+}
+
+/**
+ * Attempt to detect instance UI popups via a one-shot target discovery.
+ *
+ * Returns an empty array when the instance is not running or the
+ * targets disappear between discovery and connection.
+ */
+async function detectInstancePopups(
+  cdpPort: number,
+  cdpHost: string | undefined,
+  cdpOptions: { host?: string; allowRemote?: boolean },
+): Promise<InstancePopup[]> {
+  try {
+    const targets = await discoverTargets(cdpPort, cdpHost ?? "127.0.0.1");
+    const hasLinkedIn = targets.some(
+      (t) => t.type === "page" && t.url.includes("linkedin.com"),
+    );
+    const hasUI = targets.some(
+      (t) => t.type === "page" && t.url.includes("index.html"),
+    );
+    if (!hasLinkedIn || !hasUI) {
+      return [];
+    }
+
+    const instance = new InstanceService(cdpPort, cdpOptions);
+    try {
+      await instance.connect();
+      return await instance.getInstancePopups();
+    } finally {
+      instance.disconnect();
+    }
+  } catch {
+    return [];
   }
 }

--- a/packages/mcp/src/tools/get-errors.ts
+++ b/packages/mcp/src/tools/get-errors.ts
@@ -9,7 +9,7 @@ import { cdpConnectionSchema, mcpCatchAll, mcpSuccess } from "../helpers.js";
 export function registerGetErrors(server: McpServer): void {
   server.tool(
     "get-errors",
-    "Query current LinkedHelper UI errors, dialogs, and blocking popups. Returns instance issues (dialog and critical-error), popup overlay state, and overall health status.",
+    "Query current LinkedHelper UI errors, dialogs, and blocking popups. Returns instance issues (dialog and critical-error), popup overlay state, instance UI popups (hidden behind the LinkedIn webview), and overall health status.",
     {
       ...cdpConnectionSchema,
     },


### PR DESCRIPTION
## Summary

- Extend `getErrors()` to detect instance UI popups via `InstanceService.getInstancePopups()` on a best-effort basis
- Add `instancePopups` field to `GetErrorsOutput` and factor it into the `healthy` flag
- Update CLI handler to display instance popups section, MCP tool description updated

## Details

When the instance is running, a one-shot target discovery determines if both LinkedIn and UI CDP targets are available. If so, the operation connects to the instance and queries for DOM-level popups that render behind the LinkedIn webview (invisible to the user but blocking operations). When the instance is not running or targets are unavailable, the operation falls back gracefully with an empty `instancePopups` array — no change in behavior.

Closes #438

## Test plan

- [x] Core: 10 unit tests covering healthy/blocked with instance popups, graceful fallback when instance not running, target discovery failure, instance disconnect on error
- [x] CLI: 7 tests including new instance popup display formatting
- [x] MCP: 4 tests with updated fixtures including `instancePopups`
- [x] Build passes (`pnpm build`)
- [x] Lint passes (`pnpm lint`)
- [x] All 1621 tests pass (`pnpm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)