### PR TITLE
add dismiss-errors tool to clear instance UI error popups

### DIFF
--- a/packages/cli/src/handlers/dismiss-errors.test.ts
+++ b/packages/cli/src/handlers/dismiss-errors.test.ts
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return {
+    ...actual,
+    dismissErrors: vi.fn(),
+  };
+});
+
+import { type DismissErrorsOutput, dismissErrors } from "@lhremote/core";
+
+import { handleDismissErrors } from "./dismiss-errors.js";
+
+const mockedDismissErrors = vi.mocked(dismissErrors);
+
+describe("handleDismissErrors", () => {
+  const originalExitCode = process.exitCode;
+
+  beforeEach(() => {
+    process.exitCode = undefined;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.exitCode = originalExitCode;
+    vi.restoreAllMocks();
+  });
+
+  it("prints JSON with --json", async () => {
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockReturnValue(true);
+
+    const output: DismissErrorsOutput = {
+      accountId: 1,
+      dismissed: 2,
+      nonDismissable: 0,
+    };
+
+    mockedDismissErrors.mockResolvedValue(output);
+
+    await handleDismissErrors({ json: true });
+
+    expect(process.exitCode).toBeUndefined();
+    const text = stdoutSpy.mock.calls
+      .map((call) => String(call[0]))
+      .join("");
+    expect(JSON.parse(text)).toEqual(output);
+  });
+
+  it("prints human-friendly output when popups dismissed", async () => {
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockReturnValue(true);
+
+    mockedDismissErrors.mockResolvedValue({
+      accountId: 1,
+      dismissed: 2,
+      nonDismissable: 0,
+    });
+
+    await handleDismissErrors({});
+
+    expect(process.exitCode).toBeUndefined();
+    expect(stdoutSpy).toHaveBeenCalledWith("Account: 1\n");
+    expect(stdoutSpy).toHaveBeenCalledWith("Dismissed: 2\n");
+  });
+
+  it("prints non-dismissable count when present", async () => {
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockReturnValue(true);
+
+    mockedDismissErrors.mockResolvedValue({
+      accountId: 1,
+      dismissed: 0,
+      nonDismissable: 3,
+    });
+
+    await handleDismissErrors({});
+
+    expect(stdoutSpy).toHaveBeenCalledWith("Non-dismissable: 3\n");
+  });
+
+  it("hides non-dismissable line when zero", async () => {
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockReturnValue(true);
+
+    mockedDismissErrors.mockResolvedValue({
+      accountId: 1,
+      dismissed: 1,
+      nonDismissable: 0,
+    });
+
+    await handleDismissErrors({});
+
+    const calls = stdoutSpy.mock.calls.map((c) => String(c[0]));
+    expect(calls).not.toContain(expect.stringContaining("Non-dismissable"));
+  });
+
+  it("sets exitCode 1 on error", async () => {
+    const stderrSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockReturnValue(true);
+
+    mockedDismissErrors.mockRejectedValue(new Error("unexpected"));
+
+    await handleDismissErrors({});
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("unexpected\n");
+  });
+});

