### PR TITLE
(feat) core,mcp,cli: add campaign-erase command

### DIFF
--- a/packages/cli/src/handlers/campaign-erase.test.ts
+++ b/packages/cli/src/handlers/campaign-erase.test.ts
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return {
+    ...actual,
+    campaignErase: vi.fn(),
+  };
+});
+
+import {
+  type CampaignEraseOutput,
+  CampaignExecutionError,
+  CampaignNotFoundError,
+  InstanceNotRunningError,
+  campaignErase,
+} from "@lhremote/core";
+
+import { handleCampaignErase } from "./campaign-erase.js";
+import { getStdout } from "./testing/mock-helpers.js";
+
+const MOCK_RESULT: CampaignEraseOutput = {
+  success: true as const,
+  campaignId: 5,
+};
+
+describe("handleCampaignErase", () => {
+  const originalExitCode = process.exitCode;
+  let stdoutSpy: ReturnType<typeof vi.spyOn>;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    process.exitCode = undefined;
+    vi.clearAllMocks();
+    stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+    stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    process.exitCode = originalExitCode;
+    vi.restoreAllMocks();
+  });
+
+  it("erases campaign and prints confirmation", async () => {
+    vi.mocked(campaignErase).mockResolvedValue(MOCK_RESULT);
+
+    await handleCampaignErase(5, {});
+
+    expect(process.exitCode).toBeUndefined();
+    expect(getStdout(stdoutSpy)).toContain("Campaign 5 erased.");
+  });
+
+  it("prints JSON with --json", async () => {
+    vi.mocked(campaignErase).mockResolvedValue(MOCK_RESULT);
+
+    await handleCampaignErase(5, { json: true });
+
+    expect(process.exitCode).toBeUndefined();
+    const parsed = JSON.parse(getStdout(stdoutSpy));
+    expect(parsed.success).toBe(true);
+    expect(parsed.campaignId).toBe(5);
+  });
+
+  it("sets exitCode 1 when campaign not found", async () => {
+    vi.mocked(campaignErase).mockRejectedValue(new CampaignNotFoundError(999));
+
+    await handleCampaignErase(999, {});
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("Campaign 999 not found.\n");
+  });
+
+  it("sets exitCode 1 on CampaignExecutionError", async () => {
+    vi.mocked(campaignErase).mockRejectedValue(
+      new CampaignExecutionError("cannot erase running campaign"),
+    );
+
+    await handleCampaignErase(5, {});
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "Failed to erase campaign: cannot erase running campaign\n",
+    );
+  });
+
+  it("sets exitCode 1 on InstanceNotRunningError", async () => {
+    vi.mocked(campaignErase).mockRejectedValue(
+      new InstanceNotRunningError("No LinkedHelper instance is running."),
+    );
+
+    await handleCampaignErase(5, {});
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith(
+      "No LinkedHelper instance is running.\n",
+    );
+  });
+
+  it("sets exitCode 1 when resolveAccount fails", async () => {
+    vi.mocked(campaignErase).mockRejectedValue(new Error("connection error"));
+
+    await handleCampaignErase(5, {});
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalledWith("connection error\n");
+  });
+});

--- a/packages/cli/src/handlers/campaign-erase.ts
+++ b/packages/cli/src/handlers/campaign-erase.ts
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import {
+  CampaignExecutionError,
+  CampaignNotFoundError,
+  DEFAULT_CDP_PORT,
+  errorMessage,
+  InstanceNotRunningError,
+  campaignErase,
+  type CampaignEraseOutput,
+} from "@lhremote/core";
+
+/** Handle the {@link https://github.com/alexey-pelykh/lhremote#campaigns | campaign-erase} CLI command. */
+export async function handleCampaignErase(
+  campaignId: number,
+  options: {
+    cdpPort?: number;
+    cdpHost?: string;
+    allowRemote?: boolean;
+    json?: boolean;
+  },
+): Promise<void> {
+  let result: CampaignEraseOutput;
+  try {
+    result = await campaignErase({
+      campaignId,
+      cdpPort: options.cdpPort ?? DEFAULT_CDP_PORT,
+      cdpHost: options.cdpHost,
+      allowRemote: options.allowRemote,
+    });
+  } catch (error) {
+    if (error instanceof CampaignNotFoundError) {
+      process.stderr.write(`Campaign ${String(campaignId)} not found.\n`);
+    } else if (error instanceof CampaignExecutionError) {
+      process.stderr.write(`Failed to erase campaign: ${error.message}\n`);
+    } else if (error instanceof InstanceNotRunningError) {
+      process.stderr.write(`${error.message}\n`);
+    } else {
+      const message = errorMessage(error);
+      process.stderr.write(`${message}\n`);
+    }
+    process.exitCode = 1;
+    return;
+  }
+
+  if (options.json) {
+    process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+  } else {
+    process.stdout.write(
+      `Campaign ${String(campaignId)} erased.\n`,
+    );
+  }
+}

