### PR TITLE
Fix startInstance account fetch failure

### DIFF
--- a/packages/core/src/services/launcher.ts
+++ b/packages/core/src/services/launcher.ts
@@ -117,13 +117,23 @@ export class LauncherService {
           // 2. Get the account object from the service cache.
           //    Using refetch: false because the LH backend API now
           //    rejects the embed format used by refetchLinkedInAccounts.
-          //    The cache is populated by the launcher on startup.
-          const account = await liAccountsSvc.getLinkedInAccount({
-            id: ${String(accountId)},
-            refetch: false,
-          });
+          //    The cache is populated by the launcher on startup, but
+          //    may not be ready immediately — poll until available.
+          let account = null;
+          const cacheDeadline = Date.now() + 30000;
+          while (Date.now() < cacheDeadline) {
+            try {
+              account = await liAccountsSvc.getLinkedInAccount({
+                id: ${String(accountId)},
+                refetch: false,
+              });
+              break;
+            } catch {
+              await new Promise(r => setTimeout(r, 500));
+            }
+          }
           if (!account) {
-            return { success: false, error: 'Account not found' };
+            return { success: false, error: 'Account not found in cache after 30s' };
           }
 
           // 3. Read userId and user profile


### PR DESCRIPTION
## Summary

- Use cached account data (`refetch: false`) instead of triggering a fresh API call that the LH backend now rejects
- Poll for up to 30s for the cache to populate (the launcher loads accounts asynchronously on startup)

## Root Cause

The LinkedHelper backend API at `/linkedInAccounts` changed server-side validation — it now rejects the embed format used by `refetchLinkedInAccounts` (returns 400). The launcher still populates the account cache via another mechanism (WebSocket/IPC), but the REST-based refetch path is broken.

Full investigation in #516 comments.

Closes #516

## Test plan

- [x] E2E: `startInstanceWithRecovery` — starts an instance and returns port
- [x] E2E: idempotent (already_running)
- [x] E2E: instance can be stopped after start
- [x] Lint passes
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)