### PR TITLE
Add dialog-aware instance stop to LauncherService

### DIFF
--- a/packages/core/src/services/launcher.test.ts
+++ b/packages/core/src/services/launcher.test.ts
@@ -397,4 +397,122 @@ describe("LauncherService", () => {
       ).rejects.toThrow(ServiceError);
     });
   });
+
+  describe("stopInstanceWithDialogDismissal", () => {
+    it("calls stopInstance then polls and dismisses a dialog", async () => {
+      await service.connect();
+
+      let pollCount = 0;
+      mockEvaluate.mockImplementation((expression: string) => {
+        if (expression === "typeof require === 'function'") {
+          return Promise.resolve(true);
+        }
+        if (expression.includes("electronStore?.get")) {
+          return Promise.resolve(true);
+        }
+        // stopInstance call
+        if (expression.includes("stopInstance")) {
+          return Promise.resolve(undefined);
+        }
+        // getInstanceIssues — return a dialog on the second poll
+        if (expression.includes("issues?.items")) {
+          pollCount++;
+          if (pollCount >= 2) {
+            return Promise.resolve([
+              {
+                type: "dialog",
+                id: "dlg-close",
+                data: {
+                  id: "dlg-close",
+                  options: {
+                    message: "Are you sure?",
+                    controls: [{ id: "btn-yes", text: "Yes" }],
+                  },
+                },
+              },
+            ]);
+          }
+          return Promise.resolve([]);
+        }
+        // dismissInstanceDialog call
+        if (expression.includes("closeInstanceDialog")) {
+          return Promise.resolve(undefined);
+        }
+        return Promise.resolve(undefined);
+      });
+
+      await service.stopInstanceWithDialogDismissal(42);
+
+      // Verify stopInstance was called
+      expect(mockEvaluate).toHaveBeenCalledWith(
+        expect.stringContaining("stopInstance"),
+        true,
+        undefined,
+      );
+      // Verify dismissInstanceDialog was called with the dialog's first button
+      expect(mockEvaluate).toHaveBeenCalledWith(
+        expect.stringContaining("closeInstanceDialog"),
+        true,
+        undefined,
+      );
+      expect(mockEvaluate).toHaveBeenCalledWith(
+        expect.stringContaining('"dlg-close"'),
+        true,
+        undefined,
+      );
+      expect(mockEvaluate).toHaveBeenCalledWith(
+        expect.stringContaining('"btn-yes"'),
+        true,
+        undefined,
+      );
+    });
+
+    it("returns normally when no dialog appears within timeout", async () => {
+      await service.connect();
+
+      mockEvaluate.mockImplementation((expression: string) => {
+        if (expression === "typeof require === 'function'") {
+          return Promise.resolve(true);
+        }
+        if (expression.includes("electronStore?.get")) {
+          return Promise.resolve(true);
+        }
+        if (expression.includes("stopInstance")) {
+          return Promise.resolve(undefined);
+        }
+        // Always return empty issues
+        if (expression.includes("issues?.items")) {
+          return Promise.resolve([]);
+        }
+        return Promise.resolve(undefined);
+      });
+
+      // Use fake timers to avoid waiting 10s
+      vi.useFakeTimers();
+      const promise = service.stopInstanceWithDialogDismissal(42);
+
+      // Advance past the polling timeout
+      await vi.advanceTimersByTimeAsync(11_000);
+      await promise;
+      vi.useRealTimers();
+
+      // Verify stopInstance was called but dismissInstanceDialog was not
+      expect(mockEvaluate).toHaveBeenCalledWith(
+        expect.stringContaining("stopInstance"),
+        true,
+        undefined,
+      );
+      expect(mockEvaluate).not.toHaveBeenCalledWith(
+        expect.stringContaining("closeInstanceDialog"),
+        expect.anything(),
+        expect.anything(),
+      );
+    });
+
+    it("throws ServiceError when not connected", async () => {
+      await expect(
+        service.stopInstanceWithDialogDismissal(42),
+      ).rejects.toThrow(ServiceError);
+    });
+  });
 });

