### PR TITLE
(fix) e2e: correct FeedPost property assertion from urn to url

### DIFF
--- a/packages/e2e/src/get-profile-activity.e2e.test.ts
+++ b/packages/e2e/src/get-profile-activity.e2e.test.ts
@@ -134,7 +134,7 @@ describeE2E("get-profile-activity operation", () => {
 
       // Profile may or may not have recent posts
       for (const post of parsed.posts) {
-        expect(post).toHaveProperty("urn");
+        expect(post).toHaveProperty("url");
         expect(typeof post.reactionCount).toBe("number");
         expect(typeof post.commentCount).toBe("number");
         expect(typeof post.shareCount).toBe("number");


### PR DESCRIPTION
## Summary

- Fix `get-profile-activity.e2e.test.ts` line 137: change `expect(post).toHaveProperty("urn")` to `expect(post).toHaveProperty("url")` to match the actual `FeedPost` type shape

Closes #586

## Test plan

- [ ] All 3 tests in `get-profile-activity.e2e.test.ts` pass
- [ ] Test assertions match actual `FeedPost` type shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)