--- a/packages/cli/src/handlers/index.ts
+++ b/packages/cli/src/handlers/index.ts
@@ -5,6 +5,7 @@ export { handleAddPeopleToCollection } from "./add-people-to-collection.js";
 export { handleCampaignAddAction } from "./campaign-add-action.js";
 export { handleCampaignCreate } from "./campaign-create.js";
 export { handleCampaignDelete } from "./campaign-delete.js";
+export { handleCampaignErase } from "./campaign-erase.js";
 export { handleCampaignExcludeAdd } from "./campaign-exclude-add.js";
 export { handleCampaignExcludeList } from "./campaign-exclude-list.js";
 export { handleCampaignExcludeRemove } from "./campaign-exclude-remove.js";

--- a/packages/cli/src/program.test.ts
+++ b/packages/cli/src/program.test.ts
@@ -101,7 +101,8 @@ describe("createProgram", () => {
     expect(commandNames).toContain("like-person-posts");
     expect(commandNames).toContain("remove-connection");
     expect(commandNames).toContain("enrich-profile");
-    expect(commandNames).toHaveLength(66);
+    expect(commandNames).toContain("campaign-erase");
+    expect(commandNames).toHaveLength(67);
   });
 
   describe("launch-app", () => {

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -11,6 +11,7 @@ import {
   handleCampaignAddAction,
   handleCampaignCreate,
   handleCampaignDelete,
+  handleCampaignErase,
   handleCampaignExcludeAdd,
   handleCampaignExcludeList,
   handleCampaignExcludeRemove,
@@ -223,6 +224,16 @@ export function createProgram(): Command {
     .option("--allow-remote", "SECURITY: allow non-loopback CDP connections (enables remote code execution on target)")
     .option("--json", "Output as JSON")
     .action(handleCampaignDelete);
+
+  program
+    .command("campaign-erase")
+    .description("Permanently erase a campaign and all related data (irreversible)")
+    .argument("<campaignId>", "Campaign ID to erase", parsePositiveInt)
+    .option("--cdp-port <port>", "CDP debugging port", parsePositiveInt)
+    .option("--cdp-host <host>", "CDP host (default: 127.0.0.1)")
+    .option("--allow-remote", "SECURITY: allow non-loopback CDP connections (enables remote code execution on target)")
+    .option("--json", "Output as JSON")
+    .action(handleCampaignErase);
 
   program
     .command("campaign-exclude-list")

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -241,6 +241,9 @@ export {
   campaignDelete,
   type CampaignDeleteInput,
   type CampaignDeleteOutput,
+  campaignErase,
+  type CampaignEraseInput,
+  type CampaignEraseOutput,
   // People collection
   collectPeople,
   type CollectPeopleInput,

--- a/packages/core/src/operations/campaign-erase.test.ts
+++ b/packages/core/src/operations/campaign-erase.test.ts
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../services/account-resolution.js", () => ({
+  resolveAccount: vi.fn(),
+}));
+
+vi.mock("../services/instance-context.js", () => ({
+  withInstanceDatabase: vi.fn(),
+}));
+
+vi.mock("../services/campaign.js", () => ({
+  CampaignService: vi.fn(),
+}));
+
+import type { InstanceDatabaseContext } from "../services/instance-context.js";
+import { resolveAccount } from "../services/account-resolution.js";
+import { withInstanceDatabase } from "../services/instance-context.js";
+import { CampaignService } from "../services/campaign.js";
+import { campaignErase } from "./campaign-erase.js";
+
+function setupMocks(overrides?: { hardDelete?: ReturnType<typeof vi.fn> }) {
+  vi.mocked(resolveAccount).mockResolvedValue(1);
+
+  vi.mocked(withInstanceDatabase).mockImplementation(
+    async (_cdpPort, _accountId, callback) =>
+      callback({
+        accountId: 1,
+        instance: {},
+        db: {},
+      } as unknown as InstanceDatabaseContext),
+  );
+
+  vi.mocked(CampaignService).mockImplementation(function () {
+    return {
+      hardDelete: overrides?.hardDelete ?? vi.fn(),
+    } as unknown as CampaignService;
+  });
+}
+
+describe("campaignErase", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns success with campaignId", async () => {
+    setupMocks();
+
+    const result = await campaignErase({
+      campaignId: 42,
+      cdpPort: 9222,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.campaignId).toBe(42);
+  });
+
+  it("calls hardDelete with campaignId", async () => {
+    const hardDeleteMock = vi.fn();
+    setupMocks({ hardDelete: hardDeleteMock });
+
+    await campaignErase({
+      campaignId: 42,
+      cdpPort: 9222,
+    });
+
+    expect(hardDeleteMock).toHaveBeenCalledWith(42);
+  });
+
+  it("passes db readOnly: false to withInstanceDatabase", async () => {
+    setupMocks();
+
+    await campaignErase({
+      campaignId: 42,
+      cdpPort: 9222,
+    });
+
+    expect(withInstanceDatabase).toHaveBeenCalledWith(
+      9222,
+      1,
+      expect.any(Function),
+      { db: { readOnly: false } },
+    );
+  });
+
+  it("passes connection options to resolveAccount", async () => {
+    setupMocks();
+
+    await campaignErase({
+      campaignId: 42,
+      cdpPort: 1234,
+      cdpHost: "192.168.1.1",
+      allowRemote: true,
+    });
+
+    expect(resolveAccount).toHaveBeenCalledWith(1234, {
+      host: "192.168.1.1",
+      allowRemote: true,
+    });
+  });
+
+  it("omits undefined connection options", async () => {
+    setupMocks();
+
+    await campaignErase({
+      campaignId: 42,
+      cdpPort: 9222,
+    });
+
+    expect(resolveAccount).toHaveBeenCalledWith(9222, {});
+  });
+
+  it("propagates resolveAccount errors", async () => {
+    vi.mocked(resolveAccount).mockRejectedValue(new Error("connection refused"));
+
+    await expect(
+      campaignErase({ campaignId: 42, cdpPort: 9222 }),
+    ).rejects.toThrow("connection refused");
+  });
+
+  it("propagates withInstanceDatabase errors", async () => {
+    vi.mocked(resolveAccount).mockResolvedValue(1);
+    vi.mocked(withInstanceDatabase).mockRejectedValue(
+      new Error("instance not running"),
+    );
+
+    await expect(
+      campaignErase({ campaignId: 42, cdpPort: 9222 }),
+    ).rejects.toThrow("instance not running");
+  });
+
+  it("propagates hardDelete errors", async () => {
+    const hardDeleteMock = vi.fn().mockImplementation(() => {
+      throw new Error("Cannot hard-delete active campaign");
+    });
+    setupMocks({ hardDelete: hardDeleteMock });
+
+    await expect(
+      campaignErase({ campaignId: 42, cdpPort: 9222 }),
+    ).rejects.toThrow("Cannot hard-delete active campaign");
+  });
+});

