### PR TITLE
Fix ScrapeMessagingHistory action type rejection

### DIFF
--- a/packages/core/src/operations/scrape-messaging-history.test.ts
+++ b/packages/core/src/operations/scrape-messaging-history.test.ts
@@ -11,14 +11,24 @@ vi.mock("../services/instance-context.js", () => ({
   withInstanceDatabase: vi.fn(),
 }));
 
+vi.mock("../services/campaign.js", () => ({
+  CampaignService: vi.fn(),
+}));
+
 vi.mock("../db/index.js", () => ({
   MessageRepository: vi.fn(),
+  ProfileRepository: vi.fn(),
+}));
+
+vi.mock("../utils/delay.js", () => ({
+  delay: vi.fn().mockResolvedValue(undefined),
 }));
 
 import type { InstanceDatabaseContext } from "../services/instance-context.js";
 import { resolveAccount } from "../services/account-resolution.js";
 import { withInstanceDatabase } from "../services/instance-context.js";
-import { MessageRepository } from "../db/index.js";
+import { CampaignService } from "../services/campaign.js";
+import { MessageRepository, ProfileRepository } from "../db/index.js";
 import { scrapeMessagingHistory } from "./scrape-messaging-history.js";
 
 const MOCK_STATS = {
@@ -28,7 +38,28 @@ const MOCK_STATS = {
   latestMessage: "2026-01-15T00:00:00Z",
 };
 
-const mockInstance = { executeAction: vi.fn().mockResolvedValue(undefined) };
+const MOCK_PROFILES = [
+  { id: 100, externalIds: [{ typeGroup: "public", externalId: "john-doe" }] },
+  { id: 200, externalIds: [{ typeGroup: "public", externalId: "jane-doe" }] },
+];
+
+const mockCampaignService = {
+  create: vi.fn().mockResolvedValue({ id: 42 }),
+  importPeopleFromUrls: vi.fn().mockResolvedValue({
+    actionId: 1,
+    successful: 2,
+    alreadyInQueue: 0,
+    alreadyProcessed: 0,
+    failed: 0,
+  }),
+  start: vi.fn().mockResolvedValue(undefined),
+  getStatus: vi.fn().mockResolvedValue({
+    runnerState: "idle",
+    actionCounts: [{ queued: 0, processed: 0, successful: 2, failed: 0 }],
+  }),
+  stop: vi.fn().mockResolvedValue(undefined),
+  hardDelete: vi.fn(),
+};
 
 function setupMocks() {
   vi.mocked(resolveAccount).mockResolvedValue(1);
@@ -37,10 +68,20 @@ function setupMocks() {
     async (_cdpPort, _accountId, callback) =>
       callback({
         accountId: 1,
-        instance: mockInstance,
+        instance: {},
         db: {},
       } as unknown as InstanceDatabaseContext),
   );
+
+  vi.mocked(CampaignService).mockImplementation(function () {
+    return mockCampaignService as unknown as CampaignService;
+  });
+
+  vi.mocked(ProfileRepository).mockImplementation(function () {
+    return {
+      findByIds: vi.fn().mockReturnValue(MOCK_PROFILES),
+    } as unknown as ProfileRepository;
+  });
 
   vi.mocked(MessageRepository).mockImplementation(function () {
     return {
@@ -77,7 +118,7 @@ describe("scrapeMessagingHistory", () => {
     expect(result.stats).toBe(MOCK_STATS);
   });
 
-  it("calls instance.executeAction with ScrapeMessagingHistory and personIds", async () => {
+  it("creates ephemeral campaign with ScrapeMessagingHistory action", async () => {
     setupMocks();
 
     await scrapeMessagingHistory({
@@ -85,10 +126,94 @@ describe("scrapeMessagingHistory", () => {
       cdpPort: 9222,
     });
 
-    expect(mockInstance.executeAction).toHaveBeenCalledWith(
-      "ScrapeMessagingHistory",
-      { personIds: [100, 200] },
+    expect(mockCampaignService.create).toHaveBeenCalledWith({
+      name: expect.stringContaining("[ephemeral] ScrapeMessagingHistory"),
+      actions: [{
+        name: "ScrapeMessagingHistory",
+        actionType: "ScrapeMessagingHistory",
+        coolDown: 0,
+        maxActionResultsPerIteration: 2,
+      }],
+    });
+  });
+
+  it("resolves personIds to LinkedIn URLs and imports them", async () => {
+    setupMocks();
+
+    await scrapeMessagingHistory({
+      personIds: [100, 200],
+      cdpPort: 9222,
+    });
+
+    expect(mockCampaignService.importPeopleFromUrls).toHaveBeenCalledWith(
+      42,
+      [
+        "https://www.linkedin.com/in/john-doe",
+        "https://www.linkedin.com/in/jane-doe",
+      ],
     );
+  });
+
+  it("starts campaign and polls for completion", async () => {
+    setupMocks();
+
+    await scrapeMessagingHistory({
+      personIds: [100, 200],
+      cdpPort: 9222,
+    });
+
+    expect(mockCampaignService.start).toHaveBeenCalledWith(42, []);
+    expect(mockCampaignService.getStatus).toHaveBeenCalledWith(42);
+  });
+
+  it("cleans up campaign after success", async () => {
+    setupMocks();
+
+    await scrapeMessagingHistory({
+      personIds: [100, 200],
+      cdpPort: 9222,
+    });
+
+    expect(mockCampaignService.stop).toHaveBeenCalledWith(42);
+    expect(mockCampaignService.hardDelete).toHaveBeenCalledWith(42);
+  });
+
+  it("cleans up campaign after failure", async () => {
+    setupMocks();
+    mockCampaignService.start.mockRejectedValueOnce(new Error("start failed"));
+
+    await expect(
+      scrapeMessagingHistory({ personIds: [100, 200], cdpPort: 9222 }),
+    ).rejects.toThrow("start failed");
+
+    expect(mockCampaignService.stop).toHaveBeenCalledWith(42);
+    expect(mockCampaignService.hardDelete).toHaveBeenCalledWith(42);
+  });
+
+  it("throws when person not found in database", async () => {
+    setupMocks();
+    vi.mocked(ProfileRepository).mockImplementation(function () {
+      return {
+        findByIds: vi.fn().mockReturnValue([null]),
+      } as unknown as ProfileRepository;
+    });
+
+    await expect(
+      scrapeMessagingHistory({ personIds: [999], cdpPort: 9222 }),
+    ).rejects.toThrow("Person 999 not found in database");
+  });
+
+  it("throws when person has no LinkedIn public ID", async () => {
+    setupMocks();
+    vi.mocked(ProfileRepository).mockImplementation(function () {
+      return {
+        findByIds: vi.fn().mockReturnValue([{ id: 100, externalIds: [] }]),
+      } as unknown as ProfileRepository;
+    });
+
+    await expect(
+      scrapeMessagingHistory({ personIds: [100], cdpPort: 9222 }),
+    ).rejects.toThrow("Person 100 has no LinkedIn public ID");
   });
 
   it("passes instanceTimeout to withInstanceDatabase", async () => {
@@ -154,15 +279,7 @@ describe("scrapeMessagingHistory", () => {
   });
 
   it("propagates MessageRepository errors", async () => {
-    vi.mocked(resolveAccount).mockResolvedValue(1);
-    vi.mocked(withInstanceDatabase).mockImplementation(
-      async (_cdpPort, _accountId, callback) =>
-        callback({
-          accountId: 1,
-          instance: mockInstance,
-          db: {},
-        } as unknown as InstanceDatabaseContext),
-    );
+    setupMocks();
     vi.mocked(MessageRepository).mockImplementation(function () {
       return {
         getMessageStats: vi.fn().mockImplementation(() => {

--- a/packages/core/src/operations/scrape-messaging-history.ts
+++ b/packages/core/src/operations/scrape-messaging-history.ts
@@ -4,9 +4,18 @@
 import type { MessageStats } from "../types/index.js";
 import { resolveAccount } from "../services/account-resolution.js";
 import { withInstanceDatabase } from "../services/instance-context.js";
-import { MessageRepository } from "../db/index.js";
+import { CampaignService } from "../services/campaign.js";
+import { CampaignTimeoutError } from "../services/errors.js";
+import { MessageRepository, ProfileRepository } from "../db/index.js";
 import { DEFAULT_CDP_PORT } from "../constants.js";
+import { delay } from "../utils/delay.js";
 import type { ConnectionOptions } from "./types.js";
+
+/** Timeout for ephemeral campaign completion (5 minutes). */
+const CAMPAIGN_TIMEOUT = 300_000;
+
+/** Interval between campaign status polls (2 seconds). */
+const POLL_INTERVAL = 2_000;
 
 export interface ScrapeMessagingHistoryInput extends ConnectionOptions {
   readonly personIds: number[];
@@ -33,17 +42,77 @@ export async function scrapeMessagingHistory(
   });
 
   return withInstanceDatabase(cdpPort, accountId, async ({ instance, db }) => {
-    await instance.executeAction("ScrapeMessagingHistory", {
-      personIds: input.personIds,
+    const campaignService = new CampaignService(instance, db);
+    const profileRepo = new ProfileRepository(db);
+
+    // Resolve person IDs to LinkedIn profile URLs
+    const profiles = profileRepo.findByIds(input.personIds);
+    const linkedInUrls: string[] = [];
+    for (let i = 0; i < input.personIds.length; i++) {
+      const personId = input.personIds[i] as number;
+      const profile = profiles[i];
+      if (!profile) {
+        throw new Error(`Person ${String(personId)} not found in database`);
+      }
+      const publicId = profile.externalIds.find((e) => e.typeGroup === "public");
+      if (!publicId) {
+        throw new Error(`Person ${String(personId)} has no LinkedIn public ID`);
+      }
+      linkedInUrls.push(`https://www.linkedin.com/in/${publicId.externalId}`);
+    }
+
+    // Create ephemeral campaign with ScrapeMessagingHistory action
+    const campaign = await campaignService.create({
+      name: `[ephemeral] ScrapeMessagingHistory ${new Date().toISOString()}`,
+      actions: [{
+        name: "ScrapeMessagingHistory",
+        actionType: "ScrapeMessagingHistory",
+        coolDown: 0,
+        maxActionResultsPerIteration: input.personIds.length,
+      }],
     });
 
-    const repo = new MessageRepository(db);
-    const stats = repo.getMessageStats();
+    try {
+      // Import target persons into campaign
+      await campaignService.importPeopleFromUrls(campaign.id, linkedInUrls);
 
-    return {
-      success: true as const,
-      actionType: "ScrapeMessagingHistory" as const,
-      stats,
-    };
-  }, { instanceTimeout: 300_000 });
+      // Start campaign runner
+      await campaignService.start(campaign.id, []);
+
+      // Poll for completion (runner idle + no queued persons)
+      const deadline = Date.now() + CAMPAIGN_TIMEOUT;
+      let completed = false;
+      while (Date.now() < deadline) {
+        const status = await campaignService.getStatus(campaign.id);
+        const counts = status.actionCounts[0];
+        if (status.runnerState === "idle" && counts && counts.queued === 0) {
+          completed = true;
+          break;
+        }
+        const remaining = deadline - Date.now();
+        if (remaining <= 0) break;
+        await delay(Math.min(POLL_INTERVAL, remaining));
+      }
+
+      if (!completed) {
+        throw new CampaignTimeoutError(
+          `ScrapeMessagingHistory did not complete within ${String(CAMPAIGN_TIMEOUT)}ms`,
+          campaign.id,
+        );
+      }
+
+      // Read message stats from database
+      const repo = new MessageRepository(db);
+      const stats = repo.getMessageStats();
+
+      return {
+        success: true as const,
+        actionType: "ScrapeMessagingHistory" as const,
+        stats,
+      };
+    } finally {
+      try { await campaignService.stop(campaign.id); } catch { /* best-effort cleanup */ }
+      try { campaignService.hardDelete(campaign.id); } catch { /* best-effort cleanup */ }
+    }
+  }, { instanceTimeout: CAMPAIGN_TIMEOUT });
 }


### PR DESCRIPTION
## Summary

- Switch `scrapeMessagingHistory` from `executeSingleAction` (SingleActionController) to ephemeral campaign execution (CampaignController), which is the correct dispatch path for campaign actions like `ScrapeMessagingHistory`
- Resolve person IDs to LinkedIn profile URLs via `ProfileRepository`, create a temporary campaign, import targets, start the runner, poll for completion, then read stats and clean up
- Add new test coverage for campaign lifecycle (create, import, start, poll, cleanup on success/failure, profile resolution errors)

Closes #512

## Test plan

- [x] All 15 unit tests pass for `scrape-messaging-history.test.ts`
- [x] Full test suite passes (1263/1263 non-integration tests)
- [x] Lint clean
- [x] Build clean
- [ ] E2E: `pnpm test:e2e:file scrape-messaging-history` (requires local LinkedHelper)

🤖 Generated with [Claude Code](https://claude.com/claude-code)