### PR TITLE
Increase launchChromium default timeout for Windows CI reliability

### DIFF
--- a/packages/core/src/cdp/testing/launch-chromium.ts
+++ b/packages/core/src/cdp/testing/launch-chromium.ts
@@ -48,13 +48,13 @@ async function findFreePort(): Promise<number> {
  * is configured for test isolation (temp profile, no sandbox).
  *
  * @param options.timeout - Maximum time (ms) to wait for CDP to become
- *   available (default 10 000).
+ *   available (default 30 000).
  * @returns A {@link ChromiumInstance} handle.
  */
 export async function launchChromium(options?: {
   timeout?: number;
 }): Promise<ChromiumInstance> {
-  const timeout = options?.timeout ?? 10_000;
+  const timeout = options?.timeout ?? 30_000;
   const port = await findFreePort();
   const userDataDir = join(
     tmpdir(),


### PR DESCRIPTION
## Summary

- Increase `launchChromium()` default timeout from 10s to 30s in `packages/core/src/cdp/testing/launch-chromium.ts`
- This is a test-only helper — generous default has no production impact
- Fixes ~60-70% Windows CI failure rate caused by Chromium startup latency exceeding 10s

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm test` passes (pre-existing selector integration test failures confirmed on main, unrelated)
- [ ] CI passes on all platforms (ubuntu/macos/windows)

Closes #594

🤖 Generated with [Claude Code](https://claude.com/claude-code)