### PR TITLE
Make dismiss-errors work when LinkedIn webview is absent

### DIFF
--- a/packages/core/src/operations/dismiss-errors.test.ts
+++ b/packages/core/src/operations/dismiss-errors.test.ts
@@ -43,7 +43,7 @@ describe("dismissErrors", () => {
     });
 
     const mockInstance = {
-      connect: vi.fn().mockResolvedValue(undefined),
+      connectUiOnly: vi.fn().mockResolvedValue(undefined),
       disconnect: vi.fn(),
       dismissInstancePopups: vi.fn().mockResolvedValue({ dismissed: 0, nonDismissable: 0 }),
     };
@@ -71,7 +71,7 @@ describe("dismissErrors", () => {
     });
 
     const mockInstance = {
-      connect: vi.fn().mockResolvedValue(undefined),
+      connectUiOnly: vi.fn().mockResolvedValue(undefined),
       disconnect: vi.fn(),
       dismissInstancePopups: vi.fn().mockResolvedValue({ dismissed: 2, nonDismissable: 0 }),
     };
@@ -99,7 +99,7 @@ describe("dismissErrors", () => {
     });
 
     const mockInstance = {
-      connect: vi.fn().mockResolvedValue(undefined),
+      connectUiOnly: vi.fn().mockResolvedValue(undefined),
       disconnect: vi.fn(),
       dismissInstancePopups: vi.fn().mockResolvedValue({ dismissed: 0, nonDismissable: 1 }),
     };
@@ -127,7 +127,7 @@ describe("dismissErrors", () => {
     });
 
     const mockInstance = {
-      connect: vi.fn().mockResolvedValue(undefined),
+      connectUiOnly: vi.fn().mockResolvedValue(undefined),
       disconnect: vi.fn(),
       dismissInstancePopups: vi.fn().mockResolvedValue({ dismissed: 0, nonDismissable: 0 }),
     };
@@ -145,6 +145,35 @@ describe("dismissErrors", () => {
       host: "192.168.1.1",
       allowRemote: true,
     });
+  });
+
+  it("works when LinkedIn webview is absent (partial start)", async () => {
+    vi.mocked(resolveAccount).mockResolvedValue(1);
+
+    const mockLauncher = {
+      connect: vi.fn().mockResolvedValue(undefined),
+      disconnect: vi.fn(),
+      dismissPopup: vi.fn().mockResolvedValue(false),
+      getPopupState: vi.fn().mockResolvedValue(null),
+    };
+    vi.mocked(LauncherService).mockImplementation(function () {
+      return mockLauncher as unknown as LauncherService;
+    });
+
+    const mockInstance = {
+      connectUiOnly: vi.fn().mockResolvedValue(undefined),
+      disconnect: vi.fn(),
+      dismissInstancePopups: vi.fn().mockResolvedValue({ dismissed: 1, nonDismissable: 0 }),
+    };
+    vi.mocked(InstanceService).mockImplementation(function () {
+      return mockInstance as unknown as InstanceService;
+    });
+
+    const result = await dismissErrors({ cdpPort: 9222 });
+
+    expect(mockInstance.connectUiOnly).toHaveBeenCalledOnce();
+    expect(result.dismissed).toBe(1);
+    expect(result.nonDismissable).toBe(0);
   });
 
   it("disconnects services even on error", async () => {

--- a/packages/core/src/operations/dismiss-errors.ts
+++ b/packages/core/src/operations/dismiss-errors.ts
@@ -24,9 +24,9 @@ export interface DismissErrorsOutput {
 /**
  * Dismiss closable error popups in the LinkedHelper instance UI.
  *
- * Connects to both the launcher and instance, finds popup close/OK
- * buttons, and clicks them via CDP.  Returns the number of dismissed
- * vs non-dismissable popups.
+ * Connects to the launcher and instance UI (LinkedIn webview is not
+ * required), finds popup close/OK buttons, and clicks them via CDP.
+ * Returns the number of dismissed vs non-dismissable popups.
  */
 export async function dismissErrors(
   input: DismissErrorsInput,
@@ -64,7 +64,7 @@ export async function dismissErrors(
   // Dismiss instance UI popups
   const instance = new InstanceService(cdpPort, cdpOptions);
   try {
-    await instance.connect();
+    await instance.connectUiOnly();
     const result = await instance.dismissInstancePopups();
     dismissed += result.dismissed;
     nonDismissable += result.nonDismissable;


### PR DESCRIPTION
## Summary

- Switch `instance.connect()` to `instance.connectUiOnly()` in the dismiss-errors operation so it works when the LinkedHelper instance is partially started (UI target exists but LinkedIn webview hasn't loaded)
- Add unit test covering the partial-start scenario
- Update JSDoc to reflect that LinkedIn webview is not required

Closes #488

## Test plan

- [x] Existing unit tests updated (`connect` → `connectUiOnly`) and passing
- [x] New test: partial-start scenario (UI only, no LinkedIn webview) — verifies `connectUiOnly` is called and popups are dismissed
- [x] Full test suite passes (`pnpm test` — 10/10 tasks)
- [x] Lint clean (`pnpm lint`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)