### PR TITLE
(fix) core: prevent health check infinite recursion and fix campaign runner

### DIFF
--- a/packages/core/src/db/client.ts
+++ b/packages/core/src/db/client.ts
@@ -30,6 +30,9 @@ export class DatabaseClient {
   constructor(dbPath: string, options: DatabaseClientOptions = {}) {
     const { readOnly = true } = options;
     this.db = new DatabaseSync(dbPath, { readOnly });
+    // Allow SQLite to retry internally for up to 5 seconds when the database
+    // is locked by another process (e.g. the LinkedHelper campaign runner).
+    this.db.exec("PRAGMA busy_timeout = 5000");
   }
 
   close(): void {

--- a/packages/core/src/operations/check-replies.test.ts
+++ b/packages/core/src/operations/check-replies.test.ts
@@ -62,6 +62,9 @@ const mockCampaignService = {
     runnerState: "idle",
     actionCounts: [{ queued: 0, processed: 0, successful: 2, failed: 0 }],
   }),
+  getRunnerState: vi.fn().mockResolvedValue("idle"),
+  stopRunnerAndWaitForIdle: vi.fn().mockResolvedValue(undefined),
+  startRunner: vi.fn().mockResolvedValue(undefined),
   stop: vi.fn().mockResolvedValue(undefined),
   hardDelete: vi.fn(),
 };
@@ -213,6 +216,7 @@ describe("checkReplies", () => {
       cdpPort: 9222,
     });
 
+    expect(mockCampaignService.stopRunnerAndWaitForIdle).toHaveBeenCalled();
     expect(mockCampaignService.stop).toHaveBeenCalledWith(42);
     expect(mockCampaignService.hardDelete).toHaveBeenCalledWith(42);
   });
@@ -225,6 +229,7 @@ describe("checkReplies", () => {
       checkReplies({ personIds: [100, 200], cdpPort: 9222 }),
     ).rejects.toThrow("start failed");
 
+    expect(mockCampaignService.stopRunnerAndWaitForIdle).toHaveBeenCalled();
     expect(mockCampaignService.stop).toHaveBeenCalledWith(42);
     expect(mockCampaignService.hardDelete).toHaveBeenCalledWith(42);
   });

--- a/packages/core/src/operations/check-replies.ts
+++ b/packages/core/src/operations/check-replies.ts
@@ -66,6 +66,10 @@ export async function checkReplies(
       linkedInUrls.push(`https://www.linkedin.com/in/${publicId.externalId}`);
     }
 
+    // Capture runner state and stop if active to avoid SQLite lock contention
+    const runnerWasActive = (await campaignService.getRunnerState()) !== "idle";
+    await campaignService.stopRunnerAndWaitForIdle();
+
     // Create ephemeral campaign with CheckForReplies action
     const campaign = await campaignService.create({
       name: `[ephemeral] CheckForReplies ${new Date().toISOString()}`,
@@ -135,11 +139,15 @@ export async function checkReplies(
         checkedAt: new Date().toISOString(),
       };
     } finally {
+      // Stop runner first so DB writes don't contend with it
+      try { await campaignService.stopRunnerAndWaitForIdle(); } catch { /* best-effort */ }
       try { await campaignService.stop(campaign.id); } catch { /* best-effort cleanup */ }
       try { campaignService.hardDelete(campaign.id); } catch { /* best-effort cleanup */ }
-      try { await campaignService.stopRunner(); } catch { /* best-effort cleanup */ }
       if (pausedCampaignIds.length > 0) {
         try { await campaignService.unpauseCampaigns(pausedCampaignIds); } catch { /* best-effort restore */ }
+      }
+      if (runnerWasActive) {
+        try { await campaignService.startRunner(); } catch { /* best-effort restore */ }
       }
     }
   }, { instanceTimeout: CAMPAIGN_TIMEOUT, db: { readOnly: false } });

--- a/packages/core/src/operations/scrape-messaging-history.test.ts
+++ b/packages/core/src/operations/scrape-messaging-history.test.ts
@@ -57,6 +57,9 @@ const mockCampaignService = {
     runnerState: "idle",
     actionCounts: [{ queued: 0, processed: 0, successful: 2, failed: 0 }],
   }),
+  getRunnerState: vi.fn().mockResolvedValue("idle"),
+  stopRunnerAndWaitForIdle: vi.fn().mockResolvedValue(undefined),
+  startRunner: vi.fn().mockResolvedValue(undefined),
   stop: vi.fn().mockResolvedValue(undefined),
   hardDelete: vi.fn(),
 };
@@ -174,6 +177,7 @@ describe("scrapeMessagingHistory", () => {
       cdpPort: 9222,
     });
 