--- a/packages/core/src/services/launcher.ts
+++ b/packages/core/src/services/launcher.ts
@@ -438,6 +438,38 @@ export class LauncherService {
   }
 
   /**
+   * Stop a running instance, automatically dismissing the confirmation
+   * dialog that LinkedHelper may show.
+   *
+   * Calls {@link stopInstance}, then polls {@link getInstanceIssues} at
+   * 500 ms intervals for up to 10 s.  When a dialog issue appears, its
+   * first control button is clicked via {@link dismissInstanceDialog}.
+   * If no dialog surfaces within the timeout the method returns normally.
+   *
+   * @param liId  LinkedIn account ID that owns the instance.
+   */
+  async stopInstanceWithDialogDismissal(liId: number): Promise<void> {
+    await this.stopInstance(liId);
+
+    const POLL_INTERVAL = 500;
+    const POLL_TIMEOUT = 10_000;
+    const deadline = Date.now() + POLL_TIMEOUT;
+
+    while (Date.now() < deadline) {
+      const issues = await this.getInstanceIssues(liId);
+      const dialog = issues.find((i) => i.type === "dialog");
+      if (dialog) {
+        const firstControl = dialog.data.options.controls[0];
+        if (firstControl) {
+          await this.dismissInstanceDialog(liId, dialog.id, firstControl.id);
+        }
+        return;
+      }
+      await new Promise((r) => setTimeout(r, POLL_INTERVAL));
+    }
+  }
+
+  /**
    * Check the overall UI health of a LinkedHelper instance.
    *
    * Combines instance issue queries with popup overlay detection

--- a/packages/e2e/src/stop-instance-with-dialog-dismissal.e2e.test.ts
+++ b/packages/e2e/src/stop-instance-with-dialog-dismissal.e2e.test.ts
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  describeE2E,
+  forceStopInstance,
+  launchApp,
+  quitApp,
+  resolveAccountId,
+  retryAsync,
+} from "@lhremote/core/testing";
+import {
+  type AppService,
+  LauncherService,
+  startInstanceWithRecovery,
+} from "@lhremote/core";
+
+describeE2E("stopInstanceWithDialogDismissal", () => {
+  let app: AppService;
+  let port: number;
+  let accountId: number;
+
+  beforeAll(async () => {
+    const launched = await launchApp();
+    app = launched.app;
+    port = launched.port;
+    accountId = await resolveAccountId(port);
+  }, 120_000);
+
+  afterAll(async () => {
+    const launcher = new LauncherService(port);
+    try {
+      await launcher.connect();
+      await forceStopInstance(launcher, accountId, port);
+    } catch {
+      // Best-effort cleanup
+    } finally {
+      launcher.disconnect();
+    }
+    await quitApp(app);
+  }, 60_000);
+
+  describe("core", () => {
+    let launcher: LauncherService;
+
+    beforeAll(async () => {
+      launcher = new LauncherService(port);
+      await retryAsync(() => launcher.connect(), { retries: 3, delay: 1_000 });
+    }, 15_000);
+
+    afterAll(async () => {
+      await forceStopInstance(launcher, accountId, port);
+      launcher.disconnect();
+    }, 30_000);
+
+    it("stops a running instance and handles the closing dialog", async () => {
+      // Start the instance
+      await startInstanceWithRecovery(launcher, accountId, port);
+
+      // Stop with dialog dismissal — should handle the "Are you sure?"
+      // dialog automatically if it appears, or return cleanly if not.
+      await launcher.stopInstanceWithDialogDismissal(accountId);
+
+      // After returning, no dialog issues should remain
+      const issues = await launcher.getInstanceIssues(accountId);
+      const remainingDialogs = issues.filter((i) => i.type === "dialog");
+      expect(remainingDialogs).toHaveLength(0);
+    }, 120_000);
+
+    it("completes without error on an already-stopped instance", async () => {
+      // Call on an instance that is not running — should not throw
+      await expect(
+        launcher.stopInstanceWithDialogDismissal(accountId),
+      ).resolves.toBeUndefined();
+    }, 30_000);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `stopInstanceWithDialogDismissal(liId)` to `LauncherService` that calls `stopInstance`, then polls `getInstanceIssues` at 500 ms intervals for up to 10 s and auto-dismisses the closing dialog
- Add unit tests covering dialog polling/dismissal, timeout without dialog, and not-connected error
- Add E2E test exercising the method against a real LinkedHelper instance

Closes #572

## Test plan
- [x] Unit tests pass (`pnpm --filter @lhremote/core test -- --run launcher.test` — 27 tests)
- [x] Lint passes (`pnpm lint`)
- [ ] E2E test (`pnpm test:e2e:file stop-instance-with-dialog-dismissal`) — requires local LinkedHelper

🤖 Generated with [Claude Code](https://claude.com/claude-code)