--- a/packages/cli/src/handlers/dismiss-errors.ts
+++ b/packages/cli/src/handlers/dismiss-errors.ts
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { dismissErrors, errorMessage, DEFAULT_CDP_PORT } from "@lhremote/core";
+
+/** Handle the {@link https://github.com/alexey-pelykh/lhremote#dismiss-errors | dismiss-errors} CLI command. */
+export async function handleDismissErrors(options: {
+  cdpPort?: number;
+  cdpHost?: string;
+  allowRemote?: boolean;
+  json?: boolean;
+}): Promise<void> {
+  try {
+    const result = await dismissErrors({
+      cdpPort: options.cdpPort ?? DEFAULT_CDP_PORT,
+      cdpHost: options.cdpHost,
+      allowRemote: options.allowRemote,
+    });
+
+    if (options.json) {
+      process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+      return;
+    }
+
+    process.stdout.write(
+      `Account: ${String(result.accountId)}\n`,
+    );
+    process.stdout.write(
+      `Dismissed: ${String(result.dismissed)}\n`,
+    );
+
+    if (result.nonDismissable > 0) {
+      process.stdout.write(
+        `Non-dismissable: ${String(result.nonDismissable)}\n`,
+      );
+    }
+  } catch (error) {
+    const message = errorMessage(error);
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/packages/cli/src/handlers/index.ts
+++ b/packages/cli/src/handlers/index.ts
@@ -26,6 +26,7 @@ export { handleCampaignUpdate } from "./campaign-update.js";
 export { handleCampaignUpdateAction } from "./campaign-update-action.js";
 export { handleCreateCollection } from "./create-collection.js";
 export { handleDeleteCollection } from "./delete-collection.js";
+export { handleDismissErrors } from "./dismiss-errors.js";
 export { handleCheckReplies } from "./check-replies.js";
 export { handleCommentOnPost } from "./comment-on-post.js";
 export { handleEndorseSkills } from "./endorse-skills.js";

--- a/packages/cli/src/program.test.ts
+++ b/packages/cli/src/program.test.ts
@@ -72,6 +72,7 @@ describe("createProgram", () => {
     expect(commandNames).toContain("campaign-update-action");
     expect(commandNames).toContain("campaign-remove-people");
     expect(commandNames).toContain("get-errors");
+    expect(commandNames).toContain("dismiss-errors");
     expect(commandNames).toContain("get-action-budget");
     expect(commandNames).toContain("get-throttle-status");
     expect(commandNames).toContain("list-collections");
@@ -100,7 +101,7 @@ describe("createProgram", () => {
     expect(commandNames).toContain("like-person-posts");
     expect(commandNames).toContain("remove-connection");
     expect(commandNames).toContain("enrich-profile");
-    expect(commandNames).toHaveLength(65);
+    expect(commandNames).toHaveLength(66);
   });
 
   describe("launch-app", () => {

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -31,6 +31,7 @@ import {
   handleCampaignUpdateAction,
   handleCreateCollection,
   handleDeleteCollection,
+  handleDismissErrors,
   handleImportPeopleFromCollection,
   handleImportPeopleFromUrls,
   handleListCollections,
@@ -649,6 +650,15 @@ export function createProgram(): Command {
     .option("--allow-remote", "SECURITY: allow non-loopback CDP connections (enables remote code execution on target)")
     .option("--json", "Output as JSON")
     .action(handleGetErrors);
+
+  program
+    .command("dismiss-errors")
+    .description("Dismiss closable error popups in the instance UI")
+    .option("--cdp-port <port>", "CDP debugging port", parsePositiveInt)
+    .option("--cdp-host <host>", "CDP host (default: 127.0.0.1)")
+    .option("--allow-remote", "SECURITY: allow non-loopback CDP connections (enables remote code execution on target)")
+    .option("--json", "Output as JSON")
+    .action(handleDismissErrors);
 
   program
     .command("get-action-budget")

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -334,6 +334,9 @@ export {
   getErrors,
   type GetErrorsInput,
   type GetErrorsOutput,
+  dismissErrors,
+  type DismissErrorsInput,
+  type DismissErrorsOutput,
   // Messaging
   queryMessages,
   type QueryMessagesInput,

--- a/packages/core/src/operations/dismiss-errors.test.ts
+++ b/packages/core/src/operations/dismiss-errors.test.ts
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../services/account-resolution.js", () => ({
+  resolveAccount: vi.fn(),
+}));
+
+vi.mock("../services/launcher.js", () => ({
+  LauncherService: vi.fn(),
+}));
+
+vi.mock("../services/instance.js", () => ({
+  InstanceService: vi.fn(),
+}));
+
+import { resolveAccount } from "../services/account-resolution.js";
+import { InstanceService } from "../services/instance.js";
+import { LauncherService } from "../services/launcher.js";
+import { dismissErrors } from "./dismiss-errors.js";
+
+describe("dismissErrors", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns zero counts when no popups present", async () => {
+    vi.mocked(resolveAccount).mockResolvedValue(1);
+
+    const mockLauncher = {
+      connect: vi.fn().mockResolvedValue(undefined),
+      disconnect: vi.fn(),
+      dismissPopup: vi.fn().mockResolvedValue(false),
+      getPopupState: vi.fn().mockResolvedValue(null),
+    };
+    vi.mocked(LauncherService).mockImplementation(function () {
+      return mockLauncher as unknown as LauncherService;
+    });
+
+    const mockInstance = {
+      connect: vi.fn().mockResolvedValue(undefined),
+      disconnect: vi.fn(),
+      dismissInstancePopups: vi.fn().mockResolvedValue({ dismissed: 0, nonDismissable: 0 }),
+    };
+    vi.mocked(InstanceService).mockImplementation(function () {
+      return mockInstance as unknown as InstanceService;
+    });
+
+    const result = await dismissErrors({ cdpPort: 9222 });
+
+    expect(result.accountId).toBe(1);
+    expect(result.dismissed).toBe(0);
+    expect(result.nonDismissable).toBe(0);
+  });
+
+  it("dismisses launcher popup and instance popups", async () => {
+    vi.mocked(resolveAccount).mockResolvedValue(1);
+
+    const mockLauncher = {
+      connect: vi.fn().mockResolvedValue(undefined),
+      disconnect: vi.fn(),
+      dismissPopup: vi.fn().mockResolvedValue(true),
+    };
+    vi.mocked(LauncherService).mockImplementation(function () {
+      return mockLauncher as unknown as LauncherService;
+    });
+
+    const mockInstance = {
+      connect: vi.fn().mockResolvedValue(undefined),
+      disconnect: vi.fn(),
+      dismissInstancePopups: vi.fn().mockResolvedValue({ dismissed: 2, nonDismissable: 0 }),
+    };
+    vi.mocked(InstanceService).mockImplementation(function () {
+      return mockInstance as unknown as InstanceService;
+    });
+
+    const result = await dismissErrors({ cdpPort: 9222 });
+
+    expect(result.dismissed).toBe(3);
+    expect(result.nonDismissable).toBe(0);
+  });
+
+  it("reports non-dismissable launcher popup", async () => {
+    vi.mocked(resolveAccount).mockResolvedValue(1);
+
+    const mockLauncher = {
+      connect: vi.fn().mockResolvedValue(undefined),
+      disconnect: vi.fn(),
+      dismissPopup: vi.fn().mockResolvedValue(false),
+      getPopupState: vi.fn().mockResolvedValue({ blocked: true, closable: false }),
+    };
+    vi.mocked(LauncherService).mockImplementation(function () {
+      return mockLauncher as unknown as LauncherService;
+    });
+
+    const mockInstance = {
+      connect: vi.fn().mockResolvedValue(undefined),
+      disconnect: vi.fn(),
+      dismissInstancePopups: vi.fn().mockResolvedValue({ dismissed: 0, nonDismissable: 1 }),
+    };
+    vi.mocked(InstanceService).mockImplementation(function () {
+      return mockInstance as unknown as InstanceService;
+    });
+
+    const result = await dismissErrors({ cdpPort: 9222 });
+
+    expect(result.dismissed).toBe(0);
+    expect(result.nonDismissable).toBe(2);
+  });
+
+  it("passes connection options to resolveAccount", async () => {
+    vi.mocked(resolveAccount).mockResolvedValue(1);
+
+    const mockLauncher = {
+      connect: vi.fn().mockResolvedValue(undefined),
+      disconnect: vi.fn(),
+      dismissPopup: vi.fn().mockResolvedValue(false),
+      getPopupState: vi.fn().mockResolvedValue(null),
+    };
+    vi.mocked(LauncherService).mockImplementation(function () {
+      return mockLauncher as unknown as LauncherService;
+    });
+
+    const mockInstance = {
+      connect: vi.fn().mockResolvedValue(undefined),
+      disconnect: vi.fn(),
+      dismissInstancePopups: vi.fn().mockResolvedValue({ dismissed: 0, nonDismissable: 0 }),
+    };
+    vi.mocked(InstanceService).mockImplementation(function () {
+      return mockInstance as unknown as InstanceService;
+    });
+
+    await dismissErrors({
+      cdpPort: 1234,
+      cdpHost: "192.168.1.1",
+      allowRemote: true,
+    });
+
+    expect(resolveAccount).toHaveBeenCalledWith(1234, {
+      host: "192.168.1.1",
+      allowRemote: true,
+    });
+  });
+
+  it("disconnects services even on error", async () => {
+    vi.mocked(resolveAccount).mockResolvedValue(1);
+
+    const mockLauncher = {
+      connect: vi.fn().mockResolvedValue(undefined),
+      disconnect: vi.fn(),
+      dismissPopup: vi.fn().mockRejectedValue(new Error("CDP failure")),
+    };
+    vi.mocked(LauncherService).mockImplementation(function () {
+      return mockLauncher as unknown as LauncherService;
+    });
+
+    await expect(dismissErrors({ cdpPort: 9222 })).rejects.toThrow("CDP failure");
+    expect(mockLauncher.disconnect).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/core/src/operations/dismiss-errors.ts
+++ b/packages/core/src/operations/dismiss-errors.ts
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { resolveAccount } from "../services/account-resolution.js";
+import { InstanceService } from "../services/instance.js";
+import { LauncherService } from "../services/launcher.js";
+import { DEFAULT_CDP_PORT } from "../constants.js";
+import type { ConnectionOptions } from "./types.js";
+
+/**
+ * Input for the dismiss-errors operation.
+ */
+export type DismissErrorsInput = ConnectionOptions;
+
+/**
+ * Output from the dismiss-errors operation.
+ */
+export interface DismissErrorsOutput {
+  readonly accountId: number;
+  readonly dismissed: number;
+  readonly nonDismissable: number;
+}
+
+/**
+ * Dismiss closable error popups in the LinkedHelper instance UI.
+ *
+ * Connects to both the launcher and instance, finds popup close/OK
+ * buttons, and clicks them via CDP.  Returns the number of dismissed
+ * vs non-dismissable popups.
+ */
+export async function dismissErrors(
+  input: DismissErrorsInput,
+): Promise<DismissErrorsOutput> {
+  const cdpPort = input.cdpPort ?? DEFAULT_CDP_PORT;
+
+  const cdpOptions = {
+    ...(input.cdpHost !== undefined && { host: input.cdpHost }),
+    ...(input.allowRemote !== undefined && { allowRemote: input.allowRemote }),
+  };
+
+  const accountId = await resolveAccount(cdpPort, cdpOptions);
+
+  let dismissed = 0;
+  let nonDismissable = 0;
+
+  // Dismiss launcher popup
+  const launcher = new LauncherService(cdpPort, cdpOptions);
+  try {
+    await launcher.connect();
+    const popupDismissed = await launcher.dismissPopup();
+    if (popupDismissed) {
+      dismissed++;
+    } else {
+      // Check if there's a non-dismissable popup
+      const popupState = await launcher.getPopupState();
+      if (popupState !== null && popupState.blocked) {
+        nonDismissable++;
+      }
+    }
+  } finally {
+    launcher.disconnect();
+  }
+
+  // Dismiss instance UI popups
+  const instance = new InstanceService(cdpPort, cdpOptions);
+  try {
+    await instance.connect();
+    const result = await instance.dismissInstancePopups();
+    dismissed += result.dismissed;
+    nonDismissable += result.nonDismissable;
+  } finally {
+    instance.disconnect();
+  }
+
+  return { accountId, dismissed, nonDismissable };
+}

--- a/packages/core/src/operations/index.ts
+++ b/packages/core/src/operations/index.ts
@@ -119,6 +119,11 @@ export {
   type GetErrorsInput,
   type GetErrorsOutput,
 } from "./get-errors.js";
+export {
+  dismissErrors,
+  type DismissErrorsInput,
+  type DismissErrorsOutput,
+} from "./dismiss-errors.js";
 
 // Messaging
 export {

--- a/packages/core/src/services/instance.ts
+++ b/packages/core/src/services/instance.ts
@@ -296,6 +296,52 @@ export class InstanceService {
   }
 
   /**
+   * Dismiss closable popups in the instance UI by clicking their buttons.
+   *
+   * @returns The number of popups that were dismissed.
+   */
+  async dismissInstancePopups(): Promise<{ dismissed: number; nonDismissable: number }> {
+    return this.evaluateUI<{ dismissed: number; nonDismissable: number }>(
+      `(() => {
+        let dismissed = 0;
+        let nonDismissable = 0;
+        const seen = new WeakSet();
+
+        // Strategy 1: class-based selectors for known popup components
+        for (const header of document.querySelectorAll('[class*="Popup_Header_"], [class*="ErrorAndAlert_Title_"]')) {
+          const container = header.closest('[class*="Popup_Container_"], [class*="Popup_Wrapper_"], [class*="ErrorAndAlert_"]') || header.parentElement;
+          if (!container || seen.has(container)) continue;
+          seen.add(container);
+          const controls = container.querySelector('[class*="Popup_Controls_"], [class*="Popup_Buttons_"]');
+          const button = controls?.querySelector('button');
+          if (button) {
+            button.click();
+            dismissed++;
+          } else {
+            nonDismissable++;
+          }
+        }
+
+        // Strategy 2: role-based fallback for dialogs not caught above
+        for (const dialog of document.querySelectorAll('[role="dialog"]')) {
+          if (seen.has(dialog)) continue;
+          seen.add(dialog);
+          const button = dialog.querySelector('button');
+          if (button) {
+            button.click();
+            dismissed++;
+          } else {
+            nonDismissable++;
+          }
+        }
+
+        return { dismissed, nonDismissable };
+      })()`,
+      false,
+    );
+  }
+
+  /**
    * Create a {@link VoyagerInterceptor} attached to the LinkedIn WebView.
    *
    * Returns a cached instance — only one interceptor exists per

--- a/packages/core/src/services/launcher.ts
+++ b/packages/core/src/services/launcher.ts
@@ -255,6 +255,28 @@ export class LauncherService {
   }
 
   /**
+   * Dismiss the blocking launcher popup by clicking its first button.
+   *
+   * Returns `true` if a popup was found and dismissed, `false` if no
+   * dismissable popup was present.
+   */
+  async dismissPopup(): Promise<boolean> {
+    const client = this.ensureConnected();
+
+    return this.launcherEvaluate<boolean>(
+      client,
+      `(() => {
+        const controls = document.querySelector('.Dialog_Controls_oL8HA');
+        if (!controls) return false;
+        const button = controls.querySelector('button');
+        if (!button) return false;
+        button.click();
+        return true;
+      })()`,
+    );
+  }
+
+  /**
    * Check the overall UI health of a LinkedHelper instance.
    *
    * Combines instance issue queries with popup overlay detection

--- a/packages/mcp/src/helpers.ts
+++ b/packages/mcp/src/helpers.ts
@@ -109,7 +109,7 @@ export function mapErrorToMcpResponse(error: unknown): McpResult | undefined {
   }
   if (error instanceof UIBlockedError) {
     return mcpError(
-      `${error.message}\n\nUI Health:\n${JSON.stringify(error.health, null, 2)}`,
+      `${error.message}\n\nUse the dismiss-errors tool to clear closable popups, then retry.\n\nUI Health:\n${JSON.stringify(error.health, null, 2)}`,
     );
   }
   return undefined;

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -111,6 +111,7 @@ describe("createServer", () => {
     expect(names).toContain("campaign-update-action");
     expect(names).toContain("campaign-remove-people");
     expect(names).toContain("get-errors");
+    expect(names).toContain("dismiss-errors");
     expect(names).toContain("list-collections");
     expect(names).toContain("create-collection");
     expect(names).toContain("delete-collection");
@@ -140,6 +141,6 @@ describe("createServer", () => {
     expect(names).toContain("send-inmail");
     expect(names).toContain("send-invite");
     expect(names).toContain("get-profile-activity");
-    expect(names).toHaveLength(66);
+    expect(names).toHaveLength(67);
   });
 });

--- a/packages/mcp/src/tools/dismiss-errors.test.ts
+++ b/packages/mcp/src/tools/dismiss-errors.test.ts
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return {
+    ...actual,
+    dismissErrors: vi.fn(),
+  };
+});
+
+import { type DismissErrorsOutput, dismissErrors } from "@lhremote/core";
+
+import { registerDismissErrors } from "./dismiss-errors.js";
+import { createMockServer } from "./testing/mock-server.js";
+
+const mockedDismissErrors = vi.mocked(dismissErrors);
+
+describe("registerDismissErrors", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("registers a tool named dismiss-errors", () => {
+    const { server } = createMockServer();
+    registerDismissErrors(server);
+
+    expect(server.tool).toHaveBeenCalledOnce();
+    expect(server.tool).toHaveBeenCalledWith(
+      "dismiss-errors",
+      expect.any(String),
+      expect.any(Object),
+      expect.any(Function),
+    );
+  });
+
+  it("returns result as JSON", async () => {
+    const { server, getHandler } = createMockServer();
+    registerDismissErrors(server);
+
+    const output: DismissErrorsOutput = {
+      accountId: 1,
+      dismissed: 2,
+      nonDismissable: 0,
+    };
+
+    mockedDismissErrors.mockResolvedValue(output);
+
+    const handler = getHandler("dismiss-errors");
+    const result = (await handler({ cdpPort: 9222 })) as {
+      content: [{ text: string }];
+    };
+
+    expect(JSON.parse(result.content[0].text)).toEqual(output);
+  });
+
+  it("returns error when dismissErrors throws", async () => {
+    const { server, getHandler } = createMockServer();
+    registerDismissErrors(server);
+
+    mockedDismissErrors.mockRejectedValue(new Error("unexpected failure"));
+
+    const handler = getHandler("dismiss-errors");
+    const result = await handler({ cdpPort: 9222 });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "Failed to dismiss errors: unexpected failure",
+        },
+      ],
+    });
+  });
+
+  it("passes cdpPort to dismissErrors", async () => {
+    const { server, getHandler } = createMockServer();
+    registerDismissErrors(server);
+
+    mockedDismissErrors.mockResolvedValue({
+      accountId: 1,
+      dismissed: 0,
+      nonDismissable: 0,
+    });
+
+    const handler = getHandler("dismiss-errors");
+    await handler({ cdpPort: 4567 });
+
+    expect(mockedDismissErrors).toHaveBeenCalledWith({
+      cdpPort: 4567,
+      cdpHost: undefined,
+      allowRemote: undefined,
+    });
+  });
+});

--- a/packages/mcp/src/tools/dismiss-errors.ts
+++ b/packages/mcp/src/tools/dismiss-errors.ts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { dismissErrors } from "@lhremote/core";
+import { cdpConnectionSchema, mcpCatchAll, mcpSuccess } from "../helpers.js";
+
+/** Register the {@link https://github.com/alexey-pelykh/lhremote#dismiss-errors | dismiss-errors} MCP tool. */
+export function registerDismissErrors(server: McpServer): void {
+  server.tool(
+    "dismiss-errors",
+    "Dismiss closable error popups in LinkedHelper instance UI by clicking their close/OK buttons. Use this tool when operations fail with UI errors or when get-errors reports closable popups. Recommended after UIBlockedError.",
+    {
+      ...cdpConnectionSchema,
+    },
+    async ({ cdpPort, cdpHost, allowRemote }) => {
+      try {
+        const result = await dismissErrors({ cdpPort, cdpHost, allowRemote });
+        return mcpSuccess(JSON.stringify(result, null, 2));
+      } catch (error) {
+        return mcpCatchAll(error, "Failed to dismiss errors");
+      }
+    },
+  );
+}

--- a/packages/mcp/src/tools/index.ts
+++ b/packages/mcp/src/tools/index.ts
@@ -41,6 +41,7 @@ import { registerCreateCollection } from "./create-collection.js";
 import { registerDeleteCollection } from "./delete-collection.js";
 import { registerCheckReplies } from "./check-replies.js";
 import { registerCheckStatus } from "./check-status.js";
+import { registerDismissErrors } from "./dismiss-errors.js";
 import { registerDescribeActions } from "./describe-actions.js";
 import { registerFindApp } from "./find-app.js";
 import { registerGetActionBudget } from "./get-action-budget.js";
@@ -106,6 +107,7 @@ export {
   registerCampaignUpdate,
   registerCreateCollection,
   registerDeleteCollection,
+  registerDismissErrors,
   registerCheckReplies,
   registerCheckStatus,
   registerDescribeActions,
@@ -186,6 +188,7 @@ export function registerAllTools(server: McpServer): void {
   registerSearchPosts(server);
   registerCreateCollection(server);
   registerDeleteCollection(server);
+  registerDismissErrors(server);
   registerCheckReplies(server);
   registerCheckStatus(server);
   registerCollectPeople(server);


### PR DESCRIPTION
## Summary

- Add `dismiss-errors` operation, MCP tool, and CLI command that dismisses closable error popups in the LinkedHelper instance UI via CDP
- `LauncherService.dismissPopup()` clicks first button in launcher popup overlay; `InstanceService.dismissInstancePopups()` clicks buttons in instance UI popups using the same selector strategies as `getInstancePopups()`
- Update `UIBlockedError` MCP response to recommend using `dismiss-errors` before retrying

Closes #439

## Test plan

- [x] Unit tests for core operation (5 tests: no-popups, dismiss+instance, non-dismissable, connection options, cleanup-on-error)
- [x] Unit tests for MCP tool (4 tests: registration, JSON result, error handling, cdpPort passthrough)
- [x] Unit tests for CLI handler (5 tests: JSON output, human-friendly output, non-dismissable display, conditional hiding, error exit code)
- [x] Program and server registration tests updated (command count 65->66, tool count 66->67)
- [x] Lint passes clean
- [ ] CI passes on ubuntu/macos/windows matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)