### PR TITLE
Add Copilot review instructions and enforce review cycle

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,51 @@
+# Copilot Review Instructions — lhremote
+
+> Automation toolkit for LinkedHelper.com built on Chrome DevTools Protocol (CDP).
+
+## Project Structure
+
+pnpm monorepo with 5 packages:
+
+| Package | Purpose |
+|---------|---------|
+| `packages/core` | CDP client, account/campaign services, feed parsing |
+| `packages/mcp` | Model Context Protocol server exposing core as MCP tools |
+| `packages/cli` | CLI entry point (`lhremote` command) |
+| `packages/lhremote` | Umbrella package re-exporting core + mcp + cli |
+| `packages/e2e` | E2E tests (not published, not run in CI) |
+
+## Naming Conventions
+
+| Element | Convention | Example |
+|---------|------------|---------|
+| Files | kebab-case | `campaign-format.ts` |
+| Classes | PascalCase | `CampaignService` |
+| Functions / methods | camelCase | `checkStatus()` |
+| Constants | UPPER_SNAKE_CASE | `DEFAULT_LAUNCHER_PORT` |
+
+Flag deviations from these conventions.
+
+## Commit Message Format
+
+Format: `(type) scope: description`
+
+Types: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`
+
+Commit messages must **not** contain issue references like `(#12)` or `fixes #12`.
+
+## Code Patterns
+
+- All CDP communication goes through `CDPClient` — never use raw WebSocket calls.
+- Prefer `async`/`await` over raw Promise chains.
+- For runtime validation of external data, follow the existing approach per package: use `zod` schemas in packages that depend on it (e.g. `packages/mcp`); use established type guards elsewhere.
+- Error classes extend domain-specific base errors, not generic `Error`.
+- Avoid `any` — use `unknown` with narrowing or explicit types.
+
+## What to Flag
+
+- Direct WebSocket usage bypassing `CdpClient`.
+- `any` types without justification.
+- Missing error handling on CDP calls.
+- Test files without assertions (empty or no-op tests).
+- Duplicated helpers that exist in `@lhremote/core/testing`.
+- Magic numbers or strings without named constants.

--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -1,0 +1,21 @@
+---
+applyTo: "**/*.test.ts,**/*.integration.test.ts"
+---
+
+# Test Review Instructions
+
+## Three-Tier Testing Model
+
+| Tier | Suffix | Runs In | Uses |
+|------|--------|---------|------|
+| 1 — Unit | `*.test.ts` | CI | Mocked CDP, no external deps |
+| 2 — Integration | `*.integration.test.ts` | CI | Real headless Chromium via playwright-core |
+| 3 — E2E | `*.test.ts` in `packages/e2e/` | Local only | Full LinkedHelper app |
+
+## Rules
+
+- Integration tests **must** use the `*.integration.test.ts` suffix. Flag any test using real Chromium without this suffix.
+- E2E tests **must** assert preconditions explicitly — flag patterns like `if (accounts.length > 0)` that silently skip when preconditions fail. Use `resolveAccountId(port)` which throws.
+- Shared helpers (`resolveAccountId`, `forceStopInstance`, `assertDefined`, `getE2EPersonId`) are exported from `@lhremote/core/testing` — flag local duplicates.
+- Every `describe` / `it` block must contain at least one Vitest assertion (e.g. `expect(value).toBe(...)`, `expect(fn).toThrow(...)`, or `await expect(promise).rejects.toThrow(...)`). Flag empty or no-op tests.
+- CDP mocks should reuse established patterns (see `packages/core/src/cdp/client.test.ts`) — flag new hand-rolled mock WebSockets that diverge from the existing approach.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,19 @@ Do **not** add issue numbers (e.g. `(#12)`) to commit messages. GitHub links PRs
 - Never push directly to `main` — always create a feature/fix branch, even for small changes (`enforce_admins` is enabled)
 - Run `pnpm lint` before pushing
 - PR body must include `Closes #N` to link the related issue
-- Use Copilot review; address feedback and re-request until no actionable comments remain
+
+#### Copilot Review Cycle
+
+After pushing a PR, follow this cycle until Copilot has no actionable comments:
+
+1. **Request** Copilot review (if not auto-requested by ruleset)
+2. **Wait** for Copilot to post its review
+3. **Address** every Copilot comment systematically
+4. **Push** fixes
+5. **Re-request** Copilot review
+6. **Repeat** from step 2 until Copilot returns no actionable comments
+
+Do **not** dismiss or ignore Copilot feedback. Every comment must be explicitly addressed (fixed, rejected with rationale, or deferred with tracking).
 
 ## Testing
 


### PR DESCRIPTION
## Summary

- Add `.github/copilot-instructions.md` with project-wide review guidance (naming conventions, monorepo structure, code patterns, what to flag)
- Add `.github/instructions/tests.instructions.md` with path-specific test review rules (3-tier model, integration suffix, precondition assertions, shared helpers)
- Update `CLAUDE.md` PR Workflow to replace the passive Copilot mention with an explicit, enforceable review cycle (request → wait → address via `/github-pr-respond` → push fixes → re-request → repeat)

## Test plan

- [ ] Verify `.github/copilot-instructions.md` is under 4,000 characters (Copilot limit)
- [ ] Open a test PR to confirm Copilot reads the instructions
- [ ] Verify path-specific test instructions apply to `*.test.ts` and `*.integration.test.ts` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)