### PR TITLE
Humanize scroll, click, and delay patterns across all operations

### DIFF
--- a/packages/core/src/linkedin/dom-automation.ts
+++ b/packages/core/src/linkedin/dom-automation.ts
@@ -3,7 +3,7 @@
 
 import type { CDPClient } from "../cdp/client.js";
 import { CDPEvaluationError, CDPTimeoutError } from "../cdp/errors.js";
-import { delay } from "../utils/delay.js";
+import { delay, randomDelay } from "../utils/delay.js";
 import type { HumanizedMouse } from "./humanized-mouse.js";
 
 /** Default timeout for DOM operations (ms). */
@@ -207,6 +207,168 @@ export async function typeText(
 }
 
 // ---------------------------------------------------------------------------
+// Element geometry helpers
+// ---------------------------------------------------------------------------
+
+/** Bounding rect returned by element bounds queries. */
+export interface ElementBounds {
+  top: number;
+  bottom: number;
+  height: number;
+}
+
+/**
+ * Get the bounding rect of a DOM element selected by CSS selector.
+ *
+ * @returns `null` if the element is not found.
+ */
+export async function getElementBounds(
+  client: CDPClient,
+  selector: string,
+): Promise<ElementBounds | null> {
+  return client.evaluate<ElementBounds | null>(
+    `(() => {
+      const el = document.querySelector(${JSON.stringify(selector)});
+      if (!el) return null;
+      const r = el.getBoundingClientRect();
+      return { top: r.top, bottom: r.bottom, height: r.height };
+    })()`,
+  );
+}
+
+/**
+ * Get the bounding rect of the Nth element matching a CSS selector.
+ *
+ * Equivalent to `document.querySelectorAll(baseSelector)[index]`.
+ *
+ * @returns `null` if no element exists at the given index.
+ */
+export async function getElementBoundsByIndex(
+  client: CDPClient,
+  baseSelector: string,
+  index: number,
+): Promise<ElementBounds | null> {
+  return client.evaluate<ElementBounds | null>(
+    `(() => {
+      const els = document.querySelectorAll(${JSON.stringify(baseSelector)});
+      const el = els[${String(index)}];
+      if (!el) return null;
+      const r = el.getBoundingClientRect();
+      return { top: r.top, bottom: r.bottom, height: r.height };
+    })()`,
+  );
+}
+
+/**
+ * Get the viewport height (`window.innerHeight`).
+ */
+export async function getViewportHeight(
+  client: CDPClient,
+): Promise<number> {
+  return client.evaluate<number>(`window.innerHeight`);
+}
+
+// ---------------------------------------------------------------------------
+// Humanized scroll-to-element
+// ---------------------------------------------------------------------------
+
+/**
+ * Internal: incremental scroll loop that centers an element in the viewport.
+ *
+ * @returns `true` if the element was centered within `maxIterations`.
+ */
+async function scrollToElementLoop(
+  client: CDPClient,
+  getBounds: () => Promise<ElementBounds | null>,
+  mouse: HumanizedMouse,
+): Promise<boolean> {
+  const viewportHeight = await getViewportHeight(client);
+  const maxIterations = 10;
+  const tolerance = viewportHeight / 4;
+
+  for (let i = 0; i < maxIterations; i++) {
+    const bounds = await getBounds();
+    if (!bounds) return false;
+
+    const elementCenter = bounds.top + bounds.height / 2;
+    const viewportCenter = viewportHeight / 2;
+
+    if (Math.abs(elementCenter - viewportCenter) <= tolerance) {
+      return true;
+    }
+
+    const deltaY = elementCenter - viewportCenter;
+    await humanizedScrollY(client, deltaY, 300, 400, mouse);
+    await randomDelay(200, 400);
+  }
+
+  return false;
+}
+
+/**
+ * Scroll the page until the target element is centered in the viewport,
+ * using incremental humanized mouse-wheel strokes.
+ *
+ * When a {@link HumanizedMouse} is available, the cursor scrolls the page
+ * in small increments until the element's bounding rect is in the viewport
+ * center zone.  Falls back to instant `scrollIntoView` otherwise.
+ *
+ * @param client   - Connected CDP client targeting the page.
+ * @param selector - CSS selector for the element to scroll to.
+ * @param mouse    - Optional humanized mouse instance.
+ */
+export async function humanizedScrollTo(
+  client: CDPClient,
+  selector: string,
+  mouse?: HumanizedMouse | null,
+): Promise<void> {
+  if (mouse?.isAvailable) {
+    const success = await scrollToElementLoop(
+      client,
+      () => getElementBounds(client, selector),
+      mouse,
+    );
+    if (success) return;
+  }
+  await scrollTo(client, selector);
+}
+
+/**
+ * Scroll the page until the Nth element matching a selector is centered,
+ * using incremental humanized mouse-wheel strokes.
+ *
+ * Falls back to instant `scrollIntoView` when humanized mouse is unavailable.
+ *
+ * @param client       - Connected CDP client targeting the page.
+ * @param baseSelector - CSS selector matching multiple elements.
+ * @param index        - Zero-based index into the matched elements.
+ * @param mouse        - Optional humanized mouse instance.
+ */
+export async function humanizedScrollToByIndex(
+  client: CDPClient,
+  baseSelector: string,
+  index: number,
+  mouse?: HumanizedMouse | null,
+): Promise<void> {
+  if (mouse?.isAvailable) {
+    const success = await scrollToElementLoop(
+      client,
+      () => getElementBoundsByIndex(client, baseSelector, index),
+      mouse,
+    );
+    if (success) return;
+  }
+  // Fallback to instant scrollIntoView
+  await client.evaluate(
+    `(() => {
+      const els = document.querySelectorAll(${JSON.stringify(baseSelector)});
+      const el = els[${String(index)}];
+      if (el) el.scrollIntoView({ behavior: "instant", block: "center" });
+    })()`,
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Humanized interaction helpers
 // ---------------------------------------------------------------------------
 
@@ -254,15 +416,18 @@ export async function humanizedClick(
   selector: string,
   mouse?: HumanizedMouse | null,
 ): Promise<void> {
+  await randomDelay(0, 50); // Pre-click approach hesitation
   if (mouse?.isAvailable) {
     const center = await getElementCenter(client, selector);
     if (center) {
       await mouse.click(center.x, center.y);
+      await randomDelay(50, 150); // Post-click visual confirmation
       return;
     }
   }
   // Fallback to JS click
   await click(client, selector);
+  await randomDelay(50, 150); // Post-click visual confirmation
 }
 
 /**
@@ -283,6 +448,7 @@ export async function humanizedHover(
   selector: string,
   mouse?: HumanizedMouse | null,
 ): Promise<void> {
+  await randomDelay(0, 50); // Pre-hover approach hesitation
   if (mouse?.isAvailable) {
     const center = await getElementCenter(client, selector);
     if (center) {

--- a/packages/core/src/operations/comment-on-post.test.ts
+++ b/packages/core/src/operations/comment-on-post.test.ts
@@ -25,7 +25,7 @@ vi.mock("../cdp/client.js", () => ({
 
 vi.mock("../linkedin/dom-automation.js", () => ({
   waitForElement: vi.fn(),
-  scrollTo: vi.fn(),
+  humanizedScrollTo: vi.fn(),
   click: vi.fn(),
   humanizedClick: vi.fn(),
   typeText: vi.fn(),
@@ -42,7 +42,7 @@ import { withDatabase } from "../services/instance-context.js";
 import { ActionBudgetRepository } from "../db/index.js";
 import { discoverTargets } from "../cdp/discovery.js";
 import { CDPClient } from "../cdp/client.js";
-import { waitForElement, scrollTo, humanizedClick, typeText } from "../linkedin/dom-automation.js";
+import { waitForElement, humanizedScrollTo, humanizedClick, typeText } from "../linkedin/dom-automation.js";
 import type { ActionBudgetEntry } from "../types/action-budget.js";
 import { BudgetExceededError } from "../services/errors.js";
 import { commentOnPost } from "./comment-on-post.js";
@@ -96,7 +96,7 @@ function setupMocks(budgetEntries: ActionBudgetEntry[] = [
 
   // Reset DOM automation mocks to default resolved state
   vi.mocked(waitForElement).mockResolvedValue(undefined);
-  vi.mocked(scrollTo).mockResolvedValue(undefined);
+  vi.mocked(humanizedScrollTo).mockResolvedValue(undefined);
   vi.mocked(humanizedClick).mockResolvedValue(undefined);
   vi.mocked(typeText).mockResolvedValue(undefined);
 
@@ -277,7 +277,7 @@ describe("commentOnPost", () => {
 
     // Verify DOM automation sequence
     expect(waitForElement).toHaveBeenCalled();
-    expect(scrollTo).toHaveBeenCalled();
+    expect(humanizedScrollTo).toHaveBeenCalled();
     expect(humanizedClick).toHaveBeenCalledTimes(2); // comment input + submit
     expect(typeText).toHaveBeenCalled();
   });

--- a/packages/core/src/operations/comment-on-post.ts
+++ b/packages/core/src/operations/comment-on-post.ts
@@ -5,7 +5,7 @@ import { CDPClient } from "../cdp/client.js";
 import { discoverTargets } from "../cdp/discovery.js";
 import { DEFAULT_CDP_PORT } from "../constants.js";
 import { ActionBudgetRepository } from "../db/index.js";
-import { waitForElement, scrollTo, humanizedClick, typeText } from "../linkedin/dom-automation.js";
+import { waitForElement, humanizedScrollTo, humanizedClick, typeText } from "../linkedin/dom-automation.js";
 import type { HumanizedMouse } from "../linkedin/humanized-mouse.js";
 import { COMMENT_INPUT, COMMENT_SUBMIT_BUTTON } from "../linkedin/selectors.js";
 import { resolveAccount } from "../services/account-resolution.js";
@@ -136,7 +136,7 @@ export async function commentOnPost(
 
     // Wait for the comment input and interact
     await waitForElement(client, COMMENT_INPUT);
-    await scrollTo(client, COMMENT_INPUT);
+    await humanizedScrollTo(client, COMMENT_INPUT, mouse);
     await humanizedClick(client, COMMENT_INPUT, mouse);
     await randomDelay(400, 700);
 

--- a/packages/core/src/operations/get-feed.test.ts
+++ b/packages/core/src/operations/get-feed.test.ts
@@ -15,6 +15,13 @@ vi.mock("./navigate-away.js", () => ({
   navigateAwayIf: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock("../utils/delay.js", () => ({
+  delay: vi.fn().mockResolvedValue(undefined),
+  randomDelay: vi.fn().mockResolvedValue(undefined),
+  randomBetween: vi.fn().mockReturnValue(800),
+  maybeHesitate: vi.fn().mockResolvedValue(undefined),
+}));
+
 import { discoverTargets } from "../cdp/discovery.js";
 import { CDPClient } from "../cdp/client.js";
 import { getFeed, extractHashtags, parseTimestamp } from "./get-feed.js";
@@ -46,7 +53,7 @@ function rawPost(overrides: Partial<RawDomPost> = {}): RawDomPost {
  * Create a script-aware evaluate mock that handles the getFeed call sequence:
  * 1. waitForFeedLoad → truthy when posts exist
  * 2. SCRAPE_FEED_POSTS_SCRIPT → posts array (may repeat on scroll)
- * 3. Per-post URN extraction: menu click → true, embed read → urn string
+ * 3. Per-post URN extraction: scroll → void, menu click → true, embed read → urn string
  */
 function createEvaluateMock(scrapedPosts: RawDomPost[]) {
   let urnIdx = 0;
@@ -63,9 +70,13 @@ function createEvaluateMock(scrapedPosts: RawDomPost[]) {
       urnIdx++;
       return Promise.resolve(urn);
     }
-    // Menu button click: contains scrollIntoView
-    if (s.includes("scrollIntoView")) {
+    // Menu button click (split from scroll): contains btn.click()
+    if (s.includes("btn.click()")) {
       return Promise.resolve(true);
+    }
+    // Humanized scroll-to-element fallback: contains scrollIntoView
+    if (s.includes("scrollIntoView")) {
+      return Promise.resolve(undefined);
     }
     // waitForFeedLoad: short script with mainFeed check — always pass
     if (s.includes("mainFeed")) {
@@ -309,8 +320,11 @@ describe("getFeed", () => {
         urnIdx++;
         return Promise.resolve(`urn:li:activity:${String(urnIdx)}`);
       }
-      if (s.includes("scrollIntoView")) {
+      if (s.includes("btn.click()")) {
         return Promise.resolve(true);
+      }
+      if (s.includes("scrollIntoView")) {
+        return Promise.resolve(undefined);
       }
       if (s.includes("mainFeed")) {
         return Promise.resolve(true);
@@ -321,6 +335,7 @@ describe("getFeed", () => {
     const result = await getFeed({ cdpPort: CDP_PORT, count: 4 });
 
     expect(result.posts).toHaveLength(4);
+    // scrollFeed uses randomBetween (mocked to return 800)
     expect(send).toHaveBeenCalledWith("Input.dispatchMouseEvent", {
       type: "mouseWheel",
       x: 300,
@@ -349,8 +364,11 @@ describe("getFeed", () => {
         urnIdx++;
         return Promise.resolve(`urn:li:activity:${String(urnIdx)}`);
       }
-      if (s.includes("scrollIntoView")) {
+      if (s.includes("btn.click()")) {
         return Promise.resolve(true);
+      }
+      if (s.includes("scrollIntoView")) {
+        return Promise.resolve(undefined);
       }
       if (s.includes("mainFeed")) {
         return Promise.resolve(true);

--- a/packages/core/src/operations/get-feed.ts
+++ b/packages/core/src/operations/get-feed.ts
@@ -5,9 +5,9 @@ import type { FeedPost } from "../types/feed.js";
 import { CDPClient } from "../cdp/client.js";
 import { discoverTargets } from "../cdp/discovery.js";
 import { DEFAULT_CDP_PORT } from "../constants.js";
-import { humanizedScrollY } from "../linkedin/dom-automation.js";
+import { humanizedScrollY, humanizedScrollToByIndex } from "../linkedin/dom-automation.js";
 import type { HumanizedMouse } from "../linkedin/humanized-mouse.js";
-import { delay as utilsDelay, randomDelay } from "../utils/delay.js";
+import { delay as utilsDelay, randomDelay, randomBetween, maybeHesitate } from "../utils/delay.js";
 import type { ConnectionOptions } from "./types.js";
 import { navigateAwayIf } from "./navigate-away.js";
 
@@ -19,6 +19,8 @@ export interface GetFeedInput extends ConnectionOptions {
   readonly count?: number | undefined;
   /** Cursor token from a previous get-feed call for the next page. */
   readonly cursor?: string | undefined;
+  /** Optional humanized mouse for natural cursor movement and scrolling. */
+  readonly mouse?: HumanizedMouse | null | undefined;
 }
 
 /**
@@ -205,6 +207,10 @@ export { SCRAPE_FEED_POSTS_SCRIPT as SCRAPE_FEED_SCRIPT };
 // URN extraction via three-dot menu → Embed link
 // ---------------------------------------------------------------------------
 
+/** CSS selector for feed post menu buttons. */
+const FEED_MENU_BUTTON_SELECTOR =
+  '[data-testid="mainFeed"] div[role="listitem"] button[aria-label^="Open control menu for post"]';
+
 /**
  * Extract the post URN for a single feed item by opening its three-dot
  * menu and reading the `targetUrn` parameter from the "Embed this post"
@@ -216,15 +222,20 @@ export { SCRAPE_FEED_POSTS_SCRIPT as SCRAPE_FEED_SCRIPT };
 async function extractPostUrn(
   client: CDPClient,
   postIndex: number,
+  mouse?: HumanizedMouse | null,
 ): Promise<string | null> {
-  // Scroll the menu button into view and click it
+  await maybeHesitate(); // Probabilistic pause before menu interaction
+
+  // Scroll the menu button into view (humanized when mouse available)
+  await humanizedScrollToByIndex(client, FEED_MENU_BUTTON_SELECTOR, postIndex, mouse);
+
+  // Click the menu button
   const clicked = await client.evaluate<boolean>(`(() => {
     const btns = document.querySelectorAll(
-      '[data-testid="mainFeed"] div[role="listitem"] button[aria-label^="Open control menu for post"]'
+      ${JSON.stringify(FEED_MENU_BUTTON_SELECTOR)}
     );
     const btn = btns[${String(postIndex)}];
     if (!btn) return false;
-    btn.scrollIntoView({ block: 'center' });
     btn.click();
     return true;
   })()`);
@@ -336,7 +347,10 @@ export function mapRawPosts(raw: RawDomPost[]): FeedPost[] {
 export const delay = utilsDelay;
 
 /**
- * Scroll the feed down by one viewport worth.
+ * Scroll the feed down by a randomised viewport-like distance.
+ *
+ * The distance varies between 600–1000 px per scroll to avoid the
+ * detection signal of a perfectly uniform scroll cadence.
  *
  * When a {@link HumanizedMouse} is provided, scrolling uses incremental
  * mouse-wheel strokes (150 px / 25 ms) that mimic a physical scroll
@@ -348,7 +362,8 @@ export async function scrollFeed(
   client: CDPClient,
   mouse?: HumanizedMouse | null,
 ): Promise<void> {
-  await humanizedScrollY(client, 800, 300, 400, mouse);
+  const distance = Math.round(randomBetween(600, 1_000));
+  await humanizedScrollY(client, distance, 300, 400, mouse);
 }
 
 // ---------------------------------------------------------------------------
@@ -430,6 +445,8 @@ export async function getFeed(
   await client.connect(linkedInTarget.id);
 
   try {
+    const mouse = input.mouse ?? null;
+
     // Navigate away if already on the feed page to force a fresh load
     await navigateAwayIf(client, "/feed");
     await client.navigate("https://www.linkedin.com/feed/");
@@ -446,6 +463,7 @@ export async function getFeed(
     const cursorUrn = cursor;
 
     for (let scroll = 0; scroll <= maxScrollAttempts; scroll++) {
+      const countBeforeScroll = previousCount;
       const scraped = await client.evaluate<RawDomPost[]>(SCRAPE_FEED_POSTS_SCRIPT);
       allPosts = scraped ?? [];
 
@@ -459,8 +477,20 @@ export async function getFeed(
 
       // Scroll to load more
       if (scroll < maxScrollAttempts) {
-        await scrollFeed(client);
-        await randomDelay(1_200, 1_800);
+        await scrollFeed(client, mouse);
+
+        // Progressive session fatigue: delays increase with each scroll
+        const fatigueMultiplier = 1 + scroll * 0.1;
+        // Scale delay by newly visible content volume
+        const newPostCount = allPosts.length - countBeforeScroll;
+        const contentBonus = Math.min(
+          newPostCount * randomBetween(200, 500),
+          3_000,
+        );
+        await randomDelay(
+          1_200 * fatigueMultiplier + contentBonus,
+          1_800 * fatigueMultiplier + contentBonus,
+        );
       }
     }
 
@@ -470,7 +500,8 @@ export async function getFeed(
     for (let i = 0; i < allPosts.length; i++) {
       const post = allPosts[i];
       if (!post) continue;
-      const urn = await extractPostUrn(client, i);
+      if (i > 0) await randomDelay(300, 800); // Inter-post delay
+      const urn = await extractPostUrn(client, i, mouse);
       if (urn) {
         post.urn = urn;
         post.url = buildPostUrl(urn);

--- a/packages/core/src/operations/get-post-engagers.test.ts
+++ b/packages/core/src/operations/get-post-engagers.test.ts
@@ -19,6 +19,18 @@ vi.mock("./get-feed.js", () => ({
   delay: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock("../utils/delay.js", () => ({
+  delay: vi.fn().mockResolvedValue(undefined),
+  randomDelay: vi.fn().mockResolvedValue(undefined),
+  randomBetween: vi.fn().mockReturnValue(500),
+  maybeHesitate: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../linkedin/dom-automation.js", () => ({
+  humanizedScrollTo: vi.fn().mockResolvedValue(undefined),
+  humanizedClick: vi.fn().mockResolvedValue(undefined),
+}));
+
 import { discoverTargets } from "../cdp/discovery.js";
 import { CDPClient } from "../cdp/client.js";
 import { getPostEngagers } from "./get-post-engagers.js";
@@ -49,14 +61,14 @@ describe("getPostEngagers", () => {
    * Set up CDP mocks for the standard flow:
    *
    * 1. waitForPostLoad readiness polls (boolean[])
-   * 2. CLICK_REACTIONS_SCRIPT (boolean)
+   * 2. FIND_REACTIONS_SCRIPT (boolean) — scroll + click are via dom-automation mocks
    * 3. waitForReactionsModal readiness polls (boolean[])
    * 4. GET_MODAL_TOTAL_SCRIPT (number)
    * 5. SCRAPE_ENGAGERS_SCRIPT + SCROLL_MODAL_SCRIPT interleaved
    */
   function setupMocks(opts?: {
     postReadySequence?: boolean[];
-    reactionsClicked?: boolean;
+    reactionsFound?: boolean;
     modalReadySequence?: boolean[];
     totalReactions?: number;
     scrapeSequence?: (unknown[] | null)[];
@@ -64,7 +76,7 @@ describe("getPostEngagers", () => {
   }) {
     const {
       postReadySequence = [true],
-      reactionsClicked = true,
+      reactionsFound = true,
       modalReadySequence = [true],
       totalReactions = 2,
       scrapeSequence = [DEFAULT_ENGAGERS],
@@ -92,10 +104,10 @@ describe("getPostEngagers", () => {
       evaluateMock.mockResolvedValueOnce(ready);
     }
 
-    // 2. Click reactions
-    evaluateMock.mockResolvedValueOnce(reactionsClicked);
+    // 2. Find reactions element (scroll + click handled by dom-automation mocks)
+    evaluateMock.mockResolvedValueOnce(reactionsFound);
 
-    if (reactionsClicked) {
+    if (reactionsFound) {
       // 3. Modal readiness polls
       for (const ready of modalReadySequence) {
         evaluateMock.mockResolvedValueOnce(ready);
@@ -183,7 +195,7 @@ describe("getPostEngagers", () => {
   });
 
   it("returns empty engagers when no reactions button found", async () => {
-    setupMocks({ reactionsClicked: false });
+    setupMocks({ reactionsFound: false });
 
     const result = await getPostEngagers({
       postUrl: POST_URL,

--- a/packages/core/src/operations/get-post-engagers.ts
+++ b/packages/core/src/operations/get-post-engagers.ts
@@ -7,7 +7,9 @@ import { discoverTargets } from "../cdp/discovery.js";
 import { DEFAULT_CDP_PORT } from "../constants.js";
 import type { ConnectionOptions } from "./types.js";
 import { extractPostUrn } from "./get-post-stats.js";
-import { delay, randomDelay } from "../utils/delay.js";
+import { delay, randomDelay, randomBetween, maybeHesitate } from "../utils/delay.js";
+import { humanizedScrollTo, humanizedClick } from "../linkedin/dom-automation.js";
+import type { HumanizedMouse } from "../linkedin/humanized-mouse.js";
 import { navigateAwayIf } from "./navigate-away.js";
 
 /**
@@ -20,6 +22,8 @@ export interface GetPostEngagersInput extends ConnectionOptions {
   readonly count?: number | undefined;
   /** Offset for pagination (default: 0). */
   readonly start?: number | undefined;
+  /** Optional humanized mouse for natural cursor movement and scrolling. */
+  readonly mouse?: HumanizedMouse | null | undefined;
 }
 
 /**
@@ -56,26 +60,25 @@ interface RawEngager {
 
 /**
  * JavaScript source evaluated inside the LinkedIn post detail page to
- * find and click the reactions count element, opening the reactions modal.
+ * find the reactions count element and mark it with a data attribute
+ * for subsequent humanized scroll + click.
  *
- * The post detail page shows engagement counts (e.g. "42 reactions") as
- * clickable elements.  The script finds the first element whose trimmed
- * text matches the reaction-count pattern and clicks it.
- *
- * Returns `true` if a reactions element was found and clicked.
+ * Returns `true` if a reactions element was found and marked.
  */
-const CLICK_REACTIONS_SCRIPT = `(() => {
+const FIND_REACTIONS_SCRIPT = `(() => {
   const candidates = document.querySelectorAll('button, [role="button"], span, a');
   for (const el of candidates) {
     const txt = (el.textContent || '').trim();
     if (/^\\d[\\d,]*\\s+reactions?$/i.test(txt) && el.offsetHeight > 0) {
-      el.scrollIntoView({ block: 'center' });
-      el.click();
+      el.setAttribute('data-lhremote-reactions', 'true');
       return true;
     }
   }
   return false;
 })()`;
+
+/** Selector for the marked reactions element. */
+const REACTIONS_SELECTOR = "[data-lhremote-reactions]";
 
 /**
  * JavaScript source that extracts engager data from the reactions modal.
@@ -157,12 +160,13 @@ const SCRAPE_ENGAGERS_SCRIPT = `(() => {
 })()`;
 
 /**
- * JavaScript source that scrolls inside the reactions modal to trigger
- * lazy loading of additional engager entries.
+ * Build a scroll-modal script with a randomised scroll distance.
  *
- * Returns `true` if scrolling occurred (i.e. not at the bottom).
+ * The distance varies between 350–650 px to avoid the detection signal
+ * of a perfectly uniform modal scroll cadence.
  */
-const SCROLL_MODAL_SCRIPT = `(() => {
+function createScrollModalScript(distance: number): string {
+  return `(() => {
   const modal = document.querySelector('[role="dialog"]');
   if (!modal) return false;
 
@@ -182,9 +186,10 @@ const SCROLL_MODAL_SCRIPT = `(() => {
   if (!scrollable) scrollable = modal;
 
   const prev = scrollable.scrollTop;
-  scrollable.scrollTop += 500;
+  scrollable.scrollTop += ${String(distance)};
   return scrollable.scrollTop > prev;
 })()`;
+}
 
 /**
  * JavaScript source that extracts the total reactions count from the
@@ -315,9 +320,11 @@ export async function getPostEngagers(
     // Wait for the post content to render
     await waitForPostLoad(client);
 
-    // Click the reactions count to open the modal
-    const clicked = await client.evaluate<boolean>(CLICK_REACTIONS_SCRIPT);
-    if (!clicked) {
+    const mouse = input.mouse ?? null;
+
+    // Find the reactions count element and mark it
+    const found = await client.evaluate<boolean>(FIND_REACTIONS_SCRIPT);
+    if (!found) {
       // No reactions on this post — return empty
       return {
         postUrn,
@@ -325,6 +332,11 @@ export async function getPostEngagers(
         paging: { start, count: 0, total: 0 },
       };
     }
+
+    // Humanized scroll to the reactions element and click it
+    await maybeHesitate(); // Probabilistic pause before interaction
+    await humanizedScrollTo(client, REACTIONS_SELECTOR, mouse);
+    await humanizedClick(client, REACTIONS_SELECTOR, mouse);
 
     // Wait for the reactions modal to load
     await waitForReactionsModal(client);
@@ -345,8 +357,9 @@ export async function getPostEngagers(
       if (allEngagers.length >= targetCount) break;
 
       if (scroll < maxScrollAttempts) {
+        const modalDistance = Math.round(randomBetween(350, 650));
         const scrolled =
-          await client.evaluate<boolean>(SCROLL_MODAL_SCRIPT);
+          await client.evaluate<boolean>(createScrollModalScript(modalDistance));
         if (!scrolled) break;
         await randomDelay(800, 1_200);
       }

--- a/packages/core/src/operations/get-profile-activity.test.ts
+++ b/packages/core/src/operations/get-profile-activity.test.ts
@@ -28,6 +28,8 @@ vi.mock("./get-feed.js", async (importOriginal) => {
 vi.mock("../utils/delay.js", () => ({
   delay: vi.fn().mockResolvedValue(undefined),
   randomDelay: vi.fn().mockResolvedValue(undefined),
+  randomBetween: vi.fn().mockReturnValue(800),
+  maybeHesitate: vi.fn().mockResolvedValue(undefined),
 }));
 
 import { discoverTargets } from "../cdp/discovery.js";
@@ -74,7 +76,7 @@ function setupMocks(scrapedPosts: RawDomPost[] = [], urnResults: (string | null)
     if (typeof script === "string" && script.includes("div[role=\"article\"]") && script.includes("return true")) {
       return Promise.resolve(true);
     }
-    // extractActivityPostUrn — click phase
+    // extractActivityPostUrn — click phase (split from scroll)
     if (typeof script === "string" && script.includes("btn.click()")) {
       return Promise.resolve(true);
     }
@@ -82,6 +84,10 @@ function setupMocks(scrapedPosts: RawDomPost[] = [], urnResults: (string | null)
     if (typeof script === "string" && script.includes("embed-modal")) {
       const urn = urnResults[urnCallIdx++] ?? null;
       return Promise.resolve(urn);
+    }
+    // humanizedScrollToByIndex fallback — scrollIntoView
+    if (typeof script === "string" && script.includes("scrollIntoView")) {
+      return Promise.resolve(undefined);
     }
     // SCRAPE_ACTIVITY_POSTS_SCRIPT — return posts
     return Promise.resolve(scrapedPosts);

--- a/packages/core/src/operations/get-profile-activity.ts
+++ b/packages/core/src/operations/get-profile-activity.ts
@@ -7,7 +7,9 @@ import { discoverTargets } from "../cdp/discovery.js";
 import { DEFAULT_CDP_PORT } from "../constants.js";
 import type { ConnectionOptions } from "./types.js";
 import { navigateAwayIf } from "./navigate-away.js";
-import { randomDelay } from "../utils/delay.js";
+import { randomDelay, randomBetween, maybeHesitate } from "../utils/delay.js";
+import { humanizedScrollToByIndex } from "../linkedin/dom-automation.js";
+import type { HumanizedMouse } from "../linkedin/humanized-mouse.js";
 import {
   type RawDomPost,
   mapRawPosts,
@@ -26,6 +28,8 @@ export interface GetProfileActivityInput extends ConnectionOptions {
   readonly count?: number | undefined;
   /** Cursor token from a previous get-profile-activity call for the next page. */
   readonly cursor?: string | undefined;
+  /** Optional humanized mouse for natural cursor movement and scrolling. */
+  readonly mouse?: HumanizedMouse | null | undefined;
 }
 
 /**
@@ -219,6 +223,10 @@ async function waitForActivityLoad(
   );
 }
 
+/** CSS selector for activity post menu buttons. */
+const ACTIVITY_MENU_BUTTON_SELECTOR =
+  'div[role="article"] button[aria-label^="Open control menu"]';
+
 /**
  * Extract the post URN for a single activity post by opening its
  * three-dot menu and reading the embed link's `targetUrn`.
@@ -228,21 +236,22 @@ async function waitForActivityLoad(
 async function extractActivityPostUrn(
   client: CDPClient,
   postIndex: number,
+  mouse?: HumanizedMouse | null,
 ): Promise<string | null> {
+  await maybeHesitate(); // Probabilistic pause before menu interaction
+
+  // Scroll the menu button into view (humanized when mouse available)
+  await humanizedScrollToByIndex(client, ACTIVITY_MENU_BUTTON_SELECTOR, postIndex, mouse);
+
+  // Click the menu button
   const clicked = await client.evaluate<boolean>(`(() => {
-    const articles = document.querySelectorAll('div[role="article"]');
-    let idx = 0;
-    for (const a of articles) {
-      const btn = a.querySelector('button[aria-label^="Open control menu"]');
-      if (!btn) continue;
-      if (idx === ${String(postIndex)}) {
-        btn.scrollIntoView({ block: 'center' });
-        btn.click();
-        return true;
-      }
-      idx++;
-    }
-    return false;
+    const btns = document.querySelectorAll(
+      ${JSON.stringify(ACTIVITY_MENU_BUTTON_SELECTOR)}
+    );
+    const btn = btns[${String(postIndex)}];
+    if (!btn) return false;
+    btn.click();
+    return true;
   })()`);
 
   if (!clicked) return null;
@@ -329,6 +338,8 @@ export async function getProfileActivity(
     // Wait for activity posts to render
     await waitForActivityLoad(client);
 
+    const mouse = input.mouse ?? null;
+
     // Collect posts — scroll to load more if needed
     const maxScrollAttempts = 10;
     let allPosts: RawDomPost[] = [];
@@ -337,6 +348,7 @@ export async function getProfileActivity(
     const cursorUrn = cursor;
 
     for (let scroll = 0; scroll <= maxScrollAttempts; scroll++) {
+      const countBeforeScroll = previousCount;
       const scraped =
         await client.evaluate<RawDomPost[]>(SCRAPE_ACTIVITY_POSTS_SCRIPT);
       allPosts = scraped ?? [];
@@ -350,8 +362,20 @@ export async function getProfileActivity(
 
       // Scroll to load more
       if (scroll < maxScrollAttempts) {
-        await scrollFeed(client);
-        await randomDelay(1_200, 1_800);
+        await scrollFeed(client, mouse);
+
+        // Progressive session fatigue: delays increase with each scroll
+        const fatigueMultiplier = 1 + scroll * 0.1;
+        // Scale delay by newly visible content volume
+        const newPostCount = allPosts.length - countBeforeScroll;
+        const contentBonus = Math.min(
+          newPostCount * randomBetween(200, 500),
+          3_000,
+        );
+        await randomDelay(
+          1_200 * fatigueMultiplier + contentBonus,
+          1_800 * fatigueMultiplier + contentBonus,
+        );
       }
     }
 
@@ -359,7 +383,8 @@ export async function getProfileActivity(
     for (let i = 0; i < allPosts.length; i++) {
       const post = allPosts[i];
       if (!post) continue;
-      const urn = await extractActivityPostUrn(client, i);
+      if (i > 0) await randomDelay(300, 800); // Inter-post delay
+      const urn = await extractActivityPostUrn(client, i, mouse);
       if (urn) {
         post.urn = urn;
         post.url = buildPostUrl(urn);

--- a/packages/core/src/operations/search-posts.test.ts
+++ b/packages/core/src/operations/search-posts.test.ts
@@ -15,6 +15,13 @@ vi.mock("./navigate-away.js", () => ({
   navigateAwayIf: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock("../utils/delay.js", () => ({
+  delay: vi.fn().mockResolvedValue(undefined),
+  randomDelay: vi.fn().mockResolvedValue(undefined),
+  randomBetween: vi.fn().mockReturnValue(800),
+  maybeHesitate: vi.fn().mockResolvedValue(undefined),
+}));
+
 import { discoverTargets } from "../cdp/discovery.js";
 import { CDPClient } from "../cdp/client.js";
 import { searchPosts } from "./search-posts.js";

--- a/packages/core/src/operations/search-posts.ts
+++ b/packages/core/src/operations/search-posts.ts
@@ -7,7 +7,9 @@ import { discoverTargets } from "../cdp/discovery.js";
 import { DEFAULT_CDP_PORT } from "../constants.js";
 import type { ConnectionOptions } from "./types.js";
 import { navigateAwayIf } from "./navigate-away.js";
-import { randomDelay } from "../utils/delay.js";
+import { randomDelay, randomBetween, maybeHesitate } from "../utils/delay.js";
+import { humanizedScrollToByIndex } from "../linkedin/dom-automation.js";
+import type { HumanizedMouse } from "../linkedin/humanized-mouse.js";
 import {
   type RawDomPost,
   mapRawPosts,
@@ -25,6 +27,8 @@ export interface SearchPostsInput extends ConnectionOptions {
   readonly count?: number | undefined;
   /** Index-based cursor (offset) from a previous search-posts call for the next page. */
   readonly cursor?: number | undefined;
+  /** Optional humanized mouse for natural cursor movement and scrolling. */
+  readonly mouse?: HumanizedMouse | null | undefined;
 }
 
 /**
@@ -361,6 +365,8 @@ export async function searchPosts(
     // Wait for the search results to render
     await waitForSearchResults(client);
 
+    const mouse = input.mouse ?? null;
+
     // Collect posts — scroll to load more if needed.
     //
     // Cursor is an index-based offset (e.g. "10" means start from post
@@ -376,6 +382,7 @@ export async function searchPosts(
     }
 
     for (let scroll = 0; scroll <= maxScrollAttempts; scroll++) {
+      const countBeforeScroll = previousCount;
       const scraped =
         await client.evaluate<RawDomPost[]>(SCRAPE_SEARCH_RESULTS_SCRIPT);
       allPosts = scraped ?? [];
@@ -389,8 +396,20 @@ export async function searchPosts(
 
       // Scroll to load more
       if (scroll < maxScrollAttempts) {
-        await scrollFeed(client);
-        await randomDelay(1_200, 1_800);
+        await scrollFeed(client, mouse);
+
+        // Progressive session fatigue: delays increase with each scroll
+        const fatigueMultiplier = 1 + scroll * 0.1;
+        // Scale delay by newly visible content volume
+        const newPostCount = allPosts.length - countBeforeScroll;
+        const contentBonus = Math.min(
+          newPostCount * randomBetween(200, 500),
+          3_000,
+        );
+        await randomDelay(
+          1_200 * fatigueMultiplier + contentBonus,
+          1_800 * fatigueMultiplier + contentBonus,
+        );
       }
     }
 
@@ -415,21 +434,29 @@ export async function searchPosts(
         };`,
       );
 
+      const SEARCH_MENU_BUTTON_SELECTOR =
+        'div[role="listitem"] button[aria-label^="Open control menu for post"]';
+
       for (let i = 0; i < allPosts.length; i++) {
         const post = allPosts[i];
         if (!post || post.urn) continue;
 
+        if (i > 0) await randomDelay(300, 800); // Inter-post delay
+        await maybeHesitate(); // Probabilistic pause before menu interaction
+
         // Reset capture
         await client.evaluate(`window.__capturedClipboard = null;`);
+
+        // Scroll the menu button into view (humanized when mouse available)
+        await humanizedScrollToByIndex(client, SEARCH_MENU_BUTTON_SELECTOR, i, mouse);
 
         // Click the i-th menu button
         const clicked = await client.evaluate<boolean>(`(() => {
           const btns = document.querySelectorAll(
-            'div[role="listitem"] button[aria-label^="Open control menu for post"]'
+            ${JSON.stringify(SEARCH_MENU_BUTTON_SELECTOR)}
           );
           const btn = btns[${String(i)}];
           if (!btn) return false;
-          btn.scrollIntoView({ block: 'center' });
           btn.click();
           return true;
         })()`);

--- a/packages/core/src/utils/delay.test.ts
+++ b/packages/core/src/utils/delay.test.ts
@@ -2,7 +2,7 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import { describe, expect, it } from "vitest";
-import { delay } from "./delay.js";
+import { delay, randomBetween, maybeHesitate } from "./delay.js";
 
 describe("delay", () => {
   it("should resolve after the given time", async () => {
@@ -15,5 +15,32 @@ describe("delay", () => {
   it("should return a promise that resolves to undefined", async () => {
     const result = await delay(0);
     expect(result).toBeUndefined();
+  });
+});
+
+describe("randomBetween", () => {
+  it("returns a value within the specified range", () => {
+    for (let i = 0; i < 100; i++) {
+      const value = randomBetween(10, 20);
+      expect(value).toBeGreaterThanOrEqual(10);
+      expect(value).toBeLessThan(20);
+    }
+  });
+
+  it("returns min when range is zero", () => {
+    expect(randomBetween(5, 5)).toBe(5);
+  });
+});
+
+describe("maybeHesitate", () => {
+  it("resolves to undefined", async () => {
+    const result = await maybeHesitate(0);
+    expect(result).toBeUndefined();
+  });
+
+  it("never pauses with probability 0", async () => {
+    const start = Date.now();
+    await maybeHesitate(0);
+    expect(Date.now() - start).toBeLessThan(50);
   });
 });

--- a/packages/core/src/utils/delay.ts
+++ b/packages/core/src/utils/delay.ts
@@ -17,3 +17,28 @@ export function delay(ms: number): Promise<void> {
 export function randomDelay(min: number, max: number): Promise<void> {
   return delay(min + Math.random() * (max - min));
 }
+
+/**
+ * Return a random number between `min` and `max` (inclusive of min, exclusive of max).
+ *
+ * Useful for randomising scroll distances, coordinate offsets, and other
+ * non-delay numeric values that benefit from human-like variation.
+ */
+export function randomBetween(min: number, max: number): number {
+  return min + Math.random() * (max - min);
+}
+
+/**
+ * With the given probability (default 12%), insert a random pause of 500–2000 ms.
+ *
+ * Simulates the irregular micro-pauses humans exhibit: hovering briefly,
+ * momentarily slowing, or pausing before deciding to act.  Breaks
+ * statistical uniformity in timing patterns without adding significant
+ * average time.
+ */
+export function maybeHesitate(probability = 0.12): Promise<void> {
+  if (Math.random() < probability) {
+    return randomDelay(500, 2_000);
+  }
+  return Promise.resolve();
+}


### PR DESCRIPTION
## Summary

- **Humanized scroll-to-element** (#550): Replace instant `scrollIntoView` with incremental VirtualMouse scrolling loop across 6 call sites (dom-automation, get-feed, search-posts, get-profile-activity, get-post-engagers, comment-on-post)
- **Inter-post delays** (#551): Add `randomDelay(300, 800)` between post iterations in feed/search/activity URN extraction loops
- **Randomized scroll distance** (#552): Feed scrolls vary 600–1000px (was fixed 800px), modal scrolls vary 350–650px (was fixed 500px)
- **Progressive session fatigue** (#553): Scroll loop delays scale by `1 + scroll * 0.1` — later scrolls have longer pauses
- **Probabilistic micro-hesitation** (#554): New `maybeHesitate()` utility (12% chance of 500–2000ms pause) inserted before menu interactions
- **Pre/post-click micro-delays** (#555): `humanizedClick` and `humanizedHover` now add 0–50ms before and 50–150ms after interactions
- **Content-volume-scaled delays** (#556): Post-scroll delays scale by number of newly loaded posts, capped at 3000ms bonus

### New primitives in `dom-automation.ts`
- `getElementBounds(client, selector)` — bounding rect query
- `getElementBoundsByIndex(client, baseSelector, index)` — indexed bounding rect
- `getViewportHeight(client)` — viewport height query
- `humanizedScrollTo(client, selector, mouse?)` — scroll-to-element loop
- `humanizedScrollToByIndex(client, baseSelector, index, mouse?)` — indexed variant

### New utilities in `delay.ts`
- `randomBetween(min, max)` — random number (not delay) for distances
- `maybeHesitate(probability?)` — probabilistic micro-pause

### Operation changes
- `GetFeedInput`, `SearchPostsInput`, `GetProfileActivityInput`, `GetPostEngagersInput` — added optional `mouse?` parameter for humanized scrolling
- `CLICK_REACTIONS_SCRIPT` split into `FIND_REACTIONS_SCRIPT` + humanized scroll + click
- `SCROLL_MODAL_SCRIPT` converted to `createScrollModalScript(distance)` for randomized distance

## Test plan
- [x] All 6 affected test files pass (109 tests)
- [x] Lint passes
- [ ] CI green on all platforms
- [ ] E2E smoke test locally

Closes #550
Closes #551
Closes #552
Closes #553
Closes #554
Closes #555
Closes #556

🤖 Generated with [Claude Code](https://claude.com/claude-code)