--- a/packages/core/src/operations/campaign-erase.ts
+++ b/packages/core/src/operations/campaign-erase.ts
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { resolveAccount } from "../services/account-resolution.js";
+import { withInstanceDatabase } from "../services/instance-context.js";
+import { CampaignService } from "../services/campaign.js";
+import { DEFAULT_CDP_PORT } from "../constants.js";
+import type { ConnectionOptions } from "./types.js";
+
+/**
+ * Input for the campaign-erase operation.
+ */
+export interface CampaignEraseInput extends ConnectionOptions {
+  readonly campaignId: number;
+}
+
+/**
+ * Output from the campaign-erase operation.
+ */
+export interface CampaignEraseOutput {
+  readonly success: true;
+  readonly campaignId: number;
+}
+
+/**
+ * Permanently erase a campaign and all related data from the database.
+ */
+export async function campaignErase(
+  input: CampaignEraseInput,
+): Promise<CampaignEraseOutput> {
+  const cdpPort = input.cdpPort ?? DEFAULT_CDP_PORT;
+
+  const accountId = await resolveAccount(cdpPort, {
+    ...(input.cdpHost !== undefined && { host: input.cdpHost }),
+    ...(input.allowRemote !== undefined && { allowRemote: input.allowRemote }),
+  });
+
+  return withInstanceDatabase(cdpPort, accountId, ({ instance, db }) => {
+    const campaignService = new CampaignService(instance, db);
+    campaignService.hardDelete(input.campaignId);
+    return { success: true as const, campaignId: input.campaignId };
+  }, { db: { readOnly: false } });
+}

