### PR TITLE
Add dismissInstanceDialog method to LauncherService

### DIFF
--- a/packages/core/src/services/launcher.test.ts
+++ b/packages/core/src/services/launcher.test.ts
@@ -362,4 +362,39 @@ describe("LauncherService", () => {
       expect(listCall?.[1]).toBe(true);
     });
   });
+
+  describe("dismissInstanceDialog", () => {
+    it("evaluates the closeInstanceDialog expression", async () => {
+      await service.connect();
+
+      await service.dismissInstanceDialog(42, "dlg-1", "btn-ok");
+
+      expect(mockEvaluate).toHaveBeenCalledWith(
+        expect.stringContaining("closeInstanceDialog"),
+        true,
+        undefined,
+      );
+      expect(mockEvaluate).toHaveBeenCalledWith(
+        expect.stringContaining("42"),
+        true,
+        undefined,
+      );
+      expect(mockEvaluate).toHaveBeenCalledWith(
+        expect.stringContaining('"dlg-1"'),
+        true,
+        undefined,
+      );
+      expect(mockEvaluate).toHaveBeenCalledWith(
+        expect.stringContaining('"btn-ok"'),
+        true,
+        undefined,
+      );
+    });
+
+    it("throws ServiceError when not connected", async () => {
+      await expect(
+        service.dismissInstanceDialog(42, "dlg-1", "btn-ok"),
+      ).rejects.toThrow(ServiceError);
+    });
+  });
 });

