### PR TITLE
(fix) core: prevent health check infinite recursion and fix campaign runner start

### DIFF
--- a/packages/core/src/operations/check-replies.ts
+++ b/packages/core/src/operations/check-replies.ts
@@ -92,16 +92,8 @@ export async function checkReplies(
       // Import target persons into campaign
       await campaignService.importPeopleFromUrls(campaign.id, linkedInUrls);
 
-      if (input.startRunner) {
-        // Caller manages runner lifecycle: just unpause our campaign
-        // and start the runner via the high-level RPC — it will pick
-        // up the unpaused campaign with queued people.
-        await campaignService.unpauseCampaign(campaign.id);
-        await campaignService.startRunner();
-      } else {
-        // Default path: wait for idle runner, unpause, start
-        await campaignService.start(campaign.id, []);
-      }
+      // Start the campaign: wait for idle, unpause, start runner
+      await campaignService.start(campaign.id, []);
 
       // Poll for completion (runner idle + no queued persons)
       const deadline = Date.now() + CAMPAIGN_TIMEOUT;
@@ -145,9 +137,7 @@ export async function checkReplies(
     } finally {
       try { await campaignService.stop(campaign.id); } catch { /* best-effort cleanup */ }
       try { campaignService.hardDelete(campaign.id); } catch { /* best-effort cleanup */ }
-      if (input.startRunner) {
-        try { await campaignService.stopRunner(); } catch { /* best-effort cleanup */ }
-      }
+      try { await campaignService.stopRunner(); } catch { /* best-effort cleanup */ }
       if (pausedCampaignIds.length > 0) {
         try { await campaignService.unpauseCampaigns(pausedCampaignIds); } catch { /* best-effort restore */ }
       }

--- a/packages/core/src/operations/scrape-messaging-history.ts
+++ b/packages/core/src/operations/scrape-messaging-history.ts
@@ -84,15 +84,8 @@ export async function scrapeMessagingHistory(
       // Import target persons into campaign
       await campaignService.importPeopleFromUrls(campaign.id, linkedInUrls);
 
-      if (input.startRunner) {
-        // Caller manages runner lifecycle: just unpause our campaign
-        // and start the runner via the high-level RPC.
-        await campaignService.unpauseCampaign(campaign.id);
-        await campaignService.startRunner();
-      } else {
-        // Default path: wait for idle runner, unpause, start
-        await campaignService.start(campaign.id, []);
-      }
+      // Start the campaign: wait for idle, unpause, start runner
+      await campaignService.start(campaign.id, []);
 
       // Poll for completion (runner idle + no queued persons)
       const deadline = Date.now() + CAMPAIGN_TIMEOUT;
@@ -128,9 +121,7 @@ export async function scrapeMessagingHistory(
     } finally {
       try { await campaignService.stop(campaign.id); } catch { /* best-effort cleanup */ }
       try { campaignService.hardDelete(campaign.id); } catch { /* best-effort cleanup */ }
-      if (input.startRunner) {
-        try { await campaignService.stopRunner(); } catch { /* best-effort cleanup */ }
-      }
+      try { await campaignService.stopRunner(); } catch { /* best-effort cleanup */ }
       if (pausedCampaignIds.length > 0) {
         try { await campaignService.unpauseCampaigns(pausedCampaignIds); } catch { /* best-effort restore */ }
       }

--- a/packages/core/src/services/campaign.ts
+++ b/packages/core/src/services/campaign.ts
@@ -405,18 +405,15 @@ export class CampaignService {
   }
 
   /**
-   * Start the global campaign runner via the high-level RPC.
-   *
-   * Uses `@electron/remote` to call `startRunningCampaigns` on the
-   * main-process mainWindowService (the renderer proxy does not expose `.call()`).
+   * Start the global campaign runner via the instance UI controller.
    */
-  async startRunner(liAccountId: number = 1): Promise<void> {
+  async startRunner(): Promise<void> {
     try {
       await this.instance.evaluateUI(
-        `(async function() {
-          const mws = require('@electron/remote').getGlobal('mainWindowService');
-          await mws.call('startRunningCampaigns', ${String(liAccountId)});
+        `(function() {
+          return window.mainWindowService.mainWindow.campaignController.start();
         })()`,
+        false,
       );
     } catch (error) {
       const message = errorMessage(error);
@@ -429,18 +426,15 @@ export class CampaignService {
   }
 
   /**
-   * Stop the global campaign runner via the high-level RPC.
-   *
-   * Uses `@electron/remote` to call `stopRunningCampaigns` on the
-   * main-process mainWindowService.
+   * Stop the global campaign runner via the instance UI controller.
    */
-  async stopRunner(liAccountId: number = 1, force: boolean = true): Promise<void> {
+  async stopRunner(): Promise<void> {
     try {
       await this.instance.evaluateUI(
-        `(async function() {
-          const mws = require('@electron/remote').getGlobal('mainWindowService');
-          await mws.call('stopRunningCampaigns', ${String(liAccountId)}, ${String(force)});
+        `(function() {
+          return window.mainWindowService.mainWindow.campaignController.stop();
         })()`,
+        false,
       );
     } catch (error) {
       const message = errorMessage(error);

--- a/packages/core/src/services/instance.ts
+++ b/packages/core/src/services/instance.ts
@@ -53,6 +53,7 @@ export class InstanceService {
   private linkedInClient: CDPClient | null = null;
   private uiClient: CDPClient | null = null;
   private healthChecker: HealthChecker | null = null;
+  private healthCheckRunning = false;
   private voyagerInterceptor: VoyagerInterceptor | null = null;
   private humanizedMouse: HumanizedMouse | null = null;
 
@@ -452,12 +453,15 @@ export class InstanceService {
    * not mask the original operation result.
    */
   private async runHealthCheck(): Promise<void> {
-    if (!this.healthChecker) return;
+    if (!this.healthChecker || this.healthCheckRunning) return;
+    this.healthCheckRunning = true;
     try {
       await this.healthChecker();
     } catch (error) {
       if (error instanceof UIBlockedError) throw error;
       // Health check infrastructure failure — do not mask the original result.
+    } finally {
+      this.healthCheckRunning = false;
     }
   }
 }


### PR DESCRIPTION
## Summary

- Add re-entrance guard to `runHealthCheck()` — `getInstancePopups()` calls `evaluateUI()` which triggers `runHealthCheck()` again, creating infinite async recursion that hangs all ephemeral campaign operations
- Fix `startRunner()`/`stopRunner()` to use `campaignController.start()/stop()` instead of `@electron/remote` RPC (unavailable in instance UI context)
- Simplify both ephemeral operations (check-replies, scrape-messaging-history) to always use `CampaignService.start()` which handles the full idle-wait → unpause → start sequence

## Test plan

- [x] Unit tests pass (36 check-replies tests across core/mcp/cli)
- [x] Lint passes
- [x] E2E: 2/3 check-replies tests pass (test 1 fails due to pre-existing SQLite lock contention with runner — separate issue)

Closes #513

🤖 Generated with [Claude Code](https://claude.com/claude-code)