### PR TITLE
(fix) core: use openFixture() in collection-list integration test

### DIFF
--- a/packages/core/src/db/repositories/collection-list.integration.test.ts
+++ b/packages/core/src/db/repositories/collection-list.integration.test.ts
@@ -2,23 +2,26 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import type { DatabaseSync } from "node:sqlite";
 
 import { DatabaseClient } from "../client.js";
-import { FIXTURE_PATH } from "../testing/open-fixture.js";
+import { openFixture } from "../testing/open-fixture.js";
 import { CollectionListRepository } from "./collection-list.js";
 
 describe("CollectionListRepository (integration)", () => {
+  let rawDb: DatabaseSync;
   let client: DatabaseClient;
   let repo: CollectionListRepository;
 
   beforeAll(() => {
-    // Open in write mode so we can test write operations
-    client = new DatabaseClient(FIXTURE_PATH, { readOnly: false });
+    // Use openFixture() for an isolated writable copy
+    rawDb = openFixture();
+    client = { db: rawDb, close: () => rawDb.close() } as unknown as DatabaseClient;
     repo = new CollectionListRepository(client);
   });
 
   afterAll(() => {
-    client.close();
+    rawDb.close();
   });
 
   describe("listCollections", () => {


### PR DESCRIPTION
## Summary

- `collection-list.integration.test.ts` was opening `FIXTURE_PATH` directly with `readOnly: false`, mutating the fixture database in place on every test run
- This caused `fixture.db` to always show as modified in `git status` (file counter jumped from 26 to 351, size grew by 3 pages) and accumulated test state across runs
- Switched to `openFixture()` which copies the fixture to a temp file, matching the established pattern used by all other write-access tests

## Test plan

- [x] `pnpm test` passes (100/100 relevant test files, 1254 tests)
- [x] `pnpm lint` passes
- [x] `fixture.db` stays unmodified after test run (verified via `git diff`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)