### PR TITLE
(fix) e2e: increase quit test polling deadline

### DIFF
--- a/packages/e2e/src/app-service.e2e.test.ts
+++ b/packages/e2e/src/app-service.e2e.test.ts
@@ -54,7 +54,7 @@ describeE2E("AppService", () => {
       async () => {
         await app.quit();
 
-        const deadline = Date.now() + 5_000;
+        const deadline = Date.now() + 15_000;
         const probe = new AppService(port);
         while (Date.now() < deadline) {
           if (!(await probe.isRunning())) {


### PR DESCRIPTION
## Summary
- Increases the polling deadline in the `quit() stops the application` E2E test from 5s to 15s
- The 5s deadline was too tight for the app's graceful shutdown sequence, causing flaky failures (exceeded by ~41ms)
- The 30s test-level timeout remains as the overall safety net

## Test plan
- [ ] `pnpm test:e2e` passes locally with the quit test completing reliably

Closes #587

🤖 Generated with [Claude Code](https://claude.com/claude-code)