--- a/packages/core/src/operations/index.ts
+++ b/packages/core/src/operations/index.ts
@@ -29,6 +29,11 @@ export {
   type CampaignDeleteInput,
   type CampaignDeleteOutput,
 } from "./campaign-delete.js";
+export {
+  campaignErase,
+  type CampaignEraseInput,
+  type CampaignEraseOutput,
+} from "./campaign-erase.js";
 
 // Campaign people
 export {

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -141,6 +141,7 @@ describe("createServer", () => {
     expect(names).toContain("send-inmail");
     expect(names).toContain("send-invite");
     expect(names).toContain("get-profile-activity");
-    expect(names).toHaveLength(67);
+    expect(names).toContain("campaign-erase");
+    expect(names).toHaveLength(68);
   });
 });

--- a/packages/mcp/src/tools/campaign-erase.test.ts
+++ b/packages/mcp/src/tools/campaign-erase.test.ts
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return {
+    ...actual,
+    campaignErase: vi.fn(),
+  };
+});
+
+import {
+  CampaignExecutionError,
+  CampaignNotFoundError,
+  campaignErase,
+} from "@lhremote/core";
+
+import { registerCampaignErase } from "./campaign-erase.js";
+import { describeInfrastructureErrors } from "./testing/infrastructure-errors.js";
+import { createMockServer } from "./testing/mock-server.js";
+
+const ERASE_RESULT = { success: true as const, campaignId: 15 };
+
+describe("registerCampaignErase", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("registers a tool named campaign-erase", () => {
+    const { server } = createMockServer();
+    registerCampaignErase(server);
+
+    expect(server.tool).toHaveBeenCalledOnce();
+    expect(server.tool).toHaveBeenCalledWith(
+      "campaign-erase",
+      expect.any(String),
+      expect.any(Object),
+      expect.any(Function),
+    );
+  });
+
+  it("successfully erases a campaign", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignErase(server);
+    vi.mocked(campaignErase).mockResolvedValue(ERASE_RESULT);
+
+    const handler = getHandler("campaign-erase");
+    const result = await handler({
+      campaignId: 15,
+      cdpPort: 9222,
+    });
+
+    expect(result).toEqual({
+      content: [
+        {
+          type: "text",
+          text: JSON.stringify(ERASE_RESULT, null, 2),
+        },
+      ],
+    });
+  });
+
+  it("returns error for non-existent campaign", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignErase(server);
+
+    vi.mocked(campaignErase).mockRejectedValue(new CampaignNotFoundError(999));
+
+    const handler = getHandler("campaign-erase");
+    const result = await handler({
+      campaignId: 999,
+      cdpPort: 9222,
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "Campaign 999 not found.",
+        },
+      ],
+    });
+  });
+
+  describeInfrastructureErrors(
+    registerCampaignErase,
+    "campaign-erase",
+    () => ({ campaignId: 15, cdpPort: 9222 }),
+    (error) => vi.mocked(campaignErase).mockRejectedValue(error),
+    "Failed to erase campaign",
+  );
+
+  it("returns error when campaign execution fails", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignErase(server);
+
+    vi.mocked(campaignErase).mockRejectedValue(
+      new CampaignExecutionError(
+        "Failed to erase campaign 15: campaign is active",
+        15,
+      ),
+    );
+
+    const handler = getHandler("campaign-erase");
+    const result = await handler({
+      campaignId: 15,
+      cdpPort: 9222,
+    });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "Failed to erase campaign: Failed to erase campaign 15: campaign is active",
+        },
+      ],
+    });
+  });
+});

