### PR TITLE
(fix) core: migrate get-feed to DOM scraping

### DIFF
--- a/packages/core/src/operations/get-feed.test.ts
+++ b/packages/core/src/operations/get-feed.test.ts
@@ -11,39 +11,38 @@ vi.mock("../cdp/client.js", () => ({
   CDPClient: vi.fn(),
 }));
 
-vi.mock("../voyager/interceptor.js", () => ({
-  VoyagerInterceptor: vi.fn(),
-}));
-
 vi.mock("./navigate-away.js", () => ({
   navigateAwayIf: vi.fn().mockResolvedValue(undefined),
 }));
 
 import { discoverTargets } from "../cdp/discovery.js";
 import { CDPClient } from "../cdp/client.js";
-import { VoyagerInterceptor } from "../voyager/interceptor.js";
-import { getFeed } from "./get-feed.js";
+import { getFeed, extractHashtags, parseTimestamp } from "./get-feed.js";
+import type { RawDomPost } from "./get-feed.js";
 
 const CDP_PORT = 9222;
 
 /**
- * Build a minimal GraphQL feed response wrapper.
+ * Build a minimal raw DOM post object.
  */
-function graphqlBody(
-  elements: unknown[],
-  metadata?: Record<string, unknown>,
-) {
+function rawPost(overrides: Partial<RawDomPost> = {}): RawDomPost {
   return {
-    data: {
-      feedDashMainFeedByMainFeed: {
-        elements,
-        ...(metadata ? { metadata } : {}),
-      },
-    },
+    urn: "urn:li:activity:123",
+    url: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+    authorName: null,
+    authorHeadline: null,
+    authorProfileUrl: null,
+    text: null,
+    mediaType: null,
+    reactionCount: 0,
+    commentCount: 0,
+    shareCount: 0,
+    timestamp: null,
+    ...overrides,
   };
 }
 
-function setupMocks(body: unknown, status = 200) {
+function setupMocks(scrapedPosts: RawDomPost[] = []) {
   vi.mocked(discoverTargets).mockResolvedValue([
     {
       id: "target-1",
@@ -57,28 +56,26 @@ function setupMocks(body: unknown, status = 200) {
 
   const disconnect = vi.fn();
   const navigate = vi.fn().mockResolvedValue({ frameId: "F1" });
+  const send = vi.fn().mockResolvedValue(undefined);
+
+  // evaluate: first call is waitForFeedLoad check, subsequent calls return scraped posts
+  const evaluate = vi.fn();
+  // First call from waitForFeedLoad — return count > 0 to skip polling
+  evaluate.mockResolvedValueOnce(scrapedPosts.length || 1);
+  // Subsequent calls from SCRAPE_FEED_SCRIPT
+  evaluate.mockResolvedValue(scrapedPosts);
+
   vi.mocked(CDPClient).mockImplementation(function () {
     return {
       connect: vi.fn().mockResolvedValue(undefined),
       disconnect,
       navigate,
+      evaluate,
+      send,
     } as unknown as CDPClient;
   });
 
-  const enableMock = vi.fn().mockResolvedValue(undefined);
-  const disableMock = vi.fn().mockResolvedValue(undefined);
-  const waitForResponseMock = vi
-    .fn()
-    .mockResolvedValue({ url: "", status, body });
-  vi.mocked(VoyagerInterceptor).mockImplementation(function () {
-    return {
-      enable: enableMock,
-      disable: disableMock,
-      waitForResponse: waitForResponseMock,
-    } as unknown as VoyagerInterceptor;
-  });
-
-  return { navigate, enableMock, disableMock, waitForResponseMock, disconnect };
+  return { navigate, disconnect, evaluate, send };
 }
 
 describe("getFeed", () => {
@@ -90,58 +87,42 @@ describe("getFeed", () => {
     vi.restoreAllMocks();
   });
 
-  it("parses feed elements from the GraphQL response", async () => {
-    setupMocks(
-      graphqlBody(
-        [
-          {
-            metadata: {
-              backendUrn: "urn:li:activity:123",
-              shareUrn: "urn:li:share:111",
-            },
-            header: {
-              text: { text: "Alice Smith" },
-              image: { accessibilityText: "Engineer at Acme" },
-              navigationUrl: "https://www.linkedin.com/in/alice/",
-            },
-            commentary: {
-              text: { text: "Hello #linkedin #tech world!" },
-            },
-            content: {
-              imageComponent: { images: [] },
-            },
-            socialContent: {
-              shareUrl: "https://www.linkedin.com/posts/alice_hello-activity-123",
-            },
-          },
-        ],
-        { paginationToken: "cursor-abc" },
-      ),
-    );
+  it("parses posts from DOM-scraped data", async () => {
+    setupMocks([
+      rawPost({
+        urn: "urn:li:activity:123",
+        url: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+        authorName: "Alice Smith",
+        authorHeadline: "Engineer at Acme",
+        authorProfileUrl: "https://www.linkedin.com/in/alice",
+        text: "Hello #linkedin #tech world!",
+        mediaType: "image",
+        reactionCount: 42,
+        commentCount: 7,
+        shareCount: 3,
+        timestamp: "2h",
+      }),
+    ]);
 
     const result = await getFeed({ cdpPort: CDP_PORT });
 
     expect(result.posts).toHaveLength(1);
     const [post] = result.posts;
     expect(post?.urn).toBe("urn:li:activity:123");
-    expect(post?.url).toBe("https://www.linkedin.com/posts/alice_hello-activity-123");
+    expect(post?.url).toBe("https://www.linkedin.com/feed/update/urn:li:activity:123/");
     expect(post?.authorName).toBe("Alice Smith");
     expect(post?.authorHeadline).toBe("Engineer at Acme");
-    expect(post?.authorProfileUrl).toBe("https://www.linkedin.com/in/alice/");
+    expect(post?.authorProfileUrl).toBe("https://www.linkedin.com/in/alice");
     expect(post?.text).toBe("Hello #linkedin #tech world!");
     expect(post?.mediaType).toBe("image");
+    expect(post?.reactionCount).toBe(42);
+    expect(post?.commentCount).toBe(7);
+    expect(post?.shareCount).toBe(3);
     expect(post?.hashtags).toEqual(["linkedin", "tech"]);
-    expect(result.nextCursor).toBe("cursor-abc");
   });
 
-  it("falls back to constructed URL when shareUrl is absent", async () => {
-    setupMocks(
-      graphqlBody([
-        {
-          metadata: { backendUrn: "urn:li:activity:456" },
-        },
-      ]),
-    );
+  it("constructs URL when raw post has null url", async () => {
+    setupMocks([rawPost({ urn: "urn:li:activity:456", url: null })]);
 
     const result = await getFeed({ cdpPort: CDP_PORT });
 
@@ -151,177 +132,177 @@ describe("getFeed", () => {
   });
 
   it("navigates to the LinkedIn feed page", async () => {
-    const { navigate } = setupMocks(graphqlBody([]));
+    const { navigate } = setupMocks([]);
 
     await getFeed({ cdpPort: CDP_PORT });
 
     expect(navigate).toHaveBeenCalledWith("https://www.linkedin.com/feed/");
   });
 
-  it("enables interceptor before navigation and disables after", async () => {
-    const { enableMock, disableMock, navigate } = setupMocks(graphqlBody([]));
-
-    await getFeed({ cdpPort: CDP_PORT });
-
-    expect(enableMock).toHaveBeenCalled();
-    expect(disableMock).toHaveBeenCalled();
-
-    // enable must be called before navigate
-    const enableOrder = enableMock.mock.invocationCallOrder[0] as number;
-    const navigateOrder = navigate.mock.invocationCallOrder[0] as number;
-    const disableOrder = disableMock.mock.invocationCallOrder[0] as number;
-    expect(enableOrder).toBeLessThan(navigateOrder);
-    expect(navigateOrder).toBeLessThan(disableOrder);
-  });
-
-  it("waits for voyagerFeedDashMainFeed response", async () => {
-    const { waitForResponseMock } = setupMocks(graphqlBody([]));
-
-    await getFeed({ cdpPort: CDP_PORT });
-
-    expect(waitForResponseMock).toHaveBeenCalledWith(expect.any(Function));
-    // Verify the filter function matches the expected query name
-    const filter = waitForResponseMock.mock.calls[0]?.[0] as (
-      url: string,
-    ) => boolean;
-    expect(
-      filter(
-        "/voyager/api/graphql?queryId=voyagerFeedDashMainFeed.abc123&variables=...",
-      ),
-    ).toBe(true);
-    expect(
-      filter(
-        "/voyager/api/graphql?queryId=voyagerSearchDashClusters.xyz&variables=...",
-      ),
-    ).toBe(false);
-  });
-
-  it("skips elements without backendUrn", async () => {
-    setupMocks(
-      graphqlBody([
-        { metadata: {} },
-        { metadata: { backendUrn: "urn:li:activity:999" } },
-      ]),
-    );
+  it("returns null authorPublicId for all posts", async () => {
+    setupMocks([rawPost()]);
 
     const result = await getFeed({ cdpPort: CDP_PORT });
 
-    expect(result.posts).toHaveLength(1);
-    expect(result.posts[0]?.urn).toBe("urn:li:activity:999");
+    expect(result.posts[0]?.authorPublicId).toBeNull();
   });
 
-  it("extracts and deduplicates hashtags from post text", async () => {
-    setupMocks(
-      graphqlBody([
-        {
-          metadata: { backendUrn: "urn:li:activity:100" },
-          commentary: {
-            text: { text: "#AI and #MachineLearning are #AI transforming" },
-          },
-        },
-      ]),
-    );
+  it("limits results to count parameter", async () => {
+    setupMocks([
+      rawPost({ urn: "urn:li:activity:1" }),
+      rawPost({ urn: "urn:li:activity:2" }),
+      rawPost({ urn: "urn:li:activity:3" }),
+    ]);
 
-    const result = await getFeed({ cdpPort: CDP_PORT });
+    const result = await getFeed({ cdpPort: CDP_PORT, count: 2 });
 
-    expect(result.posts[0]?.hashtags).toEqual(["AI", "MachineLearning"]);
+    expect(result.posts).toHaveLength(2);
+    expect(result.posts[0]?.urn).toBe("urn:li:activity:1");
+    expect(result.posts[1]?.urn).toBe("urn:li:activity:2");
   });
 
-  it("returns empty hashtags when no text", async () => {
-    setupMocks(
-      graphqlBody([
-        { metadata: { backendUrn: "urn:li:activity:101" } },
-      ]),
-    );
+  it("returns nextCursor when more posts are available", async () => {
+    setupMocks([
+      rawPost({ urn: "urn:li:activity:1" }),
+      rawPost({ urn: "urn:li:activity:2" }),
+      rawPost({ urn: "urn:li:activity:3" }),
+    ]);
 
-    const result = await getFeed({ cdpPort: CDP_PORT });
+    const result = await getFeed({ cdpPort: CDP_PORT, count: 2 });
 
-    expect(result.posts[0]?.hashtags).toEqual([]);
+    expect(result.nextCursor).toBe("urn:li:activity:2");
   });
 
-  it("infers video media type from content component key", async () => {
-    setupMocks(
-      graphqlBody([
-        {
-          metadata: { backendUrn: "urn:li:activity:200" },
-          content: { linkedInVideoComponent: {} },
-        },
-      ]),
-    );
+  it("returns null nextCursor when all posts are returned", async () => {
+    setupMocks([
+      rawPost({ urn: "urn:li:activity:1" }),
+      rawPost({ urn: "urn:li:activity:2" }),
+    ]);
 
-    const result = await getFeed({ cdpPort: CDP_PORT });
-
-    expect(result.posts[0]?.mediaType).toBe("video");
-  });
-
-  it("infers article media type from content component key", async () => {
-    setupMocks(
-      graphqlBody([
-        {
-          metadata: { backendUrn: "urn:li:activity:201" },
-          content: { articleComponent: { navigationUrl: "https://example.com/article" } },
-        },
-      ]),
-    );
-
-    const result = await getFeed({ cdpPort: CDP_PORT });
-
-    expect(result.posts[0]?.mediaType).toBe("article");
-  });
-
-  it("infers document media type from content component key", async () => {
-    setupMocks(
-      graphqlBody([
-        {
-          metadata: { backendUrn: "urn:li:activity:202" },
-          content: { documentComponent: {} },
-        },
-      ]),
-    );
-
-    const result = await getFeed({ cdpPort: CDP_PORT });
-
-    expect(result.posts[0]?.mediaType).toBe("document");
-  });
-
-  it("returns null media type when content is absent", async () => {
-    setupMocks(
-      graphqlBody([
-        { metadata: { backendUrn: "urn:li:activity:203" } },
-      ]),
-    );
-
-    const result = await getFeed({ cdpPort: CDP_PORT });
-
-    expect(result.posts[0]?.mediaType).toBeNull();
-  });
-
-  it("returns null nextCursor when paginationToken is absent", async () => {
-    setupMocks(
-      graphqlBody(
-        [{ metadata: { backendUrn: "urn:li:activity:300" } }],
-      ),
-    );
-
-    const result = await getFeed({ cdpPort: CDP_PORT });
+    const result = await getFeed({ cdpPort: CDP_PORT, count: 10 });
 
     expect(result.nextCursor).toBeNull();
   });
 
-  it("throws on non-200 response", async () => {
-    setupMocks(null, 403);
+  it("supports cursor-based pagination", async () => {
+    setupMocks([
+      rawPost({ urn: "urn:li:activity:1" }),
+      rawPost({ urn: "urn:li:activity:2" }),
+      rawPost({ urn: "urn:li:activity:3" }),
+      rawPost({ urn: "urn:li:activity:4" }),
+    ]);
 
-    await expect(getFeed({ cdpPort: CDP_PORT })).rejects.toThrow(
-      "Voyager API returned HTTP 403 for feed",
-    );
+    const result = await getFeed({
+      cdpPort: CDP_PORT,
+      count: 2,
+      cursor: "urn:li:activity:2",
+    });
+
+    expect(result.posts).toHaveLength(2);
+    expect(result.posts[0]?.urn).toBe("urn:li:activity:3");
+    expect(result.posts[1]?.urn).toBe("urn:li:activity:4");
   });
 
-  it("throws on non-object response body", async () => {
-    setupMocks(null, 200);
+  it("returns empty posts when cursor is at the end", async () => {
+    setupMocks([
+      rawPost({ urn: "urn:li:activity:1" }),
+      rawPost({ urn: "urn:li:activity:2" }),
+    ]);
 
-    await expect(getFeed({ cdpPort: CDP_PORT })).rejects.toThrow(
-      "Voyager API returned an unexpected response format for feed",
-    );
+    const result = await getFeed({
+      cdpPort: CDP_PORT,
+      cursor: "urn:li:activity:2",
+    });
+
+    expect(result.posts).toHaveLength(0);
+    expect(result.nextCursor).toBeNull();
+  });
+
+  it("treats unknown cursor as start of feed", async () => {
+    setupMocks([
+      rawPost({ urn: "urn:li:activity:1" }),
+      rawPost({ urn: "urn:li:activity:2" }),
+    ]);
+
+    const result = await getFeed({
+      cdpPort: CDP_PORT,
+      cursor: "urn:li:activity:unknown",
+    });
+
+    // When cursor is not found, all posts are returned from the start
+    expect(result.posts).toHaveLength(2);
+  });
+
+  it("handles empty feed", async () => {
+    setupMocks([]);
+
+    const result = await getFeed({ cdpPort: CDP_PORT });
+
+    expect(result.posts).toHaveLength(0);
+    expect(result.nextCursor).toBeNull();
+  });
+
+  it("handles posts with null fields", async () => {
+    setupMocks([rawPost()]);
+
+    const result = await getFeed({ cdpPort: CDP_PORT });
+
+    expect(result.posts[0]?.authorName).toBeNull();
+    expect(result.posts[0]?.authorHeadline).toBeNull();
+    expect(result.posts[0]?.authorProfileUrl).toBeNull();
+    expect(result.posts[0]?.text).toBeNull();
+    expect(result.posts[0]?.mediaType).toBeNull();
+    expect(result.posts[0]?.timestamp).toBeNull();
+  });
+
+  it("scrolls to load more posts when count exceeds initial scrape", async () => {
+    const { evaluate, send } = setupMocks([]);
+
+    // waitForFeedLoad returns count > 0
+    evaluate.mockReset();
+    evaluate.mockResolvedValueOnce(1);
+    // First scrape: 2 posts
+    evaluate.mockResolvedValueOnce([
+      rawPost({ urn: "urn:li:activity:1" }),
+      rawPost({ urn: "urn:li:activity:2" }),
+    ]);
+    // Second scrape after scroll: 4 posts
+    evaluate.mockResolvedValueOnce([
+      rawPost({ urn: "urn:li:activity:1" }),
+      rawPost({ urn: "urn:li:activity:2" }),
+      rawPost({ urn: "urn:li:activity:3" }),
+      rawPost({ urn: "urn:li:activity:4" }),
+    ]);
+
+    const result = await getFeed({ cdpPort: CDP_PORT, count: 4 });
+
+    expect(result.posts).toHaveLength(4);
+    expect(send).toHaveBeenCalledWith("Input.dispatchMouseEvent", {
+      type: "mouseWheel",
+      x: 300,
+      y: 400,
+      deltaX: 0,
+      deltaY: 800,
+    });
+  });
+
+  it("stops scrolling when no new posts appear", async () => {
+    const { evaluate, send } = setupMocks([]);
+
+    evaluate.mockReset();
+    evaluate.mockResolvedValueOnce(1);
+    // Every scrape returns same 2 posts
+    const fixedPosts = [
+      rawPost({ urn: "urn:li:activity:1" }),
+      rawPost({ urn: "urn:li:activity:2" }),
+    ];
+    evaluate.mockResolvedValue(fixedPosts);
+
+    const result = await getFeed({ cdpPort: CDP_PORT, count: 10 });
+
+    expect(result.posts).toHaveLength(2);
+    // Should have scrolled once and then stopped (no new posts)
+    expect(send).toHaveBeenCalledTimes(1);
   });
 
   it("throws when no LinkedIn page found", async () => {
@@ -339,7 +320,7 @@ describe("getFeed", () => {
   });
 
   it("disconnects CDP client after operation", async () => {
-    const { disconnect } = setupMocks(graphqlBody([]));
+    const { disconnect } = setupMocks([rawPost()]);
 
     await getFeed({ cdpPort: CDP_PORT });
 
@@ -347,71 +328,131 @@ describe("getFeed", () => {
   });
 
   it("disconnects CDP client even on error", async () => {
-    const { disconnect } = setupMocks(null, 500);
+    vi.mocked(discoverTargets).mockResolvedValue([
+      {
+        id: "target-1",
+        type: "page",
+        title: "LinkedIn",
+        url: "https://www.linkedin.com/feed/",
+        description: "",
+        devtoolsFrontendUrl: "",
+      },
+    ]);
 
-    await expect(getFeed({ cdpPort: CDP_PORT })).rejects.toThrow();
+    const disconnect = vi.fn();
+    vi.mocked(CDPClient).mockImplementation(function () {
+      return {
+        connect: vi.fn().mockResolvedValue(undefined),
+        disconnect,
+        navigate: vi.fn().mockRejectedValue(new Error("nav error")),
+        evaluate: vi.fn(),
+        send: vi.fn(),
+      } as unknown as CDPClient;
+    });
 
+    await expect(getFeed({ cdpPort: CDP_PORT })).rejects.toThrow("nav error");
     expect(disconnect).toHaveBeenCalled();
   });
 
-  it("disables interceptor even on error", async () => {
-    const { disableMock } = setupMocks(null, 500);
-
-    await expect(getFeed({ cdpPort: CDP_PORT })).rejects.toThrow();
-
-    expect(disableMock).toHaveBeenCalled();
-  });
-
-  it("handles elements with header but no author headline", async () => {
-    setupMocks(
-      graphqlBody([
-        {
-          metadata: { backendUrn: "urn:li:activity:400" },
-          header: {
-            text: { text: "Acme Corp" },
-            navigationUrl: "https://www.linkedin.com/company/acme/",
-          },
-        },
-      ]),
-    );
+  it("parses relative timestamp into epoch milliseconds", async () => {
+    const now = Date.now();
+    setupMocks([rawPost({ timestamp: "2h" })]);
 
     const result = await getFeed({ cdpPort: CDP_PORT });
 
-    expect(result.posts[0]?.authorName).toBe("Acme Corp");
-    expect(result.posts[0]?.authorHeadline).toBeNull();
-    expect(result.posts[0]?.authorProfileUrl).toBe("https://www.linkedin.com/company/acme/");
+    const ts = result.posts[0]?.timestamp;
+    expect(ts).toBeTypeOf("number");
+    // Should be approximately 2 hours ago (within 5 seconds tolerance)
+    const twoHoursMs = 2 * 60 * 60 * 1000;
+    expect(Math.abs((now - twoHoursMs) - (ts as number))).toBeLessThan(5000);
   });
 
-  it("handles elements with no header at all", async () => {
-    setupMocks(
-      graphqlBody([
-        { metadata: { backendUrn: "urn:li:activity:500" } },
-      ]),
-    );
+  it("extracts and deduplicates hashtags from post text", async () => {
+    setupMocks([
+      rawPost({
+        text: "#AI and #MachineLearning are #AI transforming",
+      }),
+    ]);
 
     const result = await getFeed({ cdpPort: CDP_PORT });
 
-    expect(result.posts[0]?.authorName).toBeNull();
-    expect(result.posts[0]?.authorHeadline).toBeNull();
-    expect(result.posts[0]?.authorProfileUrl).toBeNull();
+    expect(result.posts[0]?.hashtags).toEqual(["AI", "MachineLearning"]);
   });
 
-  it("ignores content keys with null values for media type", async () => {
-    setupMocks(
-      graphqlBody([
-        {
-          metadata: { backendUrn: "urn:li:activity:600" },
-          content: {
-            imageComponent: null,
-            articleComponent: null,
-            linkedInVideoComponent: { url: "video-url" },
-          },
-        },
-      ]),
-    );
+  it("returns empty hashtags when no text", async () => {
+    setupMocks([rawPost()]);
 
     const result = await getFeed({ cdpPort: CDP_PORT });
 
-    expect(result.posts[0]?.mediaType).toBe("video");
+    expect(result.posts[0]?.hashtags).toEqual([]);
+  });
+});
+
+describe("extractHashtags", () => {
+  it("extracts unique hashtags", () => {
+    expect(extractHashtags("#hello #world #hello")).toEqual(["hello", "world"]);
+  });
+
+  it("handles accented characters", () => {
+    expect(extractHashtags("#café #résumé")).toEqual(["café", "résumé"]);
+  });
+
+  it("returns empty array for null text", () => {
+    expect(extractHashtags(null)).toEqual([]);
+  });
+
+  it("returns empty array when no hashtags", () => {
+    expect(extractHashtags("no hashtags here")).toEqual([]);
+  });
+});
+
+describe("parseTimestamp", () => {
+  it("parses seconds", () => {
+    const now = Date.now();
+    const result = parseTimestamp("30s");
+    expect(result).toBeTypeOf("number");
+    expect(Math.abs((now - 30_000) - (result as number))).toBeLessThan(1000);
+  });
+
+  it("parses minutes", () => {
+    const now = Date.now();
+    const result = parseTimestamp("52m");
+    expect(result).toBeTypeOf("number");
+    expect(Math.abs((now - 52 * 60_000) - (result as number))).toBeLessThan(1000);
+  });
+
+  it("parses hours", () => {
+    const now = Date.now();
+    const result = parseTimestamp("16h");
+    expect(result).toBeTypeOf("number");
+    expect(Math.abs((now - 16 * 3_600_000) - (result as number))).toBeLessThan(1000);
+  });
+
+  it("parses days", () => {
+    const now = Date.now();
+    const result = parseTimestamp("3d");
+    expect(result).toBeTypeOf("number");
+    expect(Math.abs((now - 3 * 86_400_000) - (result as number))).toBeLessThan(1000);
+  });
+
+  it("parses weeks", () => {
+    const now = Date.now();
+    const result = parseTimestamp("1w");
+    expect(result).toBeTypeOf("number");
+    expect(Math.abs((now - 604_800_000) - (result as number))).toBeLessThan(1000);
+  });
+
+  it("parses ISO datetime", () => {
+    expect(parseTimestamp("2026-03-25T10:00:00Z")).toBe(
+      Date.parse("2026-03-25T10:00:00Z"),
+    );
+  });
+
+  it("returns null for null input", () => {
+    expect(parseTimestamp(null)).toBeNull();
+  });
+
+  it("returns null for unrecognised format", () => {
+    expect(parseTimestamp("unknown")).toBeNull();
   });
 });

--- a/packages/core/src/operations/get-feed.ts
+++ b/packages/core/src/operations/get-feed.ts
@@ -4,7 +4,6 @@
 import type { FeedPost } from "../types/feed.js";
 import { CDPClient } from "../cdp/client.js";
 import { discoverTargets } from "../cdp/discovery.js";
-import { VoyagerInterceptor } from "../voyager/interceptor.js";
 import { DEFAULT_CDP_PORT } from "../constants.js";
 import type { ConnectionOptions } from "./types.js";
 import { navigateAwayIf } from "./navigate-away.js";
@@ -30,104 +29,167 @@ export interface GetFeedOutput {
 }
 
 // ---------------------------------------------------------------------------
-// GraphQL feed response shapes
+// Raw post shape returned by the in-page scraping script
 // ---------------------------------------------------------------------------
 
-/** Top-level GraphQL response wrapper. */
-interface GraphQLFeedResponse {
-  data?: {
-    /** LinkedIn sometimes wraps GraphQL responses in a nested `data` object. */
-    data?: {
-      feedDashMainFeedByMainFeed?: GraphQLFeedCollection;
-    };
-    feedDashMainFeedByMainFeed?: GraphQLFeedCollection;
-  };
-  /** Rest.li included entities — resolved via `*elements` URN references. */
-  included?: GraphQLFeedElement[];
+export interface RawDomPost {
+  urn: string;
+  url: string | null;
+  authorName: string | null;
+  authorHeadline: string | null;
+  authorProfileUrl: string | null;
+  text: string | null;
+  mediaType: string | null;
+  reactionCount: number;
+  commentCount: number;
+  shareCount: number;
+  timestamp: string | null;
 }
 
-/** The collection returned by the feedDashMainFeedByMainFeed query. */
-interface GraphQLFeedCollection {
-  /** Inline elements (active fetch mode). */
-  elements?: GraphQLFeedElement[];
-  /** URN references to entities in the top-level `included` array (passive interception). */
-  "*elements"?: string[];
-  metadata?: GraphQLCollectionMetadata;
-  paging?: GraphQLPaging;
-}
+// ---------------------------------------------------------------------------
+// In-page DOM scraping script
+// ---------------------------------------------------------------------------
 
-/** Per-element metadata carrying the activity URN and share URL. */
-interface GraphQLElementMetadata {
-  backendUrn?: string;
-  shareUrn?: string;
-}
+/**
+ * JavaScript source evaluated inside the LinkedIn page context via
+ * `Runtime.evaluate`.  Returns an array of {@link RawDomPost} objects.
+ *
+ * The script is intentionally a single IIFE string so it can be sent
+ * verbatim to the target without any transpilation.
+ */
+const SCRAPE_FEED_SCRIPT = `(() => {
+  const posts = [];
+  const seen = new Set();
 
-/** Social content block on each feed element. */
-interface GraphQLSocialContent {
-  shareUrl?: string;
-}
+  // Find all feed update links — each one identifies a post
+  const links = document.querySelectorAll('a[href*="/feed/update/urn:li:"]');
 
-/** A single feed element from the GraphQL endpoint. */
-interface GraphQLFeedElement {
-  /** Entity URN — present when resolved from the `included` array. */
-  entityUrn?: string;
-  metadata?: GraphQLElementMetadata;
-  socialContent?: GraphQLSocialContent;
-  header?: GraphQLHeader;
-  commentary?: GraphQLCommentary;
-  content?: GraphQLContent;
-}
+  for (const link of links) {
+    const match = link.href.match(/\\/feed\\/update\\/(urn:li:[^/]+)/);
+    if (!match) continue;
+    const urn = decodeURIComponent(match[1]);
+    if (seen.has(urn)) continue;
+    seen.add(urn);
 
-/** Actor header block containing the author identity. */
-interface GraphQLHeader {
-  text?: GraphQLTextAccessibility;
-  image?: GraphQLImageAccessibility;
-  navigationUrl?: string;
-}
+    // Walk up to find the post container.  LinkedIn wraps each feed item in
+    // a container that is a direct child of the feed list.  We climb until
+    // we find an element whose parent is the main feed container or we hit
+    // a reasonable depth limit.
+    let container = link;
+    for (let i = 0; i < 20; i++) {
+      const parent = container.parentElement;
+      if (!parent || parent.tagName === 'MAIN' || parent.tagName === 'BODY') break;
+      container = parent;
+      // Stop at data-urn boundary (LinkedIn sometimes annotates feed items)
+      if (container.hasAttribute('data-urn')) break;
+      // Stop if we've reached a large enough container
+      if (container.offsetHeight > 150) {
+        // Check if this looks like a feed item wrapper (has sibling feed items)
+        const siblings = container.parentElement?.children;
+        if (siblings && siblings.length > 1) break;
+      }
+    }
 
-/** Accessibility-wrapped text (used by header, commentary, etc.). */
-interface GraphQLTextAccessibility {
-  text?: string;
-  accessibilityText?: string;
-}
+    // --- Author info ---
+    // Author profile links are typically /in/slug or /company/slug
+    let authorName = null;
+    let authorHeadline = null;
+    let authorProfileUrl = null;
 
-interface GraphQLImageAccessibility {
-  accessibilityText?: string;
-}
+    const authorLink = container.querySelector(
+      'a[href*="/in/"], a[href*="/company/"]'
+    );
+    if (authorLink) {
+      authorProfileUrl = authorLink.href.split('?')[0] || null;
+      // The author name is usually the first meaningful text in the header area
+      const nameEl = authorLink.querySelector('span[dir="ltr"], span[aria-hidden="true"]')
+        || authorLink;
+      const rawName = (nameEl.textContent || '').trim();
+      authorName = rawName || null;
+    }
 
-/** Commentary block carrying the post text body. */
-interface GraphQLCommentary {
-  text?: GraphQLTextAccessibility;
-  numLines?: number;
-}
+    // Author headline: typically a secondary line near the author name
+    // Look for a text element that follows the author link area
+    const headerSpans = container.querySelectorAll('span.t-12, span.t-normal, span[class*="subtitle"]');
+    for (const span of headerSpans) {
+      const txt = (span.textContent || '').trim();
+      // Skip timestamps and empty strings
+      if (txt && !txt.match(/^\\d+[smhdw]$/) && txt.length > 3 && txt !== authorName) {
+        authorHeadline = txt;
+        break;
+      }
+    }
 
-/** Content block – component-based; only non-null key matters. */
-interface GraphQLContent {
-  "com.linkedin.voyager.dash.feed.ArticleComponent"?: GraphQLContentComponent;
-  articleComponent?: GraphQLContentComponent;
-  imageComponent?: GraphQLContentComponent;
-  linkedInVideoComponent?: GraphQLContentComponent;
-  documentComponent?: GraphQLContentComponent;
-  externalVideoComponent?: GraphQLContentComponent;
-  [key: string]: GraphQLContentComponent | null | undefined;
-}
+    // --- Post text ---
+    let text = null;
+    const commentaryEl = container.querySelector(
+      'span[dir="ltr"].break-words, div.feed-shared-update-v2__commentary, div[class*="update-components-text"]'
+    );
+    if (commentaryEl) {
+      text = (commentaryEl.textContent || '').trim() || null;
+    }
 
-interface GraphQLContentComponent {
-  navigationUrl?: string;
-  [key: string]: unknown;
-}
+    // --- Media type ---
+    let mediaType = null;
+    if (container.querySelector('video, div[class*="video"]')) {
+      mediaType = 'video';
+    } else if (container.querySelector('img.feed-shared-image__image, div[class*="image-component"], img[class*="update-components-image"]')) {
+      mediaType = 'image';
+    } else if (container.querySelector('article, a[class*="article"], div[class*="article"]')) {
+      mediaType = 'article';
+    } else if (container.querySelector('div[class*="document"]')) {
+      mediaType = 'document';
+    }
 
-/** Pagination metadata from the collection. */
-interface GraphQLCollectionMetadata {
-  paginationToken?: string;
-}
+    // --- Engagement counts ---
+    const containerText = container.textContent || '';
 
-/** Paging info. */
-interface GraphQLPaging {
-  start?: number;
-  count?: number;
-  total?: number;
-}
+    function parseCount(pattern) {
+      const m = containerText.match(pattern);
+      if (!m) return 0;
+      const raw = m[1].replace(/,/g, '');
+      const num = parseInt(raw, 10);
+      return isNaN(num) ? 0 : num;
+    }
+
+    const reactionCount = parseCount(/(\\d[\\d,]*)\\s+reactions?/i);
+    const commentCount = parseCount(/(\\d[\\d,]*)\\s+comments?/i);
+    const shareCount = parseCount(/(\\d[\\d,]*)\\s+reposts?/i);
+
+    // --- Timestamp ---
+    let timestamp = null;
+    const timeEl = container.querySelector('time');
+    if (timeEl) {
+      const dt = timeEl.getAttribute('datetime');
+      if (dt) {
+        timestamp = dt;
+      }
+    }
+    if (!timestamp) {
+      // Look for relative time text like "52m", "16h", "2d", "1w"
+      const timeMatch = containerText.match(/(?:^|\\s)(\\d+[smhdw])(?:\\s|$|\\u00B7|\\xB7)/);
+      if (timeMatch) {
+        timestamp = timeMatch[1];
+      }
+    }
+
+    posts.push({
+      urn: urn,
+      url: 'https://www.linkedin.com/feed/update/' + urn + '/',
+      authorName: authorName,
+      authorHeadline: authorHeadline,
+      authorProfileUrl: authorProfileUrl,
+      text: text,
+      mediaType: mediaType,
+      reactionCount: reactionCount,
+      commentCount: commentCount,
+      shareCount: shareCount,
+      timestamp: timestamp,
+    });
+  }
+
+  return posts;
+})()`;
 
 // ---------------------------------------------------------------------------
 // Parsing helpers
@@ -136,32 +198,40 @@ interface GraphQLPaging {
 /**
  * Extract hashtags from post text.
  */
-function extractHashtags(text: string | null): string[] {
+export function extractHashtags(text: string | null): string[] {
   if (!text) return [];
   const matches = text.match(/#[\w\u00C0-\u024F]+/g);
   return matches ? [...new Set(matches.map((t) => t.slice(1)))] : [];
 }
 
 /**
- * Infer media type from the GraphQL content block.
- *
- * The content object has a component-based layout where only one key is
- * non-null (e.g. `imageComponent`, `linkedInVideoComponent`).
+ * Parse a relative timestamp string (e.g. "52m", "16h", "2d", "1w") or an
+ * ISO date into epoch milliseconds.  Returns null for unrecognised formats.
  */
-function inferMediaType(content: GraphQLContent | undefined): string | null {
-  if (!content) return null;
+export function parseTimestamp(raw: string | null): number | null {
+  if (!raw) return null;
 
-  for (const key of Object.keys(content)) {
-    if (content[key] == null) continue;
+  // ISO datetime
+  const asDate = Date.parse(raw);
+  if (!isNaN(asDate)) return asDate;
 
-    const lower = key.toLowerCase();
-    if (lower.includes("image")) return "image";
-    if (lower.includes("video")) return "video";
-    if (lower.includes("article")) return "article";
-    if (lower.includes("document")) return "document";
-  }
+  // Relative time: Ns, Nm, Nh, Nd, Nw
+  const match = raw.match(/^(\d+)([smhdw])$/);
+  if (!match) return null;
 
-  return null;
+  const value = parseInt(match[1] ?? "0", 10);
+  const unit = match[2] ?? "";
+  const now = Date.now();
+
+  const multipliers: Record<string, number> = {
+    s: 1_000,
+    m: 60_000,
+    h: 3_600_000,
+    d: 86_400_000,
+    w: 604_800_000,
+  };
+
+  return now - value * (multipliers[unit] ?? 0);
 }
 
 /**
@@ -172,78 +242,66 @@ function buildPostUrl(urn: string): string {
 }
 
 /**
- * Parse the GraphQL feed response into normalised FeedPost entries.
+ * Convert raw DOM-scraped posts into normalised FeedPost entries.
  */
-function parseFeedResponse(raw: GraphQLFeedResponse): {
-  posts: FeedPost[];
-  nextCursor: string | null;
-} {
-  const collection =
-    raw.data?.data?.feedDashMainFeedByMainFeed ??
-    raw.data?.feedDashMainFeedByMainFeed;
-  const metadata = collection?.metadata;
+function mapRawPosts(raw: RawDomPost[]): FeedPost[] {
+  return raw.map((r) => ({
+    urn: r.urn,
+    url: r.url ?? buildPostUrl(r.urn),
+    authorName: r.authorName,
+    authorHeadline: r.authorHeadline,
+    authorProfileUrl: r.authorProfileUrl,
+    authorPublicId: null,
+    text: r.text,
+    mediaType: r.mediaType,
+    reactionCount: r.reactionCount,
+    commentCount: r.commentCount,
+    shareCount: r.shareCount,
+    timestamp: parseTimestamp(r.timestamp),
+    hashtags: extractHashtags(r.text),
+  }));
+}
 
-  // Resolve elements: prefer inline `elements`, fall back to `*elements` URN
-  // references resolved against the top-level `included` array (Rest.li protocol).
-  let elements = collection?.elements ?? [];
-  if (elements.length === 0) {
-    const refs = collection?.["*elements"] ?? [];
-    const included = raw.included ?? [];
-    if (refs.length > 0 && included.length > 0) {
-      const byUrn = new Map<string, GraphQLFeedElement>();
-      for (const e of included) {
-        if (e.entityUrn) byUrn.set(e.entityUrn, e);
-      }
-      elements = refs
-        .map((urn) => byUrn.get(urn))
-        .filter((e): e is GraphQLFeedElement => e !== undefined);
-    }
+// ---------------------------------------------------------------------------
+// Scroll helper
+// ---------------------------------------------------------------------------
+
+/** Delay helper. */
+function delay(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+/** Scroll down in the feed using CDP Input.dispatchMouseEvent mouseWheel. */
+async function scrollFeed(client: CDPClient): Promise<void> {
+  await client.send("Input.dispatchMouseEvent", {
+    type: "mouseWheel",
+    x: 300,
+    y: 400,
+    deltaX: 0,
+    deltaY: 800,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Wait for feed to load
+// ---------------------------------------------------------------------------
+
+/** Wait until at least one feed update link appears in the DOM. */
+async function waitForFeedLoad(
+  client: CDPClient,
+  timeoutMs = 15_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const count = await client.evaluate<number>(
+      `document.querySelectorAll('a[href*="/feed/update/urn:li:"]').length`,
+    );
+    if (count > 0) return;
+    await delay(500);
   }
-
-  const posts: FeedPost[] = [];
-
-  for (const el of elements) {
-    const urn = el.metadata?.backendUrn;
-    if (!urn) continue;
-
-    // Post URL – prefer shareUrl when available, fall back to constructed URL
-    const url = el.socialContent?.shareUrl ?? buildPostUrl(urn);
-
-    // Author info from the header block
-    const authorName = el.header?.text?.text ?? null;
-    const authorHeadline =
-      el.header?.image?.accessibilityText ?? null;
-    const authorProfileUrl = el.header?.navigationUrl ?? null;
-
-    // Post text from the commentary block
-    const text = el.commentary?.text?.text ?? null;
-
-    // Media type from the content component block
-    const mediaType = inferMediaType(el.content);
-
-    // Hashtags
-    const hashtags = extractHashtags(text);
-
-    posts.push({
-      urn,
-      url,
-      authorName,
-      authorHeadline,
-      authorProfileUrl,
-      authorPublicId: null,
-      text,
-      mediaType,
-      reactionCount: 0,
-      commentCount: 0,
-      shareCount: 0,
-      timestamp: null,
-      hashtags,
-    });
-  }
-
-  const nextCursor = metadata?.paginationToken ?? null;
-
-  return { posts, nextCursor };
+  throw new Error(
+    "Timed out waiting for feed posts to appear in the DOM",
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -253,10 +311,10 @@ function parseFeedResponse(raw: GraphQLFeedResponse): {
 /**
  * Read the LinkedIn home feed and return structured post data.
  *
- * Connects to the LinkedIn webview in LinkedHelper and calls the
- * Voyager feed updates API. Supports cursor-based pagination: the
- * first call returns the first page; pass the returned `nextCursor`
- * in subsequent calls to retrieve additional pages.
+ * Navigates to the feed page and extracts posts from the rendered DOM.
+ * Supports cursor-based pagination: the first call returns the first page;
+ * pass the returned `nextCursor` in subsequent calls to retrieve additional
+ * pages via scroll + re-scrape.
  *
  * @param input - Pagination parameters and CDP connection options.
  * @returns Feed posts with a cursor for the next page.
@@ -267,6 +325,8 @@ export async function getFeed(
   const cdpPort = input.cdpPort ?? DEFAULT_CDP_PORT;
   const cdpHost = input.cdpHost ?? "127.0.0.1";
   const allowRemote = input.allowRemote ?? false;
+  const count = input.count ?? 10;
+  const cursor = input.cursor ?? null;
 
   // Enforce loopback guard
   if (!allowRemote && cdpHost !== "127.0.0.1" && cdpHost !== "localhost") {
@@ -292,45 +352,66 @@ export async function getFeed(
   await client.connect(linkedInTarget.id);
 
   try {
-    const voyager = new VoyagerInterceptor(client);
-    await voyager.enable();
+    // Navigate away if already on the feed page to force a fresh load
+    await navigateAwayIf(client, "/feed");
+    await client.navigate("https://www.linkedin.com/feed/");
 
-    try {
-      // If the browser is already on the feed page, LinkedIn's SPA won't fire
-      // a fresh API request on navigate.  Navigate away first to force a full load.
-      await navigateAwayIf(client, "/feed");
+    // Wait for the initial feed content to render
+    await waitForFeedLoad(client);
 
-      // Set up the response listener before navigation to avoid race conditions.
-      // The filter matches the query name prefix, ignoring the rotating hash suffix.
-      const responsePromise = voyager.waitForResponse((url) =>
-        url.includes("voyagerFeedDashMainFeed"),
-      );
+    // Collect posts — scroll to load more if needed
+    const maxScrollAttempts = 10;
+    let allPosts: RawDomPost[] = [];
+    let previousCount = 0;
 
-      await client.navigate("https://www.linkedin.com/feed/");
+    // If resuming with a cursor, we need to scroll past already-seen posts
+    const cursorUrn = cursor;
 
-      const response = await responsePromise;
-      if (response.status !== 200) {
-        throw new Error(
-          `Voyager API returned HTTP ${String(response.status)} for feed`,
-        );
+    for (let scroll = 0; scroll <= maxScrollAttempts; scroll++) {
+      const scraped = await client.evaluate<RawDomPost[]>(SCRAPE_FEED_SCRIPT);
+      allPosts = scraped ?? [];
+
+      // Determine which posts to return
+      let startIdx = 0;
+      if (cursorUrn) {
+        const cursorIdx = allPosts.findIndex((p) => p.urn === cursorUrn);
+        if (cursorIdx >= 0) {
+          startIdx = cursorIdx + 1;
+        }
       }
 
-      const body = response.body;
-      if (body === null || typeof body !== "object") {
-        throw new Error(
-          "Voyager API returned an unexpected response format for feed",
-        );
+      const available = allPosts.length - startIdx;
+      if (available >= count) break;
+
+      // No new posts appeared after scroll — stop
+      if (allPosts.length === previousCount && scroll > 0) break;
+      previousCount = allPosts.length;
+
+      // Scroll to load more
+      if (scroll < maxScrollAttempts) {
+        await scrollFeed(client);
+        await delay(1500);
       }
-
-      const parsed = parseFeedResponse(body as GraphQLFeedResponse);
-
-      return {
-        posts: parsed.posts,
-        nextCursor: parsed.nextCursor,
-      };
-    } finally {
-      await voyager.disable();
     }
+
+    // Slice the result window
+    let startIdx = 0;
+    if (cursorUrn) {
+      const cursorIdx = allPosts.findIndex((p) => p.urn === cursorUrn);
+      if (cursorIdx >= 0) {
+        startIdx = cursorIdx + 1;
+      }
+    }
+
+    const window = allPosts.slice(startIdx, startIdx + count);
+    const posts = mapRawPosts(window);
+
+    // Determine next cursor
+    const hasMore = startIdx + count < allPosts.length;
+    const lastPost = window[window.length - 1];
+    const nextCursor = hasMore && lastPost ? lastPost.urn : null;
+
+    return { posts, nextCursor };
   } finally {
     client.disconnect();
   }


### PR DESCRIPTION
## Summary

- Migrate `getFeed()` from Voyager passive interception to DOM scraping
- LinkedIn's feed in the LH Electron webview no longer calls `voyagerFeedDashMainFeed` GraphQL — feed content is delivered via SSR + React Server Components
- Navigate to `/feed/`, extract post data from rendered DOM via `client.evaluate()`
- Extract engagement counts (reactions, comments, reposts) from DOM text — previously hardcoded to 0
- Parse relative timestamps (`52m`, `16h`, `2d`, `1w`) into epoch ms — previously null
- Scroll-based pagination via `Input.dispatchMouseEvent` mouseWheel
- Cursor-based pagination across calls using last-seen URN
- `FeedPost` output type contract preserved

## Test plan

- [x] Unit tests rewritten for DOM scraping approach (33 tests pass)
- [x] MCP tool tests pass (4 tests)
- [x] Lint clean
- [ ] E2E test with live LH instance (`pnpm test:e2e`)

Closes #528

🤖 Generated with [Claude Code](https://claude.com/claude-code)