### PR TITLE
(fix) core: use short moveToSuccessfulAfterMs for ephemeral CheckForReplies

### DIFF
--- a/packages/core/src/operations/check-replies.test.ts
+++ b/packages/core/src/operations/check-replies.test.ts
@@ -168,9 +168,9 @@ describe("checkReplies", () => {
         coolDown: 0,
         maxActionResultsPerIteration: 2,
         actionSettings: {
-          moveToSuccessfulAfterMs: 86_400_000,
+          moveToSuccessfulAfterMs: 1_000,
           treatMessageAcceptedAsReply: false,
-          keepInQueueIfRequestIsNotAccepted: true,
+          keepInQueueIfRequestIsNotAccepted: false,
         },
       }],
     });

--- a/packages/core/src/operations/check-replies.ts
+++ b/packages/core/src/operations/check-replies.ts
@@ -75,9 +75,9 @@ export async function checkReplies(
         coolDown: 0,
         maxActionResultsPerIteration: input.personIds.length,
         actionSettings: {
-          moveToSuccessfulAfterMs: 86_400_000,
+          moveToSuccessfulAfterMs: 1_000,
           treatMessageAcceptedAsReply: false,
-          keepInQueueIfRequestIsNotAccepted: true,
+          keepInQueueIfRequestIsNotAccepted: false,
         },
       }],
     });


### PR DESCRIPTION
## Summary

- Reduce `moveToSuccessfulAfterMs` from 24 hours to 1 second for the ephemeral CheckForReplies campaign — the one-shot check completes in seconds, so there's no need to wait 24 hours before marking a person as successful
- Disable `keepInQueueIfRequestIsNotAccepted` to prevent stalling on unaccepted connection requests during ephemeral checks

These settings caused the campaign poll loop to never complete within the 5-minute timeout, as LH would wait 24 hours before marking the person as successful if no reply was found.

## Test plan

- [x] Unit tests pass (check-replies.test.ts updated to match new settings)
- [x] Lint passes
- [ ] E2E: `check-replies` completes within timeout (blocked by separate LH CDP responsiveness issue affecting all ephemeral campaign operations)

Closes #513

🤖 Generated with [Claude Code](https://claude.com/claude-code)