### PR TITLE
(fix) core: make FeedPost.url nullable and retry URL extraction

### DIFF
--- a/packages/cli/src/handlers/get-feed.ts
+++ b/packages/cli/src/handlers/get-feed.ts
@@ -46,7 +46,9 @@ export async function handleGetFeed(
         if (post.authorHeadline) {
           process.stdout.write(`  ${post.authorHeadline}\n`);
         }
-        process.stdout.write(`  ${post.url}\n`);
+        if (post.url) {
+          process.stdout.write(`  ${post.url}\n`);
+        }
         if (post.text) {
           const truncated =
             post.text.length > 120

--- a/packages/cli/src/handlers/get-profile-activity.ts
+++ b/packages/cli/src/handlers/get-profile-activity.ts
@@ -43,7 +43,9 @@ export async function handleGetProfileActivity(
     process.stdout.write(`Profile: ${result.profilePublicId}\n\n`);
 
     for (const post of result.posts) {
-      process.stdout.write(`  ${post.url}\n`);
+      if (post.url) {
+        process.stdout.write(`  ${post.url}\n`);
+      }
       if (post.authorName) {
         process.stdout.write(`    Author:    ${post.authorName}\n`);
       }

--- a/packages/core/src/operations/get-feed.test.ts
+++ b/packages/core/src/operations/get-feed.test.ts
@@ -170,12 +170,61 @@ describe("getFeed", () => {
     expect(post?.hashtags).toEqual(["linkedin", "tech"]);
   });
 
-  it("returns empty string URL when raw post has null url", async () => {
+  it("returns null URL when raw post has null url", async () => {
     setupMocks([rawPost({ url: null })]);
 
     const result = await getFeed({ cdpPort: CDP_PORT });
 
-    expect(result.posts[0]?.url).toBe("");
+    expect(result.posts[0]?.url).toBeNull();
+  });
+
+  it("retries URL extraction when clipboard capture fails on first attempt", async () => {
+    const retryUrl = "https://www.linkedin.com/feed/update/urn:li:activity:retried/";
+    // Post scraped without a URL — URL extraction must fill it in
+    const post = rawPost({ url: null });
+
+    vi.mocked(discoverTargets).mockResolvedValue([
+      {
+        id: "target-1",
+        type: "page",
+        title: "LinkedIn",
+        url: "https://www.linkedin.com/feed/",
+        description: "",
+        devtoolsFrontendUrl: "",
+      },
+    ]);
+
+    let clipboardReadCount = 0;
+    const evaluate = vi.fn().mockImplementation((script: string) => {
+      const s = String(script);
+      if (s.includes("parseCount")) return Promise.resolve([post]);
+      if (s.includes("navigator.clipboard.writeText")) return Promise.resolve(undefined);
+      if (s.includes("__capturedClipboard = null")) return Promise.resolve(undefined);
+      if (s.includes("Copy link to post")) return Promise.resolve(undefined);
+      if (s === "window.__capturedClipboard") {
+        clipboardReadCount++;
+        return Promise.resolve(clipboardReadCount === 1 ? null : retryUrl);
+      }
+      if (s.includes("btn.click()")) return Promise.resolve(true);
+      if (s.includes("scrollIntoView")) return Promise.resolve(undefined);
+      if (s.includes("mainFeed")) return Promise.resolve(true);
+      return Promise.resolve(undefined);
+    });
+
+    vi.mocked(CDPClient).mockImplementation(function () {
+      return {
+        connect: vi.fn().mockResolvedValue(undefined),
+        disconnect: vi.fn(),
+        navigate: vi.fn().mockResolvedValue({ frameId: "F1" }),
+        evaluate,
+        send: vi.fn().mockResolvedValue(undefined),
+      } as unknown as CDPClient;
+    });
+
+    const result = await getFeed({ cdpPort: CDP_PORT });
+
+    expect(result.posts[0]?.url).toBe(retryUrl);
+    expect(clipboardReadCount).toBeGreaterThanOrEqual(2);
   });
 
   it("navigates to the LinkedIn feed page", async () => {

--- a/packages/core/src/operations/get-feed.ts
+++ b/packages/core/src/operations/get-feed.ts
@@ -223,49 +223,61 @@ async function capturePostUrl(
   postIndex: number,
   mouse?: HumanizedMouse | null,
 ): Promise<string | null> {
-  await maybeHesitate(); // Probabilistic pause before menu interaction
+  const MAX_ATTEMPTS = 3;
 
-  // Reset clipboard capture
-  await client.evaluate(`window.__capturedClipboard = null;`);
+  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+    await maybeHesitate(); // Probabilistic pause before menu interaction
 
-  // Scroll the menu button into view (humanized when mouse available)
-  await humanizedScrollToByIndex(client, FEED_MENU_BUTTON_SELECTOR, postIndex, mouse);
+    // Reset clipboard capture
+    await client.evaluate(`window.__capturedClipboard = null;`);
 
-  // Click the menu button
-  const clicked = await client.evaluate<boolean>(`(() => {
-    const btns = document.querySelectorAll(
-      ${JSON.stringify(FEED_MENU_BUTTON_SELECTOR)}
-    );
-    const btn = btns[${postIndex}];
-    if (!btn) return false;
-    btn.click();
-    return true;
-  })()`);
+    // Scroll the menu button into view (humanized when mouse available)
+    await humanizedScrollToByIndex(client, FEED_MENU_BUTTON_SELECTOR, postIndex, mouse);
 
-  if (!clicked) return null;
+    // Click the menu button
+    const clicked = await client.evaluate<boolean>(`(() => {
+      const btns = document.querySelectorAll(
+        ${JSON.stringify(FEED_MENU_BUTTON_SELECTOR)}
+      );
+      const btn = btns[${postIndex}];
+      if (!btn) return false;
+      btn.click();
+      return true;
+    })()`);
 
-  await randomDelay(500, 900);
+    if (!clicked) return null; // No menu button — structural, retrying won't help
 
-  // Click "Copy link to post" menu item
-  await client.evaluate(`(() => {
-    for (const el of document.querySelectorAll('[role="menuitem"]')) {
-      if (el.textContent.trim() === 'Copy link to post') {
-        el.click();
-        return;
+    await randomDelay(500, 900);
+
+    // Click "Copy link to post" menu item
+    await client.evaluate(`(() => {
+      for (const el of document.querySelectorAll('[role="menuitem"]')) {
+        if (el.textContent.trim() === 'Copy link to post') {
+          el.click();
+          return;
+        }
       }
+    })()`);
+
+    await randomDelay(400, 700);
+
+    // Read captured URL
+    const postUrl =
+      await client.evaluate<string | null>(`window.__capturedClipboard`);
+
+    if (postUrl) {
+      // Strip query parameters
+      return postUrl.split("?")[0] ?? postUrl;
     }
-  })()`);
 
-  await randomDelay(400, 700);
+    // Dismiss any open menu before retrying
+    await client.evaluate(`(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    })()`);
+    await randomDelay(300, 500);
+  }
 
-  // Read captured URL
-  const postUrl =
-    await client.evaluate<string | null>(`window.__capturedClipboard`);
-
-  if (!postUrl) return null;
-
-  // Strip query parameters
-  return postUrl.split("?")[0] ?? postUrl;
+  return null;
 }
 
 /**
@@ -339,7 +351,7 @@ export function buildPostUrl(urn: string): string {
 /** @internal Exported for reuse by search-posts. */
 export function mapRawPosts(raw: RawDomPost[]): FeedPost[] {
   return raw.map((r) => ({
-    url: r.url ?? "",
+    url: r.url ?? null,
     authorName: r.authorName,
     authorHeadline: r.authorHeadline,
     authorProfileUrl: r.authorProfileUrl,

--- a/packages/core/src/operations/get-profile-activity.test.ts
+++ b/packages/core/src/operations/get-profile-activity.test.ts
@@ -309,14 +309,26 @@ describe("getProfileActivity", () => {
   });
 
   it("handles posts where URL extraction fails", async () => {
-    setupMocks([rawPost()], [null]);
+    setupMocks([rawPost()], [null, null, null]);
 
     const result = await getProfileActivity({
       cdpPort: CDP_PORT,
       profile: "johndoe",
     });
 
-    expect(result.posts[0]?.url).toBe("");
+    expect(result.posts[0]?.url).toBeNull();
+  });
+
+  it("retries URL extraction when clipboard capture fails on first attempt", async () => {
+    const retryUrl = "https://www.linkedin.com/feed/update/urn:li:share:retried/";
+    setupMocks([rawPost()], [null, retryUrl]);
+
+    const result = await getProfileActivity({
+      cdpPort: CDP_PORT,
+      profile: "johndoe",
+    });
+
+    expect(result.posts[0]?.url).toBe(retryUrl);
   });
 
   it("throws when no LinkedIn page found", async () => {

--- a/packages/core/src/operations/get-profile-activity.ts
+++ b/packages/core/src/operations/get-profile-activity.ts
@@ -238,49 +238,61 @@ async function captureActivityPostUrl(
   postIndex: number,
   mouse?: HumanizedMouse | null,
 ): Promise<string | null> {
-  await maybeHesitate(); // Probabilistic pause before menu interaction
+  const MAX_ATTEMPTS = 3;
 
-  // Reset clipboard capture
-  await client.evaluate(`window.__capturedClipboard = null;`);
+  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+    await maybeHesitate(); // Probabilistic pause before menu interaction
 
-  // Scroll the menu button into view (humanized when mouse available)
-  await humanizedScrollToByIndex(client, ACTIVITY_MENU_BUTTON_SELECTOR, postIndex, mouse);
+    // Reset clipboard capture
+    await client.evaluate(`window.__capturedClipboard = null;`);
 
-  // Click the menu button
-  const clicked = await client.evaluate<boolean>(`(() => {
-    const btns = document.querySelectorAll(
-      ${JSON.stringify(ACTIVITY_MENU_BUTTON_SELECTOR)}
-    );
-    const btn = btns[${postIndex}];
-    if (!btn) return false;
-    btn.click();
-    return true;
-  })()`);
+    // Scroll the menu button into view (humanized when mouse available)
+    await humanizedScrollToByIndex(client, ACTIVITY_MENU_BUTTON_SELECTOR, postIndex, mouse);
 
-  if (!clicked) return null;
+    // Click the menu button
+    const clicked = await client.evaluate<boolean>(`(() => {
+      const btns = document.querySelectorAll(
+        ${JSON.stringify(ACTIVITY_MENU_BUTTON_SELECTOR)}
+      );
+      const btn = btns[${postIndex}];
+      if (!btn) return false;
+      btn.click();
+      return true;
+    })()`);
 
-  await randomDelay(500, 900);
+    if (!clicked) return null; // No menu button — structural, retrying won't help
 
-  // Click "Copy link to post" menu item
-  await client.evaluate(`(() => {
-    for (const el of document.querySelectorAll('[role="menuitem"]')) {
-      if (el.textContent.trim() === 'Copy link to post') {
-        el.click();
-        return;
+    await randomDelay(500, 900);
+
+    // Click "Copy link to post" menu item
+    await client.evaluate(`(() => {
+      for (const el of document.querySelectorAll('[role="menuitem"]')) {
+        if (el.textContent.trim() === 'Copy link to post') {
+          el.click();
+          return;
+        }
       }
+    })()`);
+
+    await randomDelay(400, 700);
+
+    // Read captured URL
+    const postUrl =
+      await client.evaluate<string | null>(`window.__capturedClipboard`);
+
+    if (postUrl) {
+      // Strip query parameters
+      return postUrl.split("?")[0] ?? postUrl;
     }
-  })()`);
 
-  await randomDelay(400, 700);
+    // Dismiss any open menu before retrying
+    await client.evaluate(`(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    })()`);
+    await randomDelay(300, 500);
+  }
 
-  // Read captured URL
-  const postUrl =
-    await client.evaluate<string | null>(`window.__capturedClipboard`);
-
-  if (!postUrl) return null;
-
-  // Strip query parameters
-  return postUrl.split("?")[0] ?? postUrl;
+  return null;
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/core/src/types/feed.ts
+++ b/packages/core/src/types/feed.ts
@@ -5,8 +5,8 @@
  * A post from the LinkedIn home feed or profile activity stream.
  */
 export interface FeedPost {
-  /** Direct URL to the post on LinkedIn. */
-  readonly url: string;
+  /** Direct URL to the post on LinkedIn, or `null` when URL extraction failed. */
+  readonly url: string | null;
   /** Display name of the post author. */
   readonly authorName: string | null;
   /** Professional headline of the author, if available. */

--- a/packages/e2e/src/get-post-stats.e2e.test.ts
+++ b/packages/e2e/src/get-post-stats.e2e.test.ts
@@ -20,8 +20,9 @@ import { registerGetPostStats } from "@lhremote/mcp/tools";
 import { createMockServer } from "@lhremote/mcp/testing";
 
 /**
- * Fetch a fresh post URN by scraping the feed.  Returns the URN of the
- * first feed post, or `undefined` when the feed returns no posts.
+ * Fetch a fresh post URL by scraping the feed.  Returns the URL of the
+ * first feed post, or `undefined` when the feed returns no posts or the
+ * first post has no URL.
  */
 async function fetchPostUrlFromFeed(cdpPort: number): Promise<string | undefined> {
   const { getFeed } = await import("@lhremote/core");

--- a/packages/e2e/src/get-post.e2e.test.ts
+++ b/packages/e2e/src/get-post.e2e.test.ts
@@ -20,8 +20,9 @@ import { registerGetPost } from "@lhremote/mcp/tools";
 import { createMockServer } from "@lhremote/mcp/testing";
 
 /**
- * Fetch a fresh post URN by scraping the feed.  Returns the URN of the
- * first feed post, or `undefined` when the feed returns no posts.
+ * Fetch a fresh post URL by scraping the feed.  Returns the URL of the
+ * first feed post, or `undefined` when the feed returns no posts or the
+ * first post has no URL.
  */
 async function fetchPostUrlFromFeed(cdpPort: number): Promise<string | undefined> {
   const { getFeed } = await import("@lhremote/core");


### PR DESCRIPTION
## Summary

- `FeedPost.url` type changed from `string` to `string | null` — honestly represents when URL extraction fails instead of masking with `""`
- Added retry logic (up to 3 attempts with menu dismissal) to `capturePostUrl` and `captureActivityPostUrl` to handle flaky DOM interactions
- Updated `mapRawPosts` to preserve `null` instead of coercing to `""`
- Guarded CLI feed handler against null URL output
- E2E test helpers reverted to `count: 1` with `??` — now correctly handles `null`

Closes #585

## Test plan

- [x] All 3 tests in `get-post.e2e.test.ts` pass locally
- [x] Unit tests pass (1197 passed)
- [x] CI green (ubuntu/macos/windows)
- [ ] Copilot review clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)