### PR TITLE
(fix) core: wait for webpack chunk array before startInstance

### DIFF
--- a/packages/core/src/services/launcher.ts
+++ b/packages/core/src/services/launcher.ts
@@ -100,7 +100,16 @@ export class LauncherService {
           const remote = require('@electron/remote');
           const mainWindow = remote.getGlobal('mainWindow');
 
-          // 1. Resolve renderer-side services via webpack module registry
+          // 1. Resolve renderer-side services via webpack module registry.
+          //    The webpack chunk array may not exist yet if the renderer
+          //    bundles are still loading — poll until available.
+          const wpDeadline = Date.now() + 15000;
+          while (!window.webpackChunk_linked_helper_front && Date.now() < wpDeadline) {
+            await new Promise(r => setTimeout(r, 250));
+          }
+          if (!window.webpackChunk_linked_helper_front) {
+            return { success: false, error: 'webpack module registry not available (timed out)' };
+          }
           let wpRequire = null;
           window.webpackChunk_linked_helper_front.push(
             [[Symbol()], {}, (req) => { wpRequire = req; }]


### PR DESCRIPTION
## Summary

- `startInstance` crashes with `Cannot read properties of undefined (reading 'push')` when called shortly after app launch because `window.webpackChunk_linked_helper_front` hasn't loaded yet
- The Node context (used by `listAccounts` in readiness check) is ready before the renderer webpack bundles finish loading (~2s after launch)
- Adds a poll loop (up to 15s) before accessing the chunk array, with a clear timeout error instead of a crash

## Test plan

- [x] `launcher.test.ts` — 20 tests pass
- [x] Lint clean
- [x] E2E: `get-post` tests pass with this fix (previously all tests were skipped due to `StartInstanceError` in `beforeAll`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)