### PR TITLE
(fix) e2e: get-errors tests timeout — getErrors() hangs

### DIFF
--- a/packages/core/src/operations/dismiss-errors.test.ts
+++ b/packages/core/src/operations/dismiss-errors.test.ts
@@ -91,6 +91,8 @@ describe("dismissErrors", () => {
 
     const result = await dismissErrors({ cdpPort: 9222 });
 
+    expect(discoverInstancePort).toHaveBeenCalledWith(9222);
+    expect(InstanceService).toHaveBeenCalledWith(9223, expect.anything());
     expect(result.dismissed).toBe(3);
     expect(result.nonDismissable).toBe(0);
   });

--- a/packages/core/src/operations/dismiss-errors.ts
+++ b/packages/core/src/operations/dismiss-errors.ts
@@ -5,6 +5,7 @@ import { discoverInstancePort, resolveInstancePort } from "../cdp/index.js";
 import { resolveAccount } from "../services/account-resolution.js";
 import { InstanceService } from "../services/instance.js";
 import { LauncherService } from "../services/launcher.js";
+import { isLoopbackAddress } from "../utils/loopback.js";
 import type { ConnectionOptions } from "./types.js";
 
 /**
@@ -74,9 +75,11 @@ export async function dismissErrors(
   // Dismiss instance UI popups.
   // When connected to a launcher, discover the instance's dynamic CDP
   // port — the launcher port does not host instance UI targets.
-  const instancePort = connectedToLauncher
+  // Discovery only works locally (process inspection), so skip for remote hosts.
+  const isLocal = input.cdpHost === undefined || isLoopbackAddress(input.cdpHost);
+  const instancePort = connectedToLauncher && isLocal
     ? await discoverInstancePort(cdpPort).catch(() => null)
-    : cdpPort;
+    : connectedToLauncher ? null : cdpPort;
 
   if (instancePort !== null) {
     const instance = new InstanceService(instancePort, cdpOptions);

--- a/packages/core/src/operations/get-errors.test.ts
+++ b/packages/core/src/operations/get-errors.test.ts
@@ -188,6 +188,8 @@ describe("getErrors", () => {
 
     const result = await getErrors({ cdpPort: 9222 });
 
+    expect(discoverInstancePort).toHaveBeenCalledWith(9222);
+    expect(InstanceService).toHaveBeenCalledWith(9223, expect.anything());
     expect(result.instancePopups).toHaveLength(1);
     expect(result.instancePopups[0]?.title).toBe("Failed to initialize UI");
     expect(result.healthy).toBe(false);

--- a/packages/core/src/operations/get-errors.ts
+++ b/packages/core/src/operations/get-errors.ts
@@ -6,6 +6,7 @@ import type { InstancePopup, UIHealthStatus } from "../types/index.js";
 import { resolveAccount } from "../services/account-resolution.js";
 import { InstanceService } from "../services/instance.js";
 import { LauncherService } from "../services/launcher.js";
+import { isLoopbackAddress } from "../utils/loopback.js";
 import type { ConnectionOptions } from "./types.js";
 
 /**
@@ -62,8 +63,8 @@ export async function getErrors(
     const launcher = new LauncherService(cdpPort, cdpOptions);
     try {
       await launcher.connect();
-      health = await launcher.checkUIHealth(accountId);
       connectedToLauncher = true;
+      health = await launcher.checkUIHealth(accountId);
     } finally {
       launcher.disconnect();
     }
@@ -74,15 +75,17 @@ export async function getErrors(
   // Best-effort: detect instance UI popups if the UI target is available.
   // When connected to a launcher, discover the instance's dynamic CDP port
   // first — the launcher port does not host instance UI targets.
+  // Discovery only works locally (process inspection), so skip for remote hosts.
+  const isLocal = input.cdpHost === undefined || isLoopbackAddress(input.cdpHost);
   let instancePopups: InstancePopup[] = [];
-  if (connectedToLauncher) {
+  if (connectedToLauncher && isLocal) {
     const instancePort = await discoverInstancePort(cdpPort).catch(
       () => null,
     );
     if (instancePort !== null) {
       instancePopups = await detectInstancePopups(instancePort, cdpOptions);
     }
-  } else {
+  } else if (!connectedToLauncher) {
     // Direct instance connection — cdpPort IS the instance port
     instancePopups = await detectInstancePopups(cdpPort, cdpOptions);
   }


### PR DESCRIPTION
## Summary

- Both `getErrors()` and `dismissErrors()` passed the **launcher** CDP port to `InstanceService` for popup detection. The launcher port doesn't host instance UI targets, so `connectUiOnly()` polled for 30s before timing out — matching the test timeout exactly.
- Now discovers the instance's dynamic CDP port via `discoverInstancePort()` when connected to a launcher. When instance isn't running, popup detection is skipped (returns empty array).
- Applied the same fix to `dismissErrors()` which had the identical bug.

## Test plan

- [x] All 11 `get-errors.test.ts` unit tests pass
- [x] All 6 `dismiss-errors.test.ts` unit tests pass
- [x] Full `pnpm test` passes (except pre-existing `selectors.integration.test.ts` failures)
- [x] `pnpm lint` clean
- [ ] E2E: `pnpm test:e2e` with `get-errors.e2e.test.ts` (local — requires LinkedHelper)

Closes #584

🤖 Generated with [Claude Code](https://claude.com/claude-code)