--- a/packages/mcp/src/tools/campaign-erase.ts
+++ b/packages/mcp/src/tools/campaign-erase.ts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  CampaignExecutionError,
+  campaignErase,
+} from "@lhremote/core";
+import { z } from "zod";
+import { cdpConnectionSchema, mcpCatchAll, mcpError, mcpSuccess } from "../helpers.js";
+
+/** Register the {@link https://github.com/alexey-pelykh/lhremote#campaign-erase | campaign-erase} MCP tool. */
+export function registerCampaignErase(server: McpServer): void {
+  server.tool(
+    "campaign-erase",
+    "Permanently erase a campaign and all related data from the database. This is irreversible.",
+    {
+      campaignId: z
+        .number()
+        .int()
+        .positive()
+        .describe("Campaign ID"),
+      ...cdpConnectionSchema,
+    },
+    async ({ campaignId, cdpPort, cdpHost, allowRemote }) => {
+      try {
+        const result = await campaignErase({ campaignId, cdpPort, cdpHost, allowRemote });
+        return mcpSuccess(JSON.stringify(result, null, 2));
+      } catch (error) {
+        if (error instanceof CampaignExecutionError) {
+          return mcpError(`Failed to erase campaign: ${error.message}`);
+        }
+        return mcpCatchAll(error, "Failed to erase campaign");
+      }
+    },
+  );
+}

--- a/packages/mcp/src/tools/index.ts
+++ b/packages/mcp/src/tools/index.ts
@@ -18,6 +18,7 @@ import { registerSendInvite } from "./send-invite.js";
 import { registerCampaignAddAction } from "./campaign-add-action.js";
 import { registerCampaignCreate } from "./campaign-create.js";
 import { registerCampaignDelete } from "./campaign-delete.js";
+import { registerCampaignErase } from "./campaign-erase.js";
 import { registerCampaignExcludeAdd } from "./campaign-exclude-add.js";
 import { registerCampaignExcludeList } from "./campaign-exclude-list.js";
 import { registerCampaignExcludeRemove } from "./campaign-exclude-remove.js";
@@ -87,6 +88,7 @@ export {
   registerCampaignAddAction,
   registerCampaignCreate,
   registerCampaignDelete,
+  registerCampaignErase,
   registerCampaignExcludeAdd,
   registerCampaignExcludeList,
   registerCampaignExcludeRemove,
@@ -147,6 +149,7 @@ export function registerAllTools(server: McpServer): void {
   registerCampaignAddAction(server);
   registerCampaignCreate(server);
   registerCampaignDelete(server);
+  registerCampaignErase(server);
   registerCampaignExcludeAdd(server);
   registerCampaignExcludeList(server);
   registerCampaignExcludeRemove(server);


### PR DESCRIPTION
## Summary

- Add `campaign-erase` operation in core as a thin wrapper around existing `CampaignService.hardDelete()`
- Add `campaign-erase` CLI command (no `--hard` flag — always permanent)
- Add `campaign-erase` MCP tool with Zod schema and proper error handling
- Add unit tests for all three layers (8 core + 6 CLI + 6 MCP)
- Update registration indexes and command/tool count assertions

Closes #336

## Test plan

- [x] Core operation tests pass (8 tests)
- [x] CLI handler tests pass (6 tests)
- [x] MCP tool tests pass (6 tests)
- [x] CLI program registration test updated (66 → 67 commands)
- [x] MCP server registration test updated (67 → 68 tools)
- [x] `pnpm lint` passes
- [x] Full build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)