### PR TITLE
fix: prefer LinkedHelper launcher page target over LinkedIn pages

### DIFF
--- a/packages/core/src/cdp/client.ts
+++ b/packages/core/src/cdp/client.ts
@@ -250,7 +250,16 @@ export class CDPClient {
   // ---------------------------------------------------------------------------
 
   /**
-   * Resolve a `ws://` URL for the given target ID, or the first page target.
+   * Resolve a `ws://` URL for the given target ID, or the LinkedHelper
+   * launcher page target.
+   *
+   * When no `targetId` is provided the method looks for the LinkedHelper
+   * launcher page — identified by a `file://` URL pointing to the
+   * LinkedHelper application bundle.  This is preferred over simply
+   * picking the first `page` target because LinkedHelper instances open
+   * LinkedIn pages that appear before the launcher in the target list,
+   * and those pages do not have access to `@electron/remote` or Node.js
+   * integration required by the launcher operations.
    */
   private async resolveWebSocketUrl(
     targetId?: string,
@@ -261,7 +270,23 @@ export class CDPClient {
     if (targetId) {
       target = targets.find((t) => t.id === targetId);
     } else {
-      target = targets.find((t) => t.type === "page");
+      // Prefer the LinkedHelper launcher page (file:// URL from the app bundle)
+      target = targets.find(
+        (t) =>
+          t.type === "page" &&
+          t.url?.startsWith("file://") &&
+          t.url.includes("linked-helper"),
+      );
+      // Fall back to any file:// page target (launcher may have a different path)
+      if (!target) {
+        target = targets.find(
+          (t) => t.type === "page" && t.url?.startsWith("file://"),
+        );
+      }
+      // Last resort: first page target (original behavior)
+      if (!target) {
+        target = targets.find((t) => t.type === "page");
+      }
     }
 
     if (!target) {


### PR DESCRIPTION
## Summary

- When LinkedHelper has a running instance, both the launcher page (`file://` URL) and the LinkedIn page (`https://linkedin.com`) appear as CDP targets
- `CDPClient.resolveWebSocketUrl()` previously selected the first `page` target, which is the LinkedIn page — this page does NOT have `@electron/remote` or Node.js integration
- This change adds target selection priority: LinkedHelper launcher page (file:// + "linked-helper") > any file:// page > first page (fallback)

Fixes the `@electron/remote` unavailability error reported in #524.

## Test plan

- [ ] Verify `find-app` still detects LinkedHelper instances correctly
- [ ] Verify `list-accounts` connects to the launcher target (file:// URL) instead of the LinkedIn page
- [ ] Verify backward compatibility when no instance is running (only launcher target exists)

Note: This is a partial fix for #524. The target selection was broken, but there are also deeper changes in LH2 2.112 around `mainWindow` restructuring (see issue comment for details).

Generated with [Claude Code](https://claude.com/claude-code)