### PR TITLE
(fix) cdp: add Array.isArray guard in discoverTargets

### DIFF
--- a/packages/core/src/cdp/discovery.test.ts
+++ b/packages/core/src/cdp/discovery.test.ts
@@ -74,6 +74,19 @@ describe("discoverTargets", () => {
     );
   });
 
+  it("should throw CDPConnectionError on non-array response", async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(JSON.stringify({ error: "not targets" }), { status: 200 }),
+    );
+
+    await expect(discoverTargets(9222)).rejects.toThrow(
+      expect.objectContaining({
+        constructor: CDPConnectionError,
+        message: expect.stringMatching(/Unexpected response from CDP endpoint/),
+      }),
+    );
+  });
+
   it("should throw CDPConnectionError on non-OK HTTP status", async () => {
     vi.mocked(fetch).mockResolvedValue(
       new Response("Not Found", { status: 404 }),

--- a/packages/core/src/cdp/discovery.ts
+++ b/packages/core/src/cdp/discovery.ts
@@ -42,5 +42,11 @@ export async function discoverTargets(
     );
   }
 
-  return (await response.json()) as CdpTarget[];
+  const targets: unknown = await response.json();
+  if (!Array.isArray(targets)) {
+    throw new CDPConnectionError(
+      "Unexpected response from CDP endpoint",
+    );
+  }
+  return targets as CdpTarget[];
 }


### PR DESCRIPTION
## Summary

- Add `Array.isArray` guard before casting `response.json()` to `CdpTarget[]` in `discoverTargets`
- Throws `CDPConnectionError` when the CDP endpoint returns non-array JSON
- Add unit test covering the non-array response case

Closes #608

## Test plan

- [x] New unit test passes for non-array response (object JSON returns `CDPConnectionError`)
- [x] Existing discovery tests pass (array response, custom host, fetch failure, non-OK status)
- [x] Lint passes
- [x] Full unit test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)