### PR TITLE
Fix listAccounts to use webpack account service cache

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ Do **not** add issue numbers (e.g. `(#12)`) to commit messages. GitHub links PRs
 - Test helper `packages/core/src/cdp/testing/launch-chromium.ts` manages Chromium lifecycle.
 - Chromium is installed in CI via `npx playwright-core install chromium --with-deps`.
 - E2E tests live in `packages/e2e/src/` and are **not** run in CI. Always run `pnpm test:e2e` locally before submitting PRs that add or modify E2E tests.
-- Run a single E2E file: `pnpm --filter @lhremote/e2e test:e2e:file -- <pattern>` (e.g., `list-accounts`). Do **not** use `test:e2e -- file.ts` — that filters by test name, not file, and loads all 23 files (~30s each).
+- Run a single E2E file: `pnpm --filter @lhremote/e2e test:e2e:file <pattern>` (e.g., `list-accounts`). Do **not** use `--` before the pattern — pnpm forwards it literally and vitest ignores args after `--` for file filtering.
 - E2E tests must assert preconditions explicitly — never silently skip via `if (accounts.length > 0)`. Use `resolveAccountId(port)` from `@lhremote/core/testing` which throws if no accounts exist.
 - Shared E2E helpers (`resolveAccountId`, `forceStopInstance`, `assertDefined`, `getE2EPersonId`) are exported from `@lhremote/core/testing` — do not duplicate them locally in test files.
 

--- a/packages/core/src/services/app.test.ts
+++ b/packages/core/src/services/app.test.ts
@@ -5,7 +5,7 @@ import { type ChildProcess, spawn } from "node:child_process";
 import { accessSync } from "node:fs";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { AppLaunchError, AppNotFoundError } from "./errors.js";
