### PR TITLE
Make get-errors detect popups when LinkedIn webview is absent

### DIFF
--- a/packages/core/src/operations/get-errors.test.ts
+++ b/packages/core/src/operations/get-errors.test.ts
@@ -11,15 +11,10 @@ vi.mock("../services/launcher.js", () => ({
   LauncherService: vi.fn(),
 }));
 
-vi.mock("../cdp/index.js", () => ({
-  discoverTargets: vi.fn(),
-}));
-
 vi.mock("../services/instance.js", () => ({
   InstanceService: vi.fn(),
 }));
 
-import { discoverTargets } from "../cdp/index.js";
 import { resolveAccount } from "../services/account-resolution.js";
 import { InstanceService } from "../services/instance.js";
 import { LauncherService } from "../services/launcher.js";
@@ -29,13 +24,33 @@ import { getErrors } from "./get-errors.js";
 describe("getErrors", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    // Default: no instance targets
-    vi.mocked(discoverTargets).mockResolvedValue([]);
+    // Default: connectUiOnly rejects (instance not running)
+    mockInstance({ connectFails: true });
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
   });
+
+  function mockInstance(opts: {
+    connectFails?: boolean;
+    popups?: { title: string; description?: string; closable?: boolean }[];
+    getPopupsFails?: boolean;
+  }) {
+    const mock = {
+      connectUiOnly: opts.connectFails
+        ? vi.fn().mockRejectedValue(new Error("UI target not found"))
+        : vi.fn().mockResolvedValue(undefined),
+      disconnect: vi.fn(),
+      getInstancePopups: opts.getPopupsFails
+        ? vi.fn().mockRejectedValue(new Error("DOM error"))
+        : vi.fn().mockResolvedValue(opts.popups ?? []),
+    };
+    vi.mocked(InstanceService).mockImplementation(function () {
+      return mock as unknown as InstanceService;
+    });
+    return mock;
+  }
 
   function mockLauncher(health: UIHealthStatus) {
     const mock = {
@@ -151,21 +166,10 @@ describe("getErrors", () => {
   it("includes instance popups when instance is running", async () => {
     vi.mocked(resolveAccount).mockResolvedValue(1);
     mockLauncher({ healthy: true, issues: [], popup: null, instancePopups: [] });
-
-    vi.mocked(discoverTargets).mockResolvedValue([
-      { id: "t1", type: "page", title: "LinkedIn", url: "https://www.linkedin.com/feed/", description: "", devtoolsFrontendUrl: "", webSocketDebuggerUrl: "" },
-      { id: "t2", type: "page", title: "LH", url: "file:///index.html", description: "", devtoolsFrontendUrl: "", webSocketDebuggerUrl: "" },
-    ]);
-
-    const mockInstance = {
-      connect: vi.fn().mockResolvedValue(undefined),
-      disconnect: vi.fn(),
-      getInstancePopups: vi.fn().mockResolvedValue([
+    mockInstance({
+      popups: [
         { title: "Failed to initialize UI", description: "AsyncHandlerError", closable: true },
-      ]),
-    };
-    vi.mocked(InstanceService).mockImplementation(function () {
-      return mockInstance as unknown as InstanceService;
+      ],
     });
 
     const result = await getErrors({ cdpPort: 9222 });
@@ -178,21 +182,8 @@ describe("getErrors", () => {
   it("marks unhealthy when instance popups are present even if launcher is healthy", async () => {
     vi.mocked(resolveAccount).mockResolvedValue(1);
     mockLauncher({ healthy: true, issues: [], popup: null, instancePopups: [] });
-
-    vi.mocked(discoverTargets).mockResolvedValue([
-      { id: "t1", type: "page", title: "LinkedIn", url: "https://www.linkedin.com/feed/", description: "", devtoolsFrontendUrl: "", webSocketDebuggerUrl: "" },
-      { id: "t2", type: "page", title: "LH", url: "file:///index.html", description: "", devtoolsFrontendUrl: "", webSocketDebuggerUrl: "" },
-    ]);
-
-    const mockInstance = {
-      connect: vi.fn().mockResolvedValue(undefined),
-      disconnect: vi.fn(),
-      getInstancePopups: vi.fn().mockResolvedValue([
-        { title: "Error popup", closable: false },
-      ]),
-    };
-    vi.mocked(InstanceService).mockImplementation(function () {
-      return mockInstance as unknown as InstanceService;
+    mockInstance({
+      popups: [{ title: "Error popup", closable: false }],
     });
 
     const result = await getErrors({ cdpPort: 9222 });
@@ -201,26 +192,10 @@ describe("getErrors", () => {
     expect(result.instancePopups).toHaveLength(1);
   });
 
-  it("returns empty instancePopups when instance is not running", async () => {
+  it("returns empty instancePopups when UI target is absent", async () => {
     vi.mocked(resolveAccount).mockResolvedValue(1);
     mockLauncher({ healthy: true, issues: [], popup: null, instancePopups: [] });
-
-    // Only launcher target, no instance targets
-    vi.mocked(discoverTargets).mockResolvedValue([
-      { id: "t1", type: "page", title: "Launcher", url: "file:///launcher.html", description: "", devtoolsFrontendUrl: "", webSocketDebuggerUrl: "" },
-    ]);
-
-    const result = await getErrors({ cdpPort: 9222 });
-
-    expect(result.instancePopups).toEqual([]);
-    expect(result.healthy).toBe(true);
-  });
-
-  it("returns empty instancePopups when target discovery fails", async () => {
-    vi.mocked(resolveAccount).mockResolvedValue(1);
-    mockLauncher({ healthy: true, issues: [], popup: null, instancePopups: [] });
-
-    vi.mocked(discoverTargets).mockRejectedValue(new Error("connection reset"));
+    // Default beforeEach already sets connectFails: true
 
     const result = await getErrors({ cdpPort: 9222 });
 
@@ -231,24 +206,27 @@ describe("getErrors", () => {
   it("disconnects instance service even when getInstancePopups fails", async () => {
     vi.mocked(resolveAccount).mockResolvedValue(1);
     mockLauncher({ healthy: true, issues: [], popup: null, instancePopups: [] });
-
-    vi.mocked(discoverTargets).mockResolvedValue([
-      { id: "t1", type: "page", title: "LinkedIn", url: "https://www.linkedin.com/feed/", description: "", devtoolsFrontendUrl: "", webSocketDebuggerUrl: "" },
-      { id: "t2", type: "page", title: "LH", url: "file:///index.html", description: "", devtoolsFrontendUrl: "", webSocketDebuggerUrl: "" },
-    ]);
-
-    const mockInstance = {
-      connect: vi.fn().mockResolvedValue(undefined),
-      disconnect: vi.fn(),
-      getInstancePopups: vi.fn().mockRejectedValue(new Error("DOM error")),
-    };
-    vi.mocked(InstanceService).mockImplementation(function () {
-      return mockInstance as unknown as InstanceService;
-    });
+    const inst = mockInstance({ getPopupsFails: true });
 
     const result = await getErrors({ cdpPort: 9222 });
 
     expect(result.instancePopups).toEqual([]);
-    expect(mockInstance.disconnect).toHaveBeenCalledOnce();
+    expect(inst.disconnect).toHaveBeenCalledOnce();
+  });
+
+  it("detects popups when LinkedIn webview is absent (UI-only start)", async () => {
+    vi.mocked(resolveAccount).mockResolvedValue(1);
+    mockLauncher({ healthy: true, issues: [], popup: null, instancePopups: [] });
+    mockInstance({
+      popups: [
+        { title: "Session expired", closable: true },
+      ],
+    });
+
+    const result = await getErrors({ cdpPort: 9222 });
+
+    expect(result.instancePopups).toHaveLength(1);
+    expect(result.instancePopups[0]?.title).toBe("Session expired");
+    expect(result.healthy).toBe(false);
   });
 });

--- a/packages/core/src/operations/get-errors.ts
+++ b/packages/core/src/operations/get-errors.ts
@@ -2,7 +2,6 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import type { InstancePopup, UIHealthStatus } from "../types/index.js";
-import { discoverTargets } from "../cdp/index.js";
 import { resolveAccount } from "../services/account-resolution.js";
 import { InstanceService } from "../services/instance.js";
 import { LauncherService } from "../services/launcher.js";
@@ -55,12 +54,8 @@ export async function getErrors(
     launcher.disconnect();
   }
 
-  // Best-effort: detect instance UI popups if the instance is running.
-  const instancePopups = await detectInstancePopups(
-    cdpPort,
-    input.cdpHost,
-    cdpOptions,
-  );
+  // Best-effort: detect instance UI popups if the UI target is available.
+  const instancePopups = await detectInstancePopups(cdpPort, cdpOptions);
 
   const healthy =
     health.healthy && instancePopups.length === 0;
@@ -69,36 +64,22 @@ export async function getErrors(
 }
 
 /**
- * Attempt to detect instance UI popups via a one-shot target discovery.
+ * Attempt to detect instance UI popups via {@link InstanceService.connectUiOnly}.
  *
- * Returns an empty array when the instance is not running or the
- * targets disappear between discovery and connection.
+ * Returns an empty array when the UI target is unavailable or the
+ * connection fails for any reason.
  */
 async function detectInstancePopups(
   cdpPort: number,
-  cdpHost: string | undefined,
   cdpOptions: { host?: string; allowRemote?: boolean },
 ): Promise<InstancePopup[]> {
+  const instance = new InstanceService(cdpPort, cdpOptions);
   try {
-    const targets = await discoverTargets(cdpPort, cdpHost ?? "127.0.0.1");
-    const hasLinkedIn = targets.some(
-      (t) => t.type === "page" && t.url.includes("linkedin.com"),
-    );
-    const hasUI = targets.some(
-      (t) => t.type === "page" && t.url.includes("index.html"),
-    );
-    if (!hasLinkedIn || !hasUI) {
-      return [];
-    }
-
-    const instance = new InstanceService(cdpPort, cdpOptions);
-    try {
-      await instance.connect();
-      return await instance.getInstancePopups();
-    } finally {
-      instance.disconnect();
-    }
+    await instance.connectUiOnly();
+    return await instance.getInstancePopups();
   } catch {
     return [];
+  } finally {
+    instance.disconnect();
   }
 }


### PR DESCRIPTION
## Summary
- Remove `!hasLinkedIn` guard from `detectInstancePopups()` — only `!hasUI` matters
- Switch from `instance.connect()` to `instance.connectUiOnly()` so popup detection works during partial startup
- Remove `discoverTargets` dependency from the helper (target discovery is handled internally by `connectUiOnly()`)
- Add unit test for the UI-only start scenario

Closes #489

## Test plan
- [x] Unit tests cover partial-start scenario (UI target only, no LinkedIn webview)
- [x] Existing tests for fully-running and not-running instances still pass
- [x] `pnpm lint` clean
- [x] `pnpm test` — all 1235 core + 421 MCP tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)