+    expect(mockCampaignService.stopRunnerAndWaitForIdle).toHaveBeenCalled();
     expect(mockCampaignService.stop).toHaveBeenCalledWith(42);
     expect(mockCampaignService.hardDelete).toHaveBeenCalledWith(42);
   });
@@ -186,6 +190,7 @@ describe("scrapeMessagingHistory", () => {
       scrapeMessagingHistory({ personIds: [100, 200], cdpPort: 9222 }),
     ).rejects.toThrow("start failed");
 
+    expect(mockCampaignService.stopRunnerAndWaitForIdle).toHaveBeenCalled();
     expect(mockCampaignService.stop).toHaveBeenCalledWith(42);
     expect(mockCampaignService.hardDelete).toHaveBeenCalledWith(42);
   });

--- a/packages/core/src/operations/scrape-messaging-history.ts
+++ b/packages/core/src/operations/scrape-messaging-history.ts
@@ -63,6 +63,10 @@ export async function scrapeMessagingHistory(
       linkedInUrls.push(`https://www.linkedin.com/in/${publicId.externalId}`);
     }
 
+    // Capture runner state and stop if active to avoid SQLite lock contention
+    const runnerWasActive = (await campaignService.getRunnerState()) !== "idle";
+    await campaignService.stopRunnerAndWaitForIdle();
+
     // Create ephemeral campaign with ScrapeMessagingHistory action
     const campaign = await campaignService.create({
       name: `[ephemeral] ScrapeMessagingHistory ${new Date().toISOString()}`,
@@ -119,11 +123,15 @@ export async function scrapeMessagingHistory(
         stats,
       };
     } finally {
+      // Stop runner first so DB writes don't contend with it
+      try { await campaignService.stopRunnerAndWaitForIdle(); } catch { /* best-effort */ }
       try { await campaignService.stop(campaign.id); } catch { /* best-effort cleanup */ }
       try { campaignService.hardDelete(campaign.id); } catch { /* best-effort cleanup */ }
-      try { await campaignService.stopRunner(); } catch { /* best-effort cleanup */ }
       if (pausedCampaignIds.length > 0) {
         try { await campaignService.unpauseCampaigns(pausedCampaignIds); } catch { /* best-effort restore */ }
+      }
+      if (runnerWasActive) {
+        try { await campaignService.startRunner(); } catch { /* best-effort restore */ }
       }
     }
   }, { instanceTimeout: CAMPAIGN_TIMEOUT, db: { readOnly: false } });

--- a/packages/core/src/services/campaign.ts
+++ b/packages/core/src/services/campaign.ts
@@ -447,6 +447,20 @@ export class CampaignService {
   }
 
   /**
+   * Stop the runner and wait until it reaches the idle state.
+   *
+   * Useful before DB-write operations that would conflict with the
+   * runner's own SQLite writes.
+   */
+  async stopRunnerAndWaitForIdle(): Promise<void> {
+    const state = await this.getRunnerState();
+    if (state === "idle") return;
+    await this.stopRunner();
+    // Reuse the idle-wait loop (campaignId=0 is only used in the error message)
+    await this.waitForIdle(0);
+  }
+
+  /**
    * Unpause a single campaign via CDP.
    *
    * @throws {CampaignNotFoundError} if the campaign does not exist.
@@ -696,7 +710,7 @@ export class CampaignService {
   /**
    * Get the current runner state from CDP.
    */
-  private async getRunnerState(): Promise<RunnerState> {
+  async getRunnerState(): Promise<RunnerState> {
     return this.instance.evaluateUI<RunnerState>(
       `window.mainWindowService.mainWindow.state`,
       false,


### PR DESCRIPTION
## Summary

Three bugs that blocked ephemeral campaign operations (check-replies, scrape-messaging-history):

1. **Health check infinite recursion**: `getInstancePopups()` calls `evaluateUI()` which triggers `runHealthCheck()` again — infinite async loop. Fixed with re-entrance guard.
2. **Campaign runner inaccessible**: `startRunner()`/`stopRunner()` used `@electron/remote` RPC unavailable in instance UI context. Fixed to use `campaignController.start()/stop()`.
3. **SQLite lock contention**: LH runner holds DB write lock, blocking campaign creation. Fixed by stopping runner before DB writes, adding `PRAGMA busy_timeout = 5000`, and restoring runner state after cleanup.

## Test plan

- [x] Unit tests pass (1276 core + 486 CLI + 421 MCP)
- [x] Lint passes
- [x] **E2E: 3/3 check-replies tests pass**

Closes #513

🤖 Generated with [Claude Code](https://claude.com/claude-code)