+import { AppLaunchError, AppNotFoundError, LinkedHelperUnreachableError } from "./errors.js";
 import { AppService } from "./app.js";
 
 vi.mock("node:child_process", () => ({
@@ -243,6 +243,18 @@ describe("AppService", () => {
       // spawn must not be called again — app is already running
       expect(mockedSpawn).not.toHaveBeenCalled();
       expect(service.cdpPort).toBe(54321);
+    });
+
+    it("throws LinkedHelperUnreachableError when only instance is connectable", async () => {
+      mockedFindApp.mockResolvedValue([
+        { pid: 111, cdpPort: 50982, connectable: false, role: "launcher" as const },
+        { pid: 222, cdpPort: 51011, connectable: true, role: "instance" as const },
+      ]);
+
+      const service = new AppService(undefined, FAST_OPTIONS);
+
+      await expect(service.launch()).rejects.toThrow(LinkedHelperUnreachableError);
+      expect(mockedSpawn).not.toHaveBeenCalled();
     });
 
     it("throws AppLaunchError on spawn error", async () => {

--- a/packages/core/src/services/app.ts
+++ b/packages/core/src/services/app.ts
@@ -82,10 +82,14 @@ export class AppService {
     const existingApps = await findApp();
     if (existingApps.length > 0) {
       if (!this.force) {
-        const connectable = existingApps.find((a) => a.connectable);
-        if (connectable) {
-          // Already running with CDP — use that port
-          this.assignedPort = connectable.cdpPort;
+        // Only reuse a launcher process — connecting to an instance port
+        // as a launcher yields WrongPortError because the instance lacks
+        // the electronStore / mainWindow globals.
+        const connectableLauncher = existingApps.find(
+          (a) => a.connectable && a.role === "launcher",
+        );
+        if (connectableLauncher) {
+          this.assignedPort = connectableLauncher.cdpPort;
           this.detectedExternal = true;
           return;
         }

--- a/packages/core/src/services/launcher.test.ts
+++ b/packages/core/src/services/launcher.test.ts
@@ -342,11 +342,24 @@ describe("LauncherService", () => {
       await expect(service.listAccounts()).rejects.toThrow(CDPEvaluationError);
     });
 
-    it("throws WrongPortError when electronStore is not available", async () => {
+    it("throws WrongPortError when webpack is not available", async () => {
       await service.connect();
       nextEvaluateResult = null;
 
       await expect(service.listAccounts()).rejects.toThrow(WrongPortError);
+    });
+
+    it("passes awaitPromise=true for the async expression", async () => {
+      await service.connect();
+      nextEvaluateResult = [];
+
+      await service.listAccounts();
+
+      const listCall = mockEvaluate.mock.calls.find(
+        (c) => typeof c[0] === "string" && c[0].includes("extendedLinkedInAccountsBS"),
+      );
+      expect(listCall).toBeDefined();
+      expect(listCall?.[1]).toBe(true);
     });
   });
 });

--- a/packages/core/src/services/launcher.ts
+++ b/packages/core/src/services/launcher.ts
@@ -28,6 +28,23 @@ import {
  * methods to start/stop instances and query accounts.
  */
 export class LauncherService {
+  /**
+   * CDP expression snippet that waits for the webpack module registry
+   * and sets `wpRequire` in the enclosing scope.  Callers must check
+   * `wpRequire` for null and handle the failure case themselves.
+   */
+  private static readonly WEBPACK_INIT = `
+    const _wpDeadline = Date.now() + 15000;
+    while (!window.webpackChunk_linked_helper_front && Date.now() < _wpDeadline) {
+      await new Promise(r => setTimeout(r, 250));
+    }
+    let wpRequire = null;
+    if (window.webpackChunk_linked_helper_front) {
+      window.webpackChunk_linked_helper_front.push(
+        [[Symbol()], {}, (req) => { wpRequire = req; }]
+      );
+    }`;
+
   private readonly port: number;
   private readonly host: string;
   private readonly allowRemote: boolean;
@@ -127,20 +144,7 @@ export class LauncherService {
           const remote = require('@electron/remote');
           const mainWindow = remote.getGlobal('mainWindow');
 
-          // 1. Resolve renderer-side services via webpack module registry.
-          //    The webpack chunk array may not exist yet if the renderer
-          //    bundles are still loading — poll until available.
-          const wpDeadline = Date.now() + 15000;
-          while (!window.webpackChunk_linked_helper_front && Date.now() < wpDeadline) {
-            await new Promise(r => setTimeout(r, 250));
-          }
-          if (!window.webpackChunk_linked_helper_front) {
-            return { success: false, error: 'webpack module registry not available (timed out)' };
-          }
-          let wpRequire = null;
-          window.webpackChunk_linked_helper_front.push(
-            [[Symbol()], {}, (req) => { wpRequire = req; }]
-          );
+          ${LauncherService.WEBPACK_INIT}
           if (!wpRequire) {
             return { success: false, error: 'webpack module registry not available' };
           }
@@ -270,37 +274,46 @@ export class LauncherService {
   }
 
   /**
-   * List all accounts configured in the LinkedHelper Electron store.
+   * List all accounts configured in LinkedHelper.
    *
-   * Accounts are discovered from the `linkedInPasswords` store key whose
-   * entries use the format `userId:li:accountId`.
+   * Accounts are read from the renderer-side webpack service cache
+   * (`runningLiAccountsService.extendedLinkedInAccountsBS`).  The
+   * launcher populates this cache on startup via IPC; we poll until
+   * it becomes available rather than calling `refetchLinkedInAccounts`
+   * (whose backend API now rejects the old embed format with 400).
    */
   async listAccounts(): Promise<Account[]> {
     const client = this.ensureConnected();
 
     const accounts = await this.launcherEvaluate<Account[] | null>(
       client,
-      `(() => {
-        const remote = require('@electron/remote');
-        const mainWindow = remote.getGlobal('mainWindow');
-        const store = mainWindow?.electronStore;
-        if (!store) return null;
-        const passwords = store.get('linkedInPasswords') ?? {};
-        return Object.keys(passwords)
-          .map(k => {
-            const parts = k.split(':li:');
-            if (parts.length !== 2) return null;
-            const accountId = Number(parts[1]);
-            if (Number.isNaN(accountId)) return null;
-            return {
-              id: accountId,
-              liId: accountId,
-              name: '',
-              email: undefined,
-            };
-          })
-          .filter(a => a !== null);
+      `(async () => {
+        ${LauncherService.WEBPACK_INIT}
+        if (!wpRequire) return null;
+
+        const svc = wpRequire(44354).runningLiAccountsService;
+
+        // Poll until the cache is populated by the launcher's startup
+        // process (same pattern as startInstance's account polling).
+        const cacheDeadline = Date.now() + 30000;
+        while (Date.now() < cacheDeadline) {
+          const raw = svc.extendedLinkedInAccountsBS?.value;
+          if (raw) {
+            const entries = Array.isArray(raw) ? raw : Object.values(raw);
+            if (entries.length > 0) {
+              return entries.map(a => ({
+                id: a.id,
+                liId: a.id,
+                name: a.fullName ?? '',
+                email: a.email ?? undefined,
+              }));
+            }
+          }
+          await new Promise(r => setTimeout(r, 500));
+        }
+        return [];
       })()`,
+      true,
     );
 
     if (accounts === null) {

--- a/packages/core/src/testing/e2e-helpers.ts
+++ b/packages/core/src/testing/e2e-helpers.ts
@@ -73,12 +73,14 @@ export async function launchApp(options?: {
     await delay(250);
   }
 
-  // Phase 2: Wait for full launcher readiness (WebSocket + renderer loaded)
+  // Phase 2: Wait for full launcher readiness (WebSocket + renderer loaded).
+  // We only verify that LauncherService.connect() succeeds (which validates
+  // electronStore access).  listAccounts() has its own internal cache
+  // polling, so calling it here would double the timeout budget.
   while (Date.now() < deadline) {
     const launcher = new LauncherService(port);
     try {
       await launcher.connect();
-      await launcher.listAccounts();
       launcher.disconnect();
       return { app, port };
     } catch {

--- a/packages/core/src/types/account.ts
+++ b/packages/core/src/types/account.ts
@@ -2,7 +2,7 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 /**
- * A LinkedHelper account as stored in the Electron store.
+ * A LinkedHelper account.
  *
  * Each account corresponds to a LinkedIn identity managed by
  * LinkedHelper and has its own database partition.

--- a/packages/e2e/package.json
+++ b/packages/e2e/package.json
@@ -13,7 +13,7 @@
     "build": "tsc",
     "test": "echo 'No unit tests'",
     "test:e2e": "vitest run --config ../../vitest.e2e.config.ts --reporter=verbose",
-    "test:e2e:file": "vitest run --config ../../vitest.e2e.config.ts --reporter=verbose --testPathPattern",
+    "test:e2e:file": "vitest run --config ../../vitest.e2e.config.ts --reporter=verbose",
     "lint": "eslint src/"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary

- Replace `linkedInPasswords` store key parsing in `listAccounts()` with polling the renderer-side `extendedLinkedInAccountsBS` cache — the same source the LH UI itself uses. The old heuristic breaks when users authenticate via OAuth (no password stored in the electron store).
- Extract shared `WEBPACK_INIT` CDP snippet used by both `listAccounts()` and `startInstance()` to eliminate expression duplication
- Fix `AppService.launch()` to only reuse launcher-role connectable processes, not instances — connecting to an instance port as a launcher causes `WrongPortError`
- Fix `test:e2e:file` script and CLAUDE.md invocation (remove invalid `--testPathPattern` and `--` separator that vitest ignores for file filtering)
- Simplify `launchApp()` E2E helper readiness check to avoid nested 30s timeout budgets

Closes #536

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (1257 unit tests, pre-existing integration failure unrelated)
- [x] `list-accounts` E2E test passes (6/6 tests, verified with real LinkedHelper v2.113.7)
- [x] Single-file E2E invocation confirmed: `pnpm --filter @lhremote/e2e test:e2e:file list-accounts` loads 1 file in 1s (not all 23)

🤖 Generated with [Claude Code](https://claude.com/claude-code)