### PR TITLE
Add connectUiOnly() to InstanceService for partial-start scenarios

### DIFF
--- a/packages/core/src/services/instance.test.ts
+++ b/packages/core/src/services/instance.test.ts
@@ -188,6 +188,104 @@ describe("InstanceService", () => {
     });
   });
 
+  describe("connectUiOnly", () => {
+    it("connects to UI target only when both targets exist", async () => {
+      mockedDiscoverTargets.mockResolvedValue([LINKEDIN_TARGET, UI_TARGET]);
+
+      await service.connectUiOnly();
+
+      expect(clientInstances).toHaveLength(1);
+      expect(clientsByTargetId.has("UI1")).toBe(true);
+      expect(clientsByTargetId.has("LI1")).toBe(false);
+    });
+
+    it("connects when only UI target exists", async () => {
+      mockedDiscoverTargets.mockResolvedValue([UI_TARGET]);
+
+      await service.connectUiOnly();
+
+      expect(clientInstances).toHaveLength(1);
+      expect(clientsByTargetId.has("UI1")).toBe(true);
+    });
+
+    it("evaluateUI works after connectUiOnly", async () => {
+      mockedDiscoverTargets.mockResolvedValue([UI_TARGET]);
+      await service.connectUiOnly();
+
+      const uiClient = getClientMocks("UI1");
+      uiClient.evaluate.mockResolvedValueOnce("ok");
+
+      const result = await service.evaluateUI("expr");
+
+      expect(result).toBe("ok");
+      expect(uiClient.evaluate).toHaveBeenCalledWith("expr", true);
+    });
+
+    it("ensureLinkedInClient throws ServiceError after connectUiOnly", async () => {
+      mockedDiscoverTargets.mockResolvedValue([UI_TARGET]);
+      await service.connectUiOnly();
+
+      await expect(
+        service.navigateLinkedIn("https://www.linkedin.com/feed/"),
+      ).rejects.toThrow(ServiceError);
+    });
+
+    it("polls until UI target appears", async () => {
+      vi.useFakeTimers();
+
+      mockedDiscoverTargets
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([])
+        .mockResolvedValue([UI_TARGET]);
+
+      const connectPromise = service.connectUiOnly();
+      await vi.advanceTimersByTimeAsync(5_000);
+      await connectPromise;
+
+      expect(clientsByTargetId.has("UI1")).toBe(true);
+      expect(mockedDiscoverTargets.mock.calls.length).toBeGreaterThanOrEqual(3);
+
+      vi.useRealTimers();
+    });
+
+    it("throws InstanceNotRunningError when no UI target after timeout", async () => {
+      vi.useFakeTimers();
+
+      mockedDiscoverTargets.mockResolvedValue([LINKEDIN_TARGET]);
+
+      const promise = service.connectUiOnly();
+      const assertion = expect(promise).rejects.toThrow(
+        /Instance UI target not found/,
+      );
+      await vi.advanceTimersByTimeAsync(31_000);
+      await assertion;
+
+      vi.useRealTimers();
+    });
+
+    it("throws InstanceNotRunningError when no targets at all", async () => {
+      vi.useFakeTimers();
+
+      mockedDiscoverTargets.mockResolvedValue([]);
+
+      const promise = service.connectUiOnly();
+      const assertion = expect(promise).rejects.toThrow(
+        /Instance UI target not found.*0 CDP target/,
+      );
+      await vi.advanceTimersByTimeAsync(31_000);
+      await assertion;
+
+      vi.useRealTimers();
+    });
+
+    it("isConnected returns false after connectUiOnly", async () => {
+      mockedDiscoverTargets.mockResolvedValue([UI_TARGET]);
+      await service.connectUiOnly();
+
+      expect(service.isConnected).toBe(false);
+    });
+  });
+
   describe("disconnect", () => {
     it("disconnects both clients", async () => {
       mockedDiscoverTargets.mockResolvedValue([LINKEDIN_TARGET, UI_TARGET]);

--- a/packages/core/src/services/instance.ts
+++ b/packages/core/src/services/instance.ts
@@ -129,6 +129,52 @@ export class InstanceService {
   }
 
   /**
+   * Connect to only the instance UI target, without requiring the LinkedIn webview.
+   *
+   * Use this for partial-start scenarios where LinkedHelper failed to initialize
+   * and the LinkedIn webview was never created. After this call, {@link evaluateUI}
+   * and UI-dependent methods work, but LinkedIn-dependent methods like
+   * {@link navigateLinkedIn} and {@link createVoyagerInterceptor} will throw.
+   *
+   * @throws {InstanceNotRunningError} if the UI target is not found within the timeout.
+   */
+  async connectUiOnly(): Promise<void> {
+    const deadline = Date.now() + CONNECT_TIMEOUT;
+
+    let targets: CdpTarget[] = [];
+    let uiTarget: CdpTarget | undefined;
+
+    while (Date.now() < deadline) {
+      targets = await discoverTargets(this.port, this.host);
+
+      uiTarget = targets.find(isUiTarget);
+
+      if (uiTarget) {
+        break;
+      }
+
+      await delay(CONNECT_POLL_INTERVAL);
+    }
+
+    if (!uiTarget) {
+      throw new InstanceNotRunningError(
+        `Instance UI target not found among ${String(targets.length)} CDP target(s) on port ${String(this.port)}`,
+      );
+    }
+
+    const clientOptions = {
+      host: this.host,
+      ...(this.timeout !== undefined && { timeout: this.timeout }),
+      allowRemote: this.allowRemote,
+    };
+
+    const ui = new CDPClient(this.port, clientOptions);
+    await ui.connect(uiTarget.id);
+
+    this.uiClient = ui;
+  }
+
+  /**
    * Disconnect from both targets.
    */
   disconnect(): void {


### PR DESCRIPTION
## Summary

- Add `connectUiOnly()` method to `InstanceService` that connects to only the UI target (`index.html`), without requiring the LinkedIn webview
- Enables `evaluateUI()` and UI-dependent methods (dismiss-errors, get-errors) to work during LinkedHelper initialization failures when only the UI target exists
- 8 new unit tests covering: UI-only connection with both/single targets, evaluateUI working after connectUiOnly, LinkedIn methods throwing ServiceError, polling behavior, timeout errors, and isConnected state

## Test plan

- [x] Unit tests cover all acceptance criteria from #487
- [x] `pnpm test` passes (35 instance tests, up from 27)
- [x] `pnpm lint` passes clean
- [ ] CI passes on all platforms (ubuntu/macos/windows)

Closes #487

🤖 Generated with [Claude Code](https://claude.com/claude-code)