### PR TITLE
Drop FeedPost.urn, use URL as primary post identifier

### DIFF
--- a/packages/cli/src/handlers/get-feed.test.ts
+++ b/packages/cli/src/handlers/get-feed.test.ts
@@ -15,7 +15,6 @@ import { getStderr, getStdout } from "./testing/mock-helpers.js";
 const MOCK_RESULT: GetFeedOutput = {
   posts: [
     {
-      urn: "urn:li:activity:123",
       url: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
       authorName: "Alice Smith",
       authorPublicId: "alice",
@@ -58,7 +57,7 @@ describe("handleGetFeed", () => {
     expect(process.exitCode).toBeUndefined();
     const output = JSON.parse(getStdout(stdoutSpy));
     expect(output.posts).toHaveLength(1);
-    expect(output.posts[0].urn).toBe("urn:li:activity:123");
+    expect(output.posts[0].url).toBe("https://www.linkedin.com/feed/update/urn:li:activity:123/");
     expect(output.nextCursor).toBe("cursor-abc");
   });
 
@@ -129,7 +128,6 @@ describe("handleGetFeed", () => {
     vi.mocked(getFeed).mockResolvedValue({
       posts: [
         {
-          urn: "urn:li:activity:999",
           url: "https://www.linkedin.com/feed/update/urn:li:activity:999/",
           authorName: "Jane Doe",
           authorPublicId: null,

--- a/packages/cli/src/handlers/get-profile-activity.ts
+++ b/packages/cli/src/handlers/get-profile-activity.ts
@@ -43,7 +43,7 @@ export async function handleGetProfileActivity(
     process.stdout.write(`Profile: ${result.profilePublicId}\n\n`);
 
     for (const post of result.posts) {
-      process.stdout.write(`  ${post.urn}\n`);
+      process.stdout.write(`  ${post.url}\n`);
       if (post.authorName) {
         process.stdout.write(`    Author:    ${post.authorName}\n`);
       }

--- a/packages/cli/src/handlers/search-posts.test.ts
+++ b/packages/cli/src/handlers/search-posts.test.ts
@@ -19,7 +19,6 @@ const MOCK_RESULTS: SearchPostsOutput = {
   query: "AI agents",
   posts: [
     {
-      urn: "",
       url: "https://www.linkedin.com/feed/update/urn:li:activity:7123456789012345678/",
       authorName: "Jane Smith",
       authorHeadline: "CEO at Acme Corp",
@@ -34,7 +33,6 @@ const MOCK_RESULTS: SearchPostsOutput = {
       hashtags: [],
     },
     {
-      urn: "",
       url: "https://www.linkedin.com/feed/update/urn:li:activity:7234567890123456789/",
       authorName: "Bob",
       authorHeadline: null,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -312,6 +312,7 @@ export {
   // Post analytics
   getPostStats,
   extractPostUrn,
+  resolvePostDetailUrl,
   type GetPostStatsInput,
   type GetPostStatsOutput,
   getPostEngagers,

--- a/packages/core/src/operations/get-feed.test.ts
+++ b/packages/core/src/operations/get-feed.test.ts
@@ -33,10 +33,8 @@ const CDP_PORT = 9222;
  * Build a minimal raw DOM post object.
  */
 function rawPost(overrides: Partial<RawDomPost> = {}): RawDomPost {
-  const urn = overrides.urn ?? "urn:li:activity:123";
   return {
-    urn,
-    url: `https://www.linkedin.com/feed/update/${urn}/`,
+    url: overrides.url ?? "https://www.linkedin.com/feed/update/urn:li:activity:123/",
     authorName: null,
     authorHeadline: null,
     authorProfileUrl: null,
@@ -143,7 +141,6 @@ describe("getFeed", () => {
   it("parses posts from DOM-scraped data", async () => {
     setupMocks([
       rawPost({
-        urn: "urn:li:activity:123",
         url: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
         authorName: "Alice Smith",
         authorHeadline: "Engineer at Acme",
@@ -161,7 +158,6 @@ describe("getFeed", () => {
 
     expect(result.posts).toHaveLength(1);
     const [post] = result.posts;
-    expect(post?.urn).toBe("urn:li:activity:123");
     expect(post?.url).toBe("https://www.linkedin.com/feed/update/urn:li:activity:123/");
     expect(post?.authorName).toBe("Alice Smith");
     expect(post?.authorHeadline).toBe("Engineer at Acme");
@@ -174,14 +170,12 @@ describe("getFeed", () => {
     expect(post?.hashtags).toEqual(["linkedin", "tech"]);
   });
 
-  it("constructs URL when raw post has null url", async () => {
-    setupMocks([rawPost({ urn: "urn:li:activity:456", url: null })]);
+  it("returns empty string URL when raw post has null url", async () => {
+    setupMocks([rawPost({ url: null })]);
 
     const result = await getFeed({ cdpPort: CDP_PORT });
 
-    expect(result.posts[0]?.url).toBe(
-      "https://www.linkedin.com/feed/update/urn:li:activity:456/",
-    );
+    expect(result.posts[0]?.url).toBe("");
   });
 
   it("navigates to the LinkedIn feed page", async () => {
@@ -202,34 +196,34 @@ describe("getFeed", () => {
 
   it("limits results to count parameter", async () => {
     setupMocks([
-      rawPost({ urn: "urn:li:activity:1" }),
-      rawPost({ urn: "urn:li:activity:2" }),
-      rawPost({ urn: "urn:li:activity:3" }),
+      rawPost({ url: "https://www.linkedin.com/feed/update/urn:li:activity:1/" }),
+      rawPost({ url: "https://www.linkedin.com/feed/update/urn:li:activity:2/" }),
+      rawPost({ url: "https://www.linkedin.com/feed/update/urn:li:activity:3/" }),
     ]);
 
     const result = await getFeed({ cdpPort: CDP_PORT, count: 2 });
 
     expect(result.posts).toHaveLength(2);
-    expect(result.posts[0]?.urn).toBe("urn:li:activity:1");
-    expect(result.posts[1]?.urn).toBe("urn:li:activity:2");
+    expect(result.posts[0]?.url).toBe("https://www.linkedin.com/feed/update/urn:li:activity:1/");
+    expect(result.posts[1]?.url).toBe("https://www.linkedin.com/feed/update/urn:li:activity:2/");
   });
 
   it("returns nextCursor when more posts are available", async () => {
     setupMocks([
-      rawPost({ urn: "urn:li:activity:1" }),
-      rawPost({ urn: "urn:li:activity:2" }),
-      rawPost({ urn: "urn:li:activity:3" }),
+      rawPost({ url: "https://www.linkedin.com/feed/update/urn:li:activity:1/" }),
+      rawPost({ url: "https://www.linkedin.com/feed/update/urn:li:activity:2/" }),
+      rawPost({ url: "https://www.linkedin.com/feed/update/urn:li:activity:3/" }),
     ]);
 
     const result = await getFeed({ cdpPort: CDP_PORT, count: 2 });
 
-    expect(result.nextCursor).toBe("urn:li:activity:2");
+    expect(result.nextCursor).toBe("https://www.linkedin.com/feed/update/urn:li:activity:2/");
   });
 
   it("returns null nextCursor when all posts are returned", async () => {
     setupMocks([
-      rawPost({ urn: "urn:li:activity:1" }),
-      rawPost({ urn: "urn:li:activity:2" }),
+      rawPost({ url: "https://www.linkedin.com/feed/update/urn:li:activity:1/" }),
+      rawPost({ url: "https://www.linkedin.com/feed/update/urn:li:activity:2/" }),
     ]);
 
     const result = await getFeed({ cdpPort: CDP_PORT, count: 10 });
@@ -239,32 +233,32 @@ describe("getFeed", () => {
 
   it("supports cursor-based pagination", { timeout: 15_000 }, async () => {
     setupMocks([
-      rawPost({ urn: "urn:li:activity:1" }),
-      rawPost({ urn: "urn:li:activity:2" }),
-      rawPost({ urn: "urn:li:activity:3" }),
-      rawPost({ urn: "urn:li:activity:4" }),
+      rawPost({ url: "https://www.linkedin.com/feed/update/urn:li:activity:1/" }),
+      rawPost({ url: "https://www.linkedin.com/feed/update/urn:li:activity:2/" }),
+      rawPost({ url: "https://www.linkedin.com/feed/update/urn:li:activity:3/" }),
+      rawPost({ url: "https://www.linkedin.com/feed/update/urn:li:activity:4/" }),
     ]);
 
     const result = await getFeed({
       cdpPort: CDP_PORT,
       count: 2,
-      cursor: "urn:li:activity:2",
+      cursor: "https://www.linkedin.com/feed/update/urn:li:activity:2/",
     });
 
     expect(result.posts).toHaveLength(2);
-    expect(result.posts[0]?.urn).toBe("urn:li:activity:3");
-    expect(result.posts[1]?.urn).toBe("urn:li:activity:4");
+    expect(result.posts[0]?.url).toBe("https://www.linkedin.com/feed/update/urn:li:activity:3/");
+    expect(result.posts[1]?.url).toBe("https://www.linkedin.com/feed/update/urn:li:activity:4/");
   });
 
   it("returns empty posts when cursor is at the end", async () => {
     setupMocks([
-      rawPost({ urn: "urn:li:activity:1" }),
-      rawPost({ urn: "urn:li:activity:2" }),
+      rawPost({ url: "https://www.linkedin.com/feed/update/urn:li:activity:1/" }),
+      rawPost({ url: "https://www.linkedin.com/feed/update/urn:li:activity:2/" }),
     ]);
 
     const result = await getFeed({
       cdpPort: CDP_PORT,
-      cursor: "urn:li:activity:2",
+      cursor: "https://www.linkedin.com/feed/update/urn:li:activity:2/",
     });
 
     expect(result.posts).toHaveLength(0);
@@ -273,13 +267,13 @@ describe("getFeed", () => {
 
   it("treats unknown cursor as start of feed", async () => {
     setupMocks([
-      rawPost({ urn: "urn:li:activity:1" }),
-      rawPost({ urn: "urn:li:activity:2" }),
+      rawPost({ url: "https://www.linkedin.com/feed/update/urn:li:activity:1/" }),
+      rawPost({ url: "https://www.linkedin.com/feed/update/urn:li:activity:2/" }),
     ]);
 
     const result = await getFeed({
       cdpPort: CDP_PORT,
-      cursor: "urn:li:activity:unknown",
+      cursor: "https://www.linkedin.com/feed/update/urn:li:activity:unknown/",
     });
 
     // When cursor is not found, all posts are returned from the start
@@ -313,14 +307,14 @@ describe("getFeed", () => {
 
     let scrapeCall = 0;
     const firstScrape = [
-      rawPost({ urn: "urn:li:activity:1" }),
-      rawPost({ urn: "urn:li:activity:2" }),
+      rawPost({ url: "https://www.linkedin.com/feed/update/urn:li:activity:1/" }),
+      rawPost({ url: "https://www.linkedin.com/feed/update/urn:li:activity:2/" }),
     ];
     const secondScrape = [
-      rawPost({ urn: "urn:li:activity:1" }),
-      rawPost({ urn: "urn:li:activity:2" }),
-      rawPost({ urn: "urn:li:activity:3" }),
-      rawPost({ urn: "urn:li:activity:4" }),
+      rawPost({ url: "https://www.linkedin.com/feed/update/urn:li:activity:1/" }),
+      rawPost({ url: "https://www.linkedin.com/feed/update/urn:li:activity:2/" }),
+      rawPost({ url: "https://www.linkedin.com/feed/update/urn:li:activity:3/" }),
+      rawPost({ url: "https://www.linkedin.com/feed/update/urn:li:activity:4/" }),
     ];
 
     let urnIdx = 0;
@@ -364,8 +358,8 @@ describe("getFeed", () => {
     const { evaluate, send } = setupMocks([]);
 
     const fixedPosts = [
-      rawPost({ urn: "urn:li:activity:1" }),
-      rawPost({ urn: "urn:li:activity:2" }),
+      rawPost({ url: "https://www.linkedin.com/feed/update/urn:li:activity:1/" }),
+      rawPost({ url: "https://www.linkedin.com/feed/update/urn:li:activity:2/" }),
     ];
     let urnIdx = 0;
 

--- a/packages/core/src/operations/get-feed.ts
+++ b/packages/core/src/operations/get-feed.ts
@@ -10,7 +10,6 @@ import type { HumanizedMouse } from "../linkedin/humanized-mouse.js";
 import { delay as utilsDelay, randomDelay, randomBetween, maybeHesitate } from "../utils/delay.js";
 import type { ConnectionOptions } from "./types.js";
 import { navigateAwayIf } from "./navigate-away.js";
-import { extractPostUrn as parsePostUrn } from "./get-post-stats.js";
 
 /**
  * Input for the get-feed operation.
@@ -40,7 +39,6 @@ export interface GetFeedOutput {
 
 /** @internal Exported for reuse by search-posts. */
 export interface RawDomPost {
-  urn: string | null;
   url: string | null;
   authorName: string | null;
   authorHeadline: string | null;
@@ -178,7 +176,6 @@ const SCRAPE_FEED_POSTS_SCRIPT = `(() => {
     }
 
     posts.push({
-      urn: null,
       url: null,
       authorName: authorName,
       authorHeadline: authorHeadline,
@@ -342,8 +339,7 @@ export function buildPostUrl(urn: string): string {
 /** @internal Exported for reuse by search-posts. */
 export function mapRawPosts(raw: RawDomPost[]): FeedPost[] {
   return raw.map((r) => ({
-    urn: r.urn ?? "",
-    url: r.url ?? (r.urn ? buildPostUrl(r.urn) : null),
+    url: r.url ?? "",
     authorName: r.authorName,
     authorHeadline: r.authorHeadline,
     authorProfileUrl: r.authorProfileUrl,
@@ -479,16 +475,16 @@ export async function getFeed(
     let previousCount = 0;
 
     // If resuming with a cursor, we need to scroll past already-seen posts
-    const cursorUrn = cursor;
+    const cursorUrl = cursor;
 
     for (let scroll = 0; scroll <= maxScrollAttempts; scroll++) {
       const countBeforeScroll = previousCount;
       const scraped = await client.evaluate<RawDomPost[]>(SCRAPE_FEED_POSTS_SCRIPT);
       allPosts = scraped ?? [];
 
-      // Determine which posts to return (URNs not yet available, use index)
+      // Determine which posts to return
       const available = allPosts.length;
-      if (available >= count && !cursorUrn) break;
+      if (available >= count && !cursorUrl) break;
 
       // No new posts appeared after scroll — stop
       if (allPosts.length === previousCount && scroll > 0) break;
@@ -526,18 +522,13 @@ export async function getFeed(
       const url = await capturePostUrl(client, i, mouse);
       if (url) {
         post.url = url;
-        try {
-          post.urn = parsePostUrn(url);
-        } catch {
-          // URL format not recognized — keep url but leave urn null
-        }
       }
     }
 
-    // Slice the result window (now that URNs are populated)
+    // Slice the result window
     let startIdx = 0;
-    if (cursorUrn) {
-      const cursorIdx = allPosts.findIndex((p) => p.urn === cursorUrn);
+    if (cursorUrl) {
+      const cursorIdx = allPosts.findIndex((p) => p.url === cursorUrl);
       if (cursorIdx >= 0) {
         startIdx = cursorIdx + 1;
       }
@@ -549,7 +540,7 @@ export async function getFeed(
     // Determine next cursor
     const hasMore = startIdx + count < allPosts.length;
     const lastPost = window[window.length - 1];
-    const nextCursor = hasMore && lastPost ? lastPost.urn : null;
+    const nextCursor = hasMore && lastPost ? lastPost.url : null;
 
     return { posts, nextCursor };
   } finally {

--- a/packages/core/src/operations/get-post-engagers.ts
+++ b/packages/core/src/operations/get-post-engagers.ts
@@ -6,7 +6,7 @@ import { CDPClient } from "../cdp/client.js";
 import { discoverTargets } from "../cdp/discovery.js";
 import { DEFAULT_CDP_PORT } from "../constants.js";
 import type { ConnectionOptions } from "./types.js";
-import { extractPostUrn } from "./get-post-stats.js";
+import { extractPostUrn, resolvePostDetailUrl } from "./get-post-stats.js";
 import { delay, randomDelay, randomBetween, maybeHesitate } from "../utils/delay.js";
 import { humanizedScrollTo, humanizedClick } from "../linkedin/dom-automation.js";
 import type { HumanizedMouse } from "../linkedin/humanized-mouse.js";
@@ -284,7 +284,15 @@ export async function getPostEngagers(
   const count = input.count ?? 20;
   const start = input.start ?? 0;
 
-  const postUrn = extractPostUrn(input.postUrl);
+  const postDetailUrl = resolvePostDetailUrl(input.postUrl);
+
+  // Try to extract URN for the output postUrn field
+  let postUrn: string;
+  try {
+    postUrn = extractPostUrn(input.postUrl);
+  } catch {
+    postUrn = input.postUrl;
+  }
 
   // Enforce loopback guard
   if (!allowRemote && cdpHost !== "127.0.0.1" && cdpHost !== "localhost") {
@@ -314,7 +322,6 @@ export async function getPostEngagers(
     await navigateAwayIf(client, "/feed/update/");
 
     // Navigate to the post detail page
-    const postDetailUrl = `https://www.linkedin.com/feed/update/${postUrn}/`;
     await client.navigate(postDetailUrl);
 
     // Wait for the post content to render

--- a/packages/core/src/operations/get-post-stats.ts
+++ b/packages/core/src/operations/get-post-stats.ts
@@ -49,6 +49,16 @@ export function extractPostUrn(input: string): string {
   throw new Error(`Cannot extract post URN from: ${input}`);
 }
 
+/**
+ * Resolve a post URL or URN into a navigable LinkedIn post detail URL.
+ * Accepts full LinkedIn URLs (returned as-is) or raw URNs (converted to URL).
+ */
+export function resolvePostDetailUrl(input: string): string {
+  if (input.startsWith("https://")) return input;
+  if (input.startsWith("urn:li:")) return `https://www.linkedin.com/feed/update/${input}/`;
+  throw new Error(`Invalid post identifier: ${input}`);
+}
+
 // ---------------------------------------------------------------------------
 // Raw shape returned by the in-page scraping script
 // ---------------------------------------------------------------------------
@@ -143,7 +153,15 @@ export async function getPostStats(
   const cdpHost = input.cdpHost ?? "127.0.0.1";
   const allowRemote = input.allowRemote ?? false;
 
-  const postUrn = extractPostUrn(input.postUrl);
+  const postDetailUrl = resolvePostDetailUrl(input.postUrl);
+
+  // Keep using extractPostUrn for the output postUrn field
+  let postUrn: string;
+  try {
+    postUrn = extractPostUrn(input.postUrl);
+  } catch {
+    postUrn = input.postUrl;
+  }
 
   // Enforce loopback guard
   if (!allowRemote && cdpHost !== "127.0.0.1" && cdpHost !== "localhost") {
@@ -173,7 +191,6 @@ export async function getPostStats(
     await navigateAwayIf(client, "/feed/update/");
 
     // Navigate to the post detail page
-    const postDetailUrl = `https://www.linkedin.com/feed/update/${postUrn}/`;
     await client.navigate(postDetailUrl);
 
     // Wait for the post content to render

--- a/packages/core/src/operations/get-post.ts
+++ b/packages/core/src/operations/get-post.ts
@@ -6,7 +6,7 @@ import { CDPClient } from "../cdp/client.js";
 import { discoverTargets } from "../cdp/discovery.js";
 import { DEFAULT_CDP_PORT } from "../constants.js";
 import type { ConnectionOptions } from "./types.js";
-import { extractPostUrn } from "./get-post-stats.js";
+import { extractPostUrn, resolvePostDetailUrl } from "./get-post-stats.js";
 import { delay, parseTimestamp } from "./get-feed.js";
 import { navigateAwayIf } from "./navigate-away.js";
 
@@ -395,7 +395,15 @@ export async function getPost(input: GetPostInput): Promise<GetPostOutput> {
   const allowRemote = input.allowRemote ?? false;
   const maxComments = input.commentCount ?? 100;
 
-  const postUrn = extractPostUrn(input.postUrl);
+  const postDetailUrl = resolvePostDetailUrl(input.postUrl);
+
+  // Try to extract URN for the output postUrn field
+  let postUrn: string;
+  try {
+    postUrn = extractPostUrn(input.postUrl);
+  } catch {
+    postUrn = input.postUrl;
+  }
 
   // Enforce loopback guard
   if (!allowRemote && cdpHost !== "127.0.0.1" && cdpHost !== "localhost") {
@@ -425,7 +433,6 @@ export async function getPost(input: GetPostInput): Promise<GetPostOutput> {
     await navigateAwayIf(client, "/feed/update/");
 
     // Navigate to the post detail page
-    const postDetailUrl = `https://www.linkedin.com/feed/update/${postUrn}/`;
     await client.navigate(postDetailUrl);
 
     // Wait for the post content to render

--- a/packages/core/src/operations/get-profile-activity.test.ts
+++ b/packages/core/src/operations/get-profile-activity.test.ts
@@ -41,7 +41,6 @@ const CDP_PORT = 9222;
 
 function rawPost(overrides: Partial<RawDomPost> = {}): RawDomPost {
   return {
-    urn: null,
     url: null,
     authorName: "Jane Doe",
     authorHeadline: "Engineer at Acme",
@@ -232,7 +231,7 @@ describe("getProfileActivity", () => {
     expect(evaluate).toHaveBeenCalled();
   });
 
-  it("extracts URNs via three-dot menu for each post", async () => {
+  it("extracts URLs via three-dot menu for each post", async () => {
     const posts = [rawPost(), rawPost({ authorName: "Bob" })];
     setupMocks(posts, [urnToUrl("urn:li:share:111"), urnToUrl("urn:li:share:222")]);
 
@@ -241,8 +240,8 @@ describe("getProfileActivity", () => {
       profile: "johndoe",
     });
 
-    expect(result.posts[0]?.urn).toBe("urn:li:share:111");
-    expect(result.posts[1]?.urn).toBe("urn:li:share:222");
+    expect(result.posts[0]?.url).toBe("https://www.linkedin.com/feed/update/urn:li:share:111/");
+    expect(result.posts[1]?.url).toBe("https://www.linkedin.com/feed/update/urn:li:share:222/");
   });
 
   it("returns posts with profilePublicId and nextCursor", async () => {
@@ -275,7 +274,7 @@ describe("getProfileActivity", () => {
     });
 
     expect(result.posts).toHaveLength(10);
-    expect(result.nextCursor).toBe("urn:li:share:9");
+    expect(result.nextCursor).toBe("https://www.linkedin.com/feed/update/urn:li:share:9/");
   });
 
   it("uses cursor to skip past already-seen posts", async () => {
@@ -289,7 +288,7 @@ describe("getProfileActivity", () => {
       cdpPort: CDP_PORT,
       profile: "johndoe",
       count: 5,
-      cursor: "urn:li:share:4",
+      cursor: "https://www.linkedin.com/feed/update/urn:li:share:4/",
     });
 
     expect(result.posts).toHaveLength(5);
@@ -309,7 +308,7 @@ describe("getProfileActivity", () => {
     );
   });
 
-  it("handles posts where URN extraction fails", async () => {
+  it("handles posts where URL extraction fails", async () => {
     setupMocks([rawPost()], [null]);
 
     const result = await getProfileActivity({
@@ -317,8 +316,7 @@ describe("getProfileActivity", () => {
       profile: "johndoe",
     });
 
-    expect(result.posts[0]?.urn).toBe("");
-    expect(result.posts[0]?.url).toBeNull();
+    expect(result.posts[0]?.url).toBe("");
   });
 
   it("throws when no LinkedIn page found", async () => {

--- a/packages/core/src/operations/get-profile-activity.ts
+++ b/packages/core/src/operations/get-profile-activity.ts
@@ -16,7 +16,6 @@ import {
   scrollFeed,
   delay,
 } from "./get-feed.js";
-import { extractPostUrn as parsePostUrn } from "./get-post-stats.js";
 
 /**
  * Input for the get-profile-activity operation.
@@ -179,7 +178,6 @@ const SCRAPE_ACTIVITY_POSTS_SCRIPT = `(() => {
     }
 
     posts.push({
-      urn: null,
       url: null,
       authorName: authorName,
       authorHeadline: authorHeadline,
@@ -351,7 +349,7 @@ export async function getProfileActivity(
     let allPosts: RawDomPost[] = [];
     let previousCount = 0;
 
-    const cursorUrn = cursor;
+    const cursorUrl = cursor;
 
     for (let scroll = 0; scroll <= maxScrollAttempts; scroll++) {
       const countBeforeScroll = previousCount;
@@ -360,7 +358,7 @@ export async function getProfileActivity(
       allPosts = scraped ?? [];
 
       const available = allPosts.length;
-      if (available >= count && !cursorUrn) break;
+      if (available >= count && !cursorUrl) break;
 
       // No new posts appeared after scroll — stop
       if (allPosts.length === previousCount && scroll > 0) break;
@@ -401,18 +399,13 @@ export async function getProfileActivity(
       const url = await captureActivityPostUrl(client, i, mouse);
       if (url) {
         post.url = url;
-        try {
-          post.urn = parsePostUrn(url);
-        } catch {
-          // URL format not recognized — keep url but leave urn null
-        }
       }
     }
 
-    // Slice the result window (now that URNs are populated)
+    // Slice the result window
     let startIdx = 0;
-    if (cursorUrn) {
-      const cursorIdx = allPosts.findIndex((p) => p.urn === cursorUrn);
+    if (cursorUrl) {
+      const cursorIdx = allPosts.findIndex((p) => p.url === cursorUrl);
       if (cursorIdx >= 0) {
         startIdx = cursorIdx + 1;
       }
@@ -421,14 +414,14 @@ export async function getProfileActivity(
     const window = allPosts.slice(startIdx, startIdx + count);
     const posts = mapRawPosts(window);
 
-    // Determine next cursor — use last post with a non-null URN
+    // Determine next cursor — use last post with a non-null URL
     const hasMore = startIdx + count < allPosts.length;
     let nextCursor: string | null = null;
     if (hasMore) {
       for (let i = window.length - 1; i >= 0; i--) {
-        const urn = window[i]?.urn;
-        if (urn) {
-          nextCursor = urn;
+        const url = window[i]?.url;
+        if (url) {
+          nextCursor = url;
           break;
         }
       }

--- a/packages/core/src/operations/index.ts
+++ b/packages/core/src/operations/index.ts
@@ -215,6 +215,7 @@ export {
 export {
   getPostStats,
   extractPostUrn,
+  resolvePostDetailUrl,
   type GetPostStatsInput,
   type GetPostStatsOutput,
 } from "./get-post-stats.js";

--- a/packages/core/src/operations/search-posts.test.ts
+++ b/packages/core/src/operations/search-posts.test.ts
@@ -35,7 +35,6 @@ const CDP_PORT = 9222;
  */
 function rawPost(overrides: Partial<RawDomPost> = {}): RawDomPost {
   return {
-    urn: "urn:li:activity:123",
     url: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
     authorName: null,
     authorHeadline: null,
@@ -116,7 +115,6 @@ describe("searchPosts", () => {
   it("parses posts from DOM-scraped data", async () => {
     setupMocks([
       rawPost({
-        urn: "urn:li:activity:123",
         url: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
         authorName: "Alice Smith",
         authorHeadline: "Engineer at Acme",
@@ -135,7 +133,6 @@ describe("searchPosts", () => {
     expect(result.query).toBe("linkedin");
     expect(result.posts).toHaveLength(1);
     const [post] = result.posts;
-    expect(post?.urn).toBe("urn:li:activity:123");
     expect(post?.url).toBe("https://www.linkedin.com/feed/update/urn:li:activity:123/");
     expect(post?.authorName).toBe("Alice Smith");
     expect(post?.authorHeadline).toBe("Engineer at Acme");
@@ -148,20 +145,17 @@ describe("searchPosts", () => {
     expect(post?.hashtags).toEqual(["linkedin", "tech"]);
   });
 
-  it("returns posts with URNs from chameleon strategy", async () => {
+  it("returns posts with URLs from chameleon strategy", async () => {
     setupMocks([
-      rawPost({ urn: "urn:li:activity:1", url: "https://www.linkedin.com/feed/update/urn:li:activity:1/" }),
-      rawPost({ urn: "urn:li:activity:2", url: "https://www.linkedin.com/feed/update/urn:li:activity:2/" }),
+      rawPost({ url: "https://www.linkedin.com/feed/update/urn:li:activity:1/" }),
+      rawPost({ url: "https://www.linkedin.com/feed/update/urn:li:activity:2/" }),
     ]);
 
     const result = await searchPosts({ query: "test", cdpPort: CDP_PORT });
 
     expect(result.posts).toHaveLength(2);
-    expect(result.posts[0]?.urn).toBe("urn:li:activity:1");
-    expect(result.posts[1]?.urn).toBe("urn:li:activity:2");
-    expect(result.posts[0]?.url).toBe(
-      "https://www.linkedin.com/feed/update/urn:li:activity:1/",
-    );
+    expect(result.posts[0]?.url).toBe("https://www.linkedin.com/feed/update/urn:li:activity:1/");
+    expect(result.posts[1]?.url).toBe("https://www.linkedin.com/feed/update/urn:li:activity:2/");
   });
 
   it("navigates to the search results page with query", async () => {
@@ -185,23 +179,23 @@ describe("searchPosts", () => {
 
   it("limits results to count parameter", async () => {
     setupMocks([
-      rawPost({ urn: "urn:li:activity:1" }),
-      rawPost({ urn: "urn:li:activity:2" }),
-      rawPost({ urn: "urn:li:activity:3" }),
+      rawPost({ url: "https://www.linkedin.com/feed/update/urn:li:activity:1/" }),
+      rawPost({ url: "https://www.linkedin.com/feed/update/urn:li:activity:2/" }),
+      rawPost({ url: "https://www.linkedin.com/feed/update/urn:li:activity:3/" }),
     ]);
 
     const result = await searchPosts({ query: "test", cdpPort: CDP_PORT, count: 2 });
 
     expect(result.posts).toHaveLength(2);
-    expect(result.posts[0]?.urn).toBe("urn:li:activity:1");
-    expect(result.posts[1]?.urn).toBe("urn:li:activity:2");
+    expect(result.posts[0]?.url).toBe("https://www.linkedin.com/feed/update/urn:li:activity:1/");
+    expect(result.posts[1]?.url).toBe("https://www.linkedin.com/feed/update/urn:li:activity:2/");
   });
 
   it("returns nextCursor when more posts are available", async () => {
     setupMocks([
-      rawPost({ urn: "urn:li:activity:1" }),
-      rawPost({ urn: "urn:li:activity:2" }),
-      rawPost({ urn: "urn:li:activity:3" }),
+      rawPost({ url: "https://www.linkedin.com/feed/update/urn:li:activity:1/" }),
+      rawPost({ url: "https://www.linkedin.com/feed/update/urn:li:activity:2/" }),
+      rawPost({ url: "https://www.linkedin.com/feed/update/urn:li:activity:3/" }),
     ]);
 
     const result = await searchPosts({ query: "test", cdpPort: CDP_PORT, count: 2 });
@@ -211,8 +205,8 @@ describe("searchPosts", () => {
 
   it("returns null nextCursor when all posts are returned", async () => {
     setupMocks([
-      rawPost({ urn: "urn:li:activity:1" }),
-      rawPost({ urn: "urn:li:activity:2" }),
+      rawPost({ url: "https://www.linkedin.com/feed/update/urn:li:activity:1/" }),
+      rawPost({ url: "https://www.linkedin.com/feed/update/urn:li:activity:2/" }),
     ]);
 
     const result = await searchPosts({ query: "test", cdpPort: CDP_PORT, count: 10 });
@@ -222,10 +216,10 @@ describe("searchPosts", () => {
 
   it("supports cursor-based pagination", async () => {
     setupMocks([
-      rawPost({ urn: "urn:li:activity:1" }),
-      rawPost({ urn: "urn:li:activity:2" }),
-      rawPost({ urn: "urn:li:activity:3" }),
-      rawPost({ urn: "urn:li:activity:4" }),
+      rawPost({ url: "https://www.linkedin.com/feed/update/urn:li:activity:1/" }),
+      rawPost({ url: "https://www.linkedin.com/feed/update/urn:li:activity:2/" }),
+      rawPost({ url: "https://www.linkedin.com/feed/update/urn:li:activity:3/" }),
+      rawPost({ url: "https://www.linkedin.com/feed/update/urn:li:activity:4/" }),
     ]);
 
     const result = await searchPosts({
@@ -236,14 +230,14 @@ describe("searchPosts", () => {
     });
 
     expect(result.posts).toHaveLength(2);
-    expect(result.posts[0]?.urn).toBe("urn:li:activity:3");
-    expect(result.posts[1]?.urn).toBe("urn:li:activity:4");
+    expect(result.posts[0]?.url).toBe("https://www.linkedin.com/feed/update/urn:li:activity:3/");
+    expect(result.posts[1]?.url).toBe("https://www.linkedin.com/feed/update/urn:li:activity:4/");
   });
 
   it("returns empty posts when cursor is at the end", async () => {
     setupMocks([
-      rawPost({ urn: "urn:li:activity:1" }),
-      rawPost({ urn: "urn:li:activity:2" }),
+      rawPost({ url: "https://www.linkedin.com/feed/update/urn:li:activity:1/" }),
+      rawPost({ url: "https://www.linkedin.com/feed/update/urn:li:activity:2/" }),
     ]);
 
     const result = await searchPosts({
@@ -269,12 +263,12 @@ describe("searchPosts", () => {
     const { evaluate, send } = setupMocks([]);
 
     const firstScrape = [
-      rawPost({ urn: "urn:li:activity:1" }),
+      rawPost({ url: "https://www.linkedin.com/feed/update/urn:li:activity:1/" }),
     ];
     const secondScrape = [
-      rawPost({ urn: "urn:li:activity:1" }),
-      rawPost({ urn: "urn:li:activity:2" }),
-      rawPost({ urn: "urn:li:activity:3" }),
+      rawPost({ url: "https://www.linkedin.com/feed/update/urn:li:activity:1/" }),
+      rawPost({ url: "https://www.linkedin.com/feed/update/urn:li:activity:2/" }),
+      rawPost({ url: "https://www.linkedin.com/feed/update/urn:li:activity:3/" }),
     ];
 
     let scrapeIdx = 0;
@@ -306,8 +300,8 @@ describe("searchPosts", () => {
     const { evaluate, send } = setupMocks([]);
 
     const fixedPosts = [
-      rawPost({ urn: "urn:li:activity:1" }),
-      rawPost({ urn: "urn:li:activity:2" }),
+      rawPost({ url: "https://www.linkedin.com/feed/update/urn:li:activity:1/" }),
+      rawPost({ url: "https://www.linkedin.com/feed/update/urn:li:activity:2/" }),
     ];
 
     evaluate.mockReset();

--- a/packages/core/src/operations/search-posts.ts
+++ b/packages/core/src/operations/search-posts.ts
@@ -70,8 +70,7 @@ const SCRAPE_SEARCH_RESULTS_SCRIPT = `(() => {
       const menuBtn = card.querySelector('button[aria-label^="Open control menu for post"]');
       if (!menuBtn) continue;
 
-      // URN is not available in search results; URL extracted via three-dot menu
-      let urnRaw = null;
+      // URL extracted via three-dot menu
 
       let authorName = null;
       let authorHeadline = null;
@@ -149,8 +148,7 @@ const SCRAPE_SEARCH_RESULTS_SCRIPT = `(() => {
       }
 
       posts.push({
-        urn: urnRaw,
-        url: urnRaw ? 'https://www.linkedin.com/feed/update/' + urnRaw + '/' : null,
+        url: null,
         authorName,
         authorHeadline,
         authorProfileUrl,
@@ -248,7 +246,6 @@ const SCRAPE_SEARCH_RESULTS_SCRIPT = `(() => {
     }
 
     posts.push({
-      urn: null,
       url: null,
       authorName,
       authorHeadline,
@@ -424,7 +421,7 @@ export async function searchPosts(
     // Electron's clipboard API is broken (readText returns {}) so we
     // monkey-patch navigator.clipboard.writeText to capture into a
     // window global instead.
-    const needsUrlExtraction = allPosts.some((p) => p.urn === null);
+    const needsUrlExtraction = allPosts.some((p) => p.url === null);
     if (needsUrlExtraction) {
       // Install clipboard interceptor once
       await client.evaluate(
@@ -439,7 +436,7 @@ export async function searchPosts(
 
       for (let i = 0; i < allPosts.length; i++) {
         const post = allPosts[i];
-        if (!post || post.urn) continue;
+        if (!post || post.url) continue;
 
         if (i > 0) await randomDelay(300, 800); // Inter-post delay
         await maybeHesitate(); // Probabilistic pause before menu interaction

--- a/packages/core/src/types/feed.ts
+++ b/packages/core/src/types/feed.ts
@@ -5,10 +5,8 @@
  * A post from the LinkedIn home feed or profile activity stream.
  */
 export interface FeedPost {
-  /** Feed update URN (e.g. `urn:li:activity:1234567890`). */
-  readonly urn: string;
   /** Direct URL to the post on LinkedIn. */
-  readonly url: string | null;
+  readonly url: string;
   /** Display name of the post author. */
   readonly authorName: string | null;
   /** Professional headline of the author, if available. */

--- a/packages/e2e/src/get-feed.e2e.test.ts
+++ b/packages/e2e/src/get-feed.e2e.test.ts
@@ -107,8 +107,8 @@ describeE2E("get-feed operation", () => {
       expect(parsed.posts.length).toBeGreaterThan(0);
 
       const post = parsed.posts[0] as FeedPost;
-      expect(post).toHaveProperty("urn");
-      expect(typeof post.urn).toBe("string");
+      expect(post).toHaveProperty("url");
+      expect(typeof post.url).toBe("string");
       expect(typeof post.reactionCount).toBe("number");
       expect(typeof post.commentCount).toBe("number");
       expect(typeof post.shareCount).toBe("number");
@@ -154,7 +154,7 @@ describeE2E("get-feed operation", () => {
       expect(parsed.posts.length).toBeGreaterThan(0);
 
       const post = parsed.posts[0] as FeedPost;
-      expect(post).toHaveProperty("urn");
+      expect(post).toHaveProperty("url");
       expect(typeof post.reactionCount).toBe("number");
     }, 60_000);
   });

--- a/packages/e2e/src/get-post-engagers.e2e.test.ts
+++ b/packages/e2e/src/get-post-engagers.e2e.test.ts
@@ -90,14 +90,14 @@ describeE2E("get-post-engagers operation", () => {
 
       // Pick first post with reactions > 0; fall back to first post
       const postWithReactions = feedParsed.posts.find((p) => p.reactionCount > 0);
-      const postUrn = postWithReactions?.urn ?? feedParsed.posts[0]?.urn;
-      assertDefined(postUrn, "No posts returned from get-feed");
+      const postUrl = postWithReactions?.url ?? feedParsed.posts[0]?.url;
+      assertDefined(postUrl, "No posts returned from get-feed");
 
       const { server, getHandler } = createMockServer();
       registerGetPostEngagers(server);
 
       const handler = getHandler("get-post-engagers");
-      const result = (await handler({ postUrl: postUrn, cdpPort, count: 5 })) as {
+      const result = (await handler({ postUrl: postUrl, cdpPort, count: 5 })) as {
         isError?: boolean;
         content: { type: string; text: string }[];
       };

--- a/packages/e2e/src/get-post-stats.e2e.test.ts
+++ b/packages/e2e/src/get-post-stats.e2e.test.ts
@@ -23,11 +23,11 @@ import { createMockServer } from "@lhremote/mcp/testing";
  * Fetch a fresh post URN by scraping the feed.  Returns the URN of the
  * first feed post, or `undefined` when the feed returns no posts.
  */
-async function fetchPostUrnFromFeed(cdpPort: number): Promise<string | undefined> {
+async function fetchPostUrlFromFeed(cdpPort: number): Promise<string | undefined> {
   const { getFeed } = await import("@lhremote/core");
   const result = await getFeed({ cdpPort, count: 1 });
   const first = result.posts[0];
-  return first?.urn ?? undefined;
+  return first?.url ?? undefined;
 }
 
 describeE2E("get-post-stats operation", () => {
@@ -35,7 +35,7 @@ describeE2E("get-post-stats operation", () => {
   let port: number;
   let accountId: number;
   let cdpPort: number;
-  let capturedPostUrn: string | undefined;
+  let capturedPostUrl: string | undefined;
 
   beforeAll(async () => {
     const launched = await launchApp();
@@ -75,7 +75,7 @@ describeE2E("get-post-stats operation", () => {
     );
 
     // Pre-fetch a live post URN from the feed
-    capturedPostUrn = await fetchPostUrnFromFeed(cdpPort);
+    capturedPostUrl = await fetchPostUrlFromFeed(cdpPort);
   }, 120_000);
 
   afterAll(async () => {
@@ -104,13 +104,13 @@ describeE2E("get-post-stats operation", () => {
     });
 
     it("get-post-stats --json returns valid stats", async () => {
-      assertDefined(capturedPostUrn, "No post URN — feed returned no posts");
+      assertDefined(capturedPostUrl, "No post URL — feed returned no posts");
 
       const stdoutSpy = vi
         .spyOn(process.stdout, "write")
         .mockReturnValue(true);
 
-      await handleGetPostStats(capturedPostUrn, { cdpPort, json: true });
+      await handleGetPostStats(capturedPostUrl, { cdpPort, json: true });
 
       expect(process.exitCode).toBeUndefined();
       expect(stdoutSpy).toHaveBeenCalled();
@@ -128,13 +128,13 @@ describeE2E("get-post-stats operation", () => {
     }, 60_000);
 
     it("get-post-stats prints human-friendly output", async () => {
-      assertDefined(capturedPostUrn, "No post URN — feed returned no posts");
+      assertDefined(capturedPostUrl, "No post URL — feed returned no posts");
 
       const stdoutSpy = vi
         .spyOn(process.stdout, "write")
         .mockReturnValue(true);
 
-      await handleGetPostStats(capturedPostUrn, { cdpPort });
+      await handleGetPostStats(capturedPostUrl, { cdpPort });
 
       expect(process.exitCode).toBeUndefined();
       expect(stdoutSpy).toHaveBeenCalled();
@@ -149,13 +149,13 @@ describeE2E("get-post-stats operation", () => {
 
   describe("MCP tools", () => {
     it("get-post-stats tool returns valid JSON", async () => {
-      assertDefined(capturedPostUrn, "No post URN — feed returned no posts");
+      assertDefined(capturedPostUrl, "No post URL — feed returned no posts");
 
       const { server, getHandler } = createMockServer();
       registerGetPostStats(server);
 
       const handler = getHandler("get-post-stats");
-      const result = (await handler({ postUrl: capturedPostUrn, cdpPort })) as {
+      const result = (await handler({ postUrl: capturedPostUrl, cdpPort })) as {
         isError?: boolean;
         content: { type: string; text: string }[];
       };

--- a/packages/e2e/src/get-post.e2e.test.ts
+++ b/packages/e2e/src/get-post.e2e.test.ts
@@ -23,11 +23,11 @@ import { createMockServer } from "@lhremote/mcp/testing";
  * Fetch a fresh post URN by scraping the feed.  Returns the URN of the
  * first feed post, or `undefined` when the feed returns no posts.
  */
-async function fetchPostUrnFromFeed(cdpPort: number): Promise<string | undefined> {
+async function fetchPostUrlFromFeed(cdpPort: number): Promise<string | undefined> {
   const { getFeed } = await import("@lhremote/core");
   const result = await getFeed({ cdpPort, count: 1 });
   const first = result.posts[0];
-  return first?.urn ?? undefined;
+  return first?.url ?? undefined;
 }
 
 describeE2E("get-post operation", () => {
@@ -35,7 +35,7 @@ describeE2E("get-post operation", () => {
   let port: number;
   let accountId: number;
   let cdpPort: number;
-  let capturedPostUrn: string | undefined;
+  let capturedPostUrl: string | undefined;
 
   beforeAll(async () => {
     const launched = await launchApp();
@@ -75,7 +75,7 @@ describeE2E("get-post operation", () => {
     );
 
     // Pre-fetch a live post URN from the feed
-    capturedPostUrn = await fetchPostUrnFromFeed(cdpPort);
+    capturedPostUrl = await fetchPostUrlFromFeed(cdpPort);
   }, 120_000);
 
   afterAll(async () => {
@@ -104,13 +104,13 @@ describeE2E("get-post operation", () => {
     });
 
     it("get-post --json returns post content", async () => {
-      assertDefined(capturedPostUrn, "No post URN — feed returned no posts");
+      assertDefined(capturedPostUrl, "No post URL — feed returned no posts");
 
       const stdoutSpy = vi
         .spyOn(process.stdout, "write")
         .mockReturnValue(true);
 
-      await handleGetPost(capturedPostUrn, { cdpPort, json: true });
+      await handleGetPost(capturedPostUrl, { cdpPort, json: true });
 
       expect(process.exitCode).toBeUndefined();
       expect(stdoutSpy).toHaveBeenCalled();
@@ -131,13 +131,13 @@ describeE2E("get-post operation", () => {
     }, 60_000);
 
     it("get-post prints human-friendly output", async () => {
-      assertDefined(capturedPostUrn, "No post URN — feed returned no posts");
+      assertDefined(capturedPostUrl, "No post URL — feed returned no posts");
 
       const stdoutSpy = vi
         .spyOn(process.stdout, "write")
         .mockReturnValue(true);
 
-      await handleGetPost(capturedPostUrn, { cdpPort });
+      await handleGetPost(capturedPostUrl, { cdpPort });
 
       expect(process.exitCode).toBeUndefined();
       expect(stdoutSpy).toHaveBeenCalled();
@@ -152,13 +152,13 @@ describeE2E("get-post operation", () => {
 
   describe("MCP tools", () => {
     it("get-post tool returns valid JSON", async () => {
-      assertDefined(capturedPostUrn, "No post URN — feed returned no posts");
+      assertDefined(capturedPostUrl, "No post URL — feed returned no posts");
 
       const { server, getHandler } = createMockServer();
       registerGetPost(server);
 
       const handler = getHandler("get-post");
-      const result = (await handler({ postUrl: capturedPostUrn, cdpPort })) as {
+      const result = (await handler({ postUrl: capturedPostUrl, cdpPort })) as {
         isError?: boolean;
         content: { type: string; text: string }[];
       };

--- a/packages/mcp/src/tools/get-feed.test.ts
+++ b/packages/mcp/src/tools/get-feed.test.ts
@@ -15,7 +15,6 @@ import { createMockServer } from "./testing/mock-server.js";
 const MOCK_RESULT = {
   posts: [
     {
-      urn: "urn:li:activity:123",
       url: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
       authorName: "Alice Smith",
       authorPublicId: null,

--- a/packages/mcp/src/tools/get-profile-activity.test.ts
+++ b/packages/mcp/src/tools/get-profile-activity.test.ts
@@ -16,7 +16,6 @@ const MOCK_ACTIVITY = {
   profilePublicId: "johndoe",
   posts: [
     {
-      urn: "urn:li:activity:7123456789012345678",
       text: "Excited to announce...",
       authorName: "John Doe",
       authorPublicId: null,

--- a/packages/mcp/src/tools/search-posts.test.ts
+++ b/packages/mcp/src/tools/search-posts.test.ts
@@ -17,7 +17,6 @@ const MOCK_RESULTS: SearchPostsOutput = {
   query: "AI agents",
   posts: [
     {
-      urn: "",
       url: "https://www.linkedin.com/feed/update/urn:li:activity:7123456789012345678/",
       authorName: "Jane Smith",
       authorHeadline: "CEO at Acme Corp",


### PR DESCRIPTION
## Summary

- Remove `urn` field from `FeedPost` type — URL (from clipboard capture) is now the primary post identifier
- Add `resolvePostDetailUrl()` helper that accepts both URLs and raw URNs for navigation
- Operations (`get-post`, `get-post-engagers`, `get-post-stats`) now navigate directly to URLs instead of extracting URNs first
- E2E helpers switch from `fetchPostUrnFromFeed` to `fetchPostUrlFromFeed`
- All unit tests updated (22 files, 1256 tests pass)

## Context

LinkedIn's SSR migration broke URN extraction from clipboard-captured URLs. The `FeedPost.urn` field was frequently empty, breaking all downstream operations. The clipboard URL was always available — this PR makes it the primary identifier.

## Test plan

- [x] `pnpm lint` passes (all 8 packages)
- [x] `pnpm test` passes (1256 unit tests, only pre-existing integration test failures)
- [ ] E2E: `get-feed`, `get-post`, `get-post-engagers`, `get-post-stats` — requires live LH

Closes #565
Closes #506

🤖 Generated with [Claude Code](https://claude.com/claude-code)