### PR TITLE
(chore) gitignore: add .tmp/ to ignored paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 # Turbo
 .turbo/
 
+# Scratch / temporary files
+.tmp/
+
 # MCP configuration with credentials
 .mcp.json.local
 


### PR DESCRIPTION
## Summary
- Add `.tmp/` directory to `.gitignore` for scratch/temporary files

## Test plan
- [x] Verify `.tmp/` is ignored by git

🤖 Generated with [Claude Code](https://claude.com/claude-code)