--- a/packages/core/src/services/launcher.ts
+++ b/packages/core/src/services/launcher.ts
@@ -404,6 +404,40 @@ export class LauncherService {
   }
 
   /**
+   * Dismiss an active dialog issue on a LinkedHelper instance.
+   *
+   * Dialogs appear as "issues" on the instance (e.g. when the launcher
+   * sends a close command).  Each dialog exposes one or more control
+   * buttons identified by `buttonId`.  This method programmatically
+   * clicks the specified button to dismiss the dialog.
+   *
+   * @param liId       LinkedIn account ID that owns the instance.
+   * @param dialogId   The dialog issue ID (from {@link InstanceIssue}).
+   * @param buttonId   The control button ID to click (from `DialogIssueData.options.controls[].id`).
+   */
+  async dismissInstanceDialog(
+    liId: number,
+    dialogId: string,
+    buttonId: string,
+  ): Promise<void> {
+    const client = this.ensureConnected();
+
+    await this.launcherEvaluate(
+      client,
+      `(async () => {
+        const remote = require('@electron/remote');
+        const mainWindow = remote.getGlobal('mainWindow');
+        return await mainWindow.instanceManager.closeInstanceDialog(
+          ${String(liId)},
+          ${JSON.stringify(dialogId)},
+          { buttonId: ${JSON.stringify(buttonId)} }
+        );
+      })()`,
+      true,
+    );
+  }
+
+  /**
    * Check the overall UI health of a LinkedHelper instance.
    *
    * Combines instance issue queries with popup overlay detection

--- a/packages/e2e/src/dismiss-instance-dialog.e2e.test.ts
+++ b/packages/e2e/src/dismiss-instance-dialog.e2e.test.ts
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  describeE2E,
+  forceStopInstance,
+  launchApp,
+  quitApp,
+  resolveAccountId,
+  retryAsync,
+} from "@lhremote/core/testing";
+import {
+  type AppService,
+  type InstanceIssue,
+  LauncherService,
+  startInstanceWithRecovery,
+} from "@lhremote/core";
+
+describeE2E("dismissInstanceDialog", () => {
+  let app: AppService;
+  let port: number;
+  let accountId: number;
+
+  beforeAll(async () => {
+    const launched = await launchApp();
+    app = launched.app;
+    port = launched.port;
+    accountId = await resolveAccountId(port);
+  }, 120_000);
+
+  afterAll(async () => {
+    const launcher = new LauncherService(port);
+    try {
+      await launcher.connect();
+      await forceStopInstance(launcher, accountId, port);
+    } catch {
+      // Best-effort cleanup
+    } finally {
+      launcher.disconnect();
+    }
+    await quitApp(app);
+  }, 60_000);
+
+  describe("core", () => {
+    let launcher: LauncherService;
+
+    beforeAll(async () => {
+      launcher = new LauncherService(port);
+      await retryAsync(() => launcher.connect(), { retries: 3, delay: 1_000 });
+    }, 15_000);
+
+    afterAll(async () => {
+      await forceStopInstance(launcher, accountId, port);
+      launcher.disconnect();
+    }, 30_000);
+
+    it("does not hang when called with a non-existent dialogId", async () => {
+      // AC2: calling with a non-existent dialogId should complete without hanging.
+      // This verifies the CDP call resolves even when no dialog matches.
+      await expect(
+        launcher.dismissInstanceDialog(accountId, "non-existent-dialog", "btn-ok"),
+      ).resolves.toBeUndefined();
+    }, 30_000);
+
+    it("dismisses a closing dialog after stopInstance when one appears", async () => {
+      // Start the instance
+      await startInstanceWithRecovery(launcher, accountId, port);
+
+      // Stop the instance — may or may not trigger a closing dialog
+      await launcher.stopInstance(accountId);
+
+      // Poll for the dialog issue to appear (dialog is not guaranteed)
+      let dialogIssue: InstanceIssue | undefined;
+      for (let attempt = 0; attempt < 40; attempt++) {
+        const issues = await launcher.getInstanceIssues(accountId);
+        dialogIssue = issues.find((i) => i.type === "dialog");
+        if (dialogIssue) break;
+        await new Promise((r) => setTimeout(r, 500));
+      }
+
+      // The closing dialog does not appear deterministically — it depends
+      // on internal LH instance state and timing.  When absent, we verify
+      // the instance stopped without a dialog (still a valid outcome).
+      if (!dialogIssue) {
+        const issues = await launcher.getInstanceIssues(accountId);
+        expect(issues.filter((i) => i.type === "dialog")).toHaveLength(0);
+        console.log("  no closing dialog appeared — instance closed cleanly");
+        return;
+      }
+
+      expect(dialogIssue.type).toBe("dialog");
+      expect(dialogIssue.data.options.controls.length).toBeGreaterThan(0);
+
+      const dialogId = dialogIssue.id;
+      const firstControl = dialogIssue.data.options.controls[0];
+      expect(firstControl).toBeDefined();
+      const buttonId = firstControl.id;
+
+      // Dismiss the dialog
+      await launcher.dismissInstanceDialog(accountId, dialogId, buttonId);
+
+      // Verify dialog was dismissed — issues should no longer contain it
+      const issuesAfter = await launcher.getInstanceIssues(accountId);
+      const stillPresent = issuesAfter.find((i) => i.id === dialogId);
+      expect(stillPresent).toBeUndefined();
+    }, 120_000);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `dismissInstanceDialog(liId, dialogId, buttonId)` method to `LauncherService` that dismisses an instance dialog via `mainWindow.instanceManager.closeInstanceDialog()` IPC call
- Add unit tests verifying CDP expression and not-connected error handling
- Add E2E test covering both ACs: non-existent dialogId completes without hanging, and dialog dismissal after stopInstance when a dialog appears

Closes #571

## Test plan

- [x] Unit tests: `packages/core/src/services/launcher.test.ts` — 24 tests pass
- [x] Lint: `pnpm lint` passes clean
- [x] E2E test: `packages/e2e/src/dismiss-instance-dialog.e2e.test.ts` — 2 tests pass locally
  - AC2 (non-existent dialogId): verified CDP call completes without hanging
  - AC1 (active dialog dismiss): test exercises when dialog appears; gracefully skips when instance closes without dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)