### PR TITLE
(test) core: add unit tests for 12 ephemeral action operations

### DIFF
--- a/packages/core/src/operations/build-linkedin-url.test.ts
+++ b/packages/core/src/operations/build-linkedin-url.test.ts
@@ -1,0 +1,220 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../services/source-type-registry.js", () => ({
+  validateSourceType: vi.fn(),
+}));
+
+vi.mock("../services/url-builder.js", () => ({
+  buildBasicSearchUrl: vi.fn(),
+}));
+
+vi.mock("../services/sn-url-builder.js", () => ({
+  buildSNSearchUrl: vi.fn(),
+}));
+
+vi.mock("../services/url-templates.js", () => ({
+  isSearchBuilderType: vi.fn(),
+  isSNSearchBuilderType: vi.fn(),
+  isParameterisedType: vi.fn(),
+  isFixedUrlType: vi.fn(),
+  buildParameterisedUrl: vi.fn(),
+  getFixedUrl: vi.fn(),
+}));
+
+import { validateSourceType } from "../services/source-type-registry.js";
+import { buildBasicSearchUrl } from "../services/url-builder.js";
+import { buildSNSearchUrl } from "../services/sn-url-builder.js";
+import {
+  isSearchBuilderType,
+  isSNSearchBuilderType,
+  isParameterisedType,
+  isFixedUrlType,
+  buildParameterisedUrl,
+  getFixedUrl,
+} from "../services/url-templates.js";
+import { buildLinkedInUrl } from "./build-linkedin-url.js";
+
+describe("buildLinkedInUrl", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: all type checks return false
+    vi.mocked(isSearchBuilderType).mockReturnValue(false);
+    vi.mocked(isSNSearchBuilderType).mockReturnValue(false);
+    vi.mocked(isParameterisedType).mockReturnValue(false);
+    vi.mocked(isFixedUrlType).mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("throws on unknown source type", () => {
+    vi.mocked(validateSourceType).mockReturnValue(false);
+
+    expect(() =>
+      buildLinkedInUrl({ sourceType: "UnknownType" }),
+    ).toThrow('Unknown source type: "UnknownType"');
+  });
+
+  it("dispatches SearchPage to basic search builder", () => {
+    vi.mocked(validateSourceType).mockReturnValue(true);
+    vi.mocked(isSearchBuilderType).mockReturnValue(true);
+    vi.mocked(buildBasicSearchUrl).mockReturnValue({
+      url: "https://www.linkedin.com/search/results/people/?keywords=test",
+      sourceType: "SearchPage",
+      warnings: [],
+    });
+
+    const result = buildLinkedInUrl({
+      sourceType: "SearchPage",
+      keywords: "test",
+    });
+
+    expect(buildBasicSearchUrl).toHaveBeenCalledWith({ keywords: "test" });
+    expect(result.url).toBe(
+      "https://www.linkedin.com/search/results/people/?keywords=test",
+    );
+  });
+
+  it("passes all search params to basic search builder", () => {
+    vi.mocked(validateSourceType).mockReturnValue(true);
+    vi.mocked(isSearchBuilderType).mockReturnValue(true);
+    vi.mocked(buildBasicSearchUrl).mockReturnValue({
+      url: "https://example.com",
+      sourceType: "SearchPage",
+      warnings: [],
+    });
+
+    buildLinkedInUrl({
+      sourceType: "SearchPage",
+      keywords: "engineer",
+      currentCompany: ["1234"],
+      pastCompany: ["5678"],
+      geoUrn: ["101"],
+      industry: ["96"],
+      school: ["abc"],
+      network: ["F"],
+      profileLanguage: ["en"],
+      serviceCategory: ["cat1"],
+    });
+
+    expect(buildBasicSearchUrl).toHaveBeenCalledWith({
+      keywords: "engineer",
+      currentCompany: ["1234"],
+      pastCompany: ["5678"],
+      geoUrn: ["101"],
+      industry: ["96"],
+      school: ["abc"],
+      network: ["F"],
+      profileLanguage: ["en"],
+      serviceCategory: ["cat1"],
+    });
+  });
+
+  it("omits undefined search params", () => {
+    vi.mocked(validateSourceType).mockReturnValue(true);
+    vi.mocked(isSearchBuilderType).mockReturnValue(true);
+    vi.mocked(buildBasicSearchUrl).mockReturnValue({
+      url: "https://example.com",
+      sourceType: "SearchPage",
+      warnings: [],
+    });
+
+    buildLinkedInUrl({ sourceType: "SearchPage" });
+
+    expect(buildBasicSearchUrl).toHaveBeenCalledWith({});
+  });
+
+  it("dispatches SNSearchPage to SN search builder", () => {
+    vi.mocked(validateSourceType).mockReturnValue(true);
+    vi.mocked(isSNSearchBuilderType).mockReturnValue(true);
+    vi.mocked(buildSNSearchUrl).mockReturnValue({
+      url: "https://www.linkedin.com/sales/search/people?query=test",
+      sourceType: "SNSearchPage",
+      warnings: [],
+    });
+
+    const filters = [{ type: "COMPANY_SIZE", values: [{ id: "B", selectionType: "INCLUDED" as const }] }];
+
+    const result = buildLinkedInUrl({
+      sourceType: "SNSearchPage",
+      keywords: "test",
+      filters,
+    });
+
+    expect(buildSNSearchUrl).toHaveBeenCalledWith({
+      keywords: "test",
+      filters,
+    });
+    expect(result.sourceType).toBe("SNSearchPage");
+  });
+
+  it("dispatches parameterised type to template builder", () => {
+    vi.mocked(validateSourceType).mockReturnValue(true);
+    vi.mocked(isParameterisedType).mockReturnValue(true);
+    vi.mocked(buildParameterisedUrl).mockReturnValue(
+      "https://www.linkedin.com/company/acme/people/",
+    );
+
+    const result = buildLinkedInUrl({
+      sourceType: "OrganizationPeople",
+      slug: "acme",
+    });
+
+    expect(buildParameterisedUrl).toHaveBeenCalledWith(
+      "OrganizationPeople",
+      { slug: "acme" },
+    );
+    expect(result.url).toBe(
+      "https://www.linkedin.com/company/acme/people/",
+    );
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("throws when parameterised type returns undefined (missing param)", () => {
+    vi.mocked(validateSourceType).mockReturnValue(true);
+    vi.mocked(isParameterisedType).mockReturnValue(true);
+    vi.mocked(buildParameterisedUrl).mockReturnValue(undefined);
+
+    expect(() =>
+      buildLinkedInUrl({ sourceType: "OrganizationPeople" }),
+    ).toThrow("Missing required parameter");
+  });
+
+  it("dispatches fixed URL type", () => {
+    vi.mocked(validateSourceType).mockReturnValue(true);
+    vi.mocked(isFixedUrlType).mockReturnValue(true);
+    vi.mocked(getFixedUrl).mockReturnValue(
+      "https://www.linkedin.com/mynetwork/invite-connect/connections/",
+    );
+
+    const result = buildLinkedInUrl({ sourceType: "MyConnections" });
+
+    expect(getFixedUrl).toHaveBeenCalledWith("MyConnections");
+    expect(result.url).toBe(
+      "https://www.linkedin.com/mynetwork/invite-connect/connections/",
+    );
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("throws when fixed URL type returns undefined", () => {
+    vi.mocked(validateSourceType).mockReturnValue(true);
+    vi.mocked(isFixedUrlType).mockReturnValue(true);
+    vi.mocked(getFixedUrl).mockReturnValue(undefined);
+
+    expect(() =>
+      buildLinkedInUrl({ sourceType: "MyConnections" }),
+    ).toThrow("Missing fixed URL");
+  });
+
+  it("throws when no builder matches a validated source type", () => {
+    vi.mocked(validateSourceType).mockReturnValue(true);
+
+    expect(() =>
+      buildLinkedInUrl({ sourceType: "SearchPage" }),
+    ).toThrow("No URL builder available");
+  });
+});

--- a/packages/core/src/operations/endorse-skills.test.ts
+++ b/packages/core/src/operations/endorse-skills.test.ts
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./ephemeral-action.js", () => ({
+  executeEphemeralAction: vi.fn(),
+}));
+
+import { executeEphemeralAction } from "./ephemeral-action.js";
+import { endorseSkills } from "./endorse-skills.js";
+
+const MOCK_RESULT = { success: true, personId: 42, results: [] };
+
+describe("endorseSkills", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(executeEphemeralAction).mockResolvedValue(MOCK_RESULT);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("calls executeEphemeralAction with EndorseSkills action type", async () => {
+    const input = { personId: 42, cdpPort: 9222 };
+
+    await endorseSkills(input);
+
+    expect(executeEphemeralAction).toHaveBeenCalledWith(
+      "EndorseSkills",
+      input,
+      expect.any(Object),
+    );
+  });
+
+  it("defaults skipIfNotEndorsable to true", async () => {
+    await endorseSkills({ personId: 42, cdpPort: 9222 });
+
+    expect(executeEphemeralAction).toHaveBeenCalledWith(
+      "EndorseSkills",
+      expect.any(Object),
+      expect.objectContaining({ skipIfNotEndorsable: true }),
+    );
+  });
+
+  it("passes explicit skipIfNotEndorsable value", async () => {
+    await endorseSkills({
+      personId: 42,
+      cdpPort: 9222,
+      skipIfNotEndorsable: false,
+    });
+
+    expect(executeEphemeralAction).toHaveBeenCalledWith(
+      "EndorseSkills",
+      expect.any(Object),
+      expect.objectContaining({ skipIfNotEndorsable: false }),
+    );
+  });
+
+  it("includes skillNames when provided", async () => {
+    await endorseSkills({
+      personId: 42,
+      cdpPort: 9222,
+      skillNames: ["TypeScript", "Node.js"],
+    });
+
+    expect(executeEphemeralAction).toHaveBeenCalledWith(
+      "EndorseSkills",
+      expect.any(Object),
+      expect.objectContaining({ skillNames: ["TypeScript", "Node.js"] }),
+    );
+  });
+
+  it("omits skillNames when undefined", async () => {
+    await endorseSkills({ personId: 42, cdpPort: 9222 });
+
+    const settings = vi.mocked(executeEphemeralAction).mock.calls[0]?.[2] as Record<string, unknown>;
+    expect(settings).not.toHaveProperty("skillNames");
+  });
+
+  it("includes limit when provided", async () => {
+    await endorseSkills({
+      personId: 42,
+      cdpPort: 9222,
+      limit: 5,
+    });
+
+    expect(executeEphemeralAction).toHaveBeenCalledWith(
+      "EndorseSkills",
+      expect.any(Object),
+      expect.objectContaining({ limit: 5 }),
+    );
+  });
+
+  it("omits limit when undefined", async () => {
+    await endorseSkills({ personId: 42, cdpPort: 9222 });
+
+    const settings = vi.mocked(executeEphemeralAction).mock.calls[0]?.[2] as Record<string, unknown>;
+    expect(settings).not.toHaveProperty("limit");
+  });
+
+  it("returns the result from executeEphemeralAction", async () => {
+    const result = await endorseSkills({ personId: 42, cdpPort: 9222 });
+
+    expect(result).toBe(MOCK_RESULT);
+  });
+
+  it("propagates errors from executeEphemeralAction", async () => {
+    vi.mocked(executeEphemeralAction).mockRejectedValue(
+      new Error("action failed"),
+    );
+
+    await expect(
+      endorseSkills({ personId: 42, cdpPort: 9222 }),
+    ).rejects.toThrow("action failed");
+  });
+});

--- a/packages/core/src/operations/enrich-profile.test.ts
+++ b/packages/core/src/operations/enrich-profile.test.ts
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./ephemeral-action.js", () => ({
+  executeEphemeralAction: vi.fn(),
+}));
+
+import { executeEphemeralAction } from "./ephemeral-action.js";
+import { enrichProfile } from "./enrich-profile.js";
+
+const MOCK_RESULT = { success: true, personId: 42, results: [] };
+
+describe("enrichProfile", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(executeEphemeralAction).mockResolvedValue(MOCK_RESULT);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("calls executeEphemeralAction with DataEnrichment action type", async () => {
+    const input = { personId: 42, cdpPort: 9222 };
+
+    await enrichProfile(input);
+
+    expect(executeEphemeralAction).toHaveBeenCalledWith(
+      "DataEnrichment",
+      input,
+      expect.any(Object),
+    );
+  });
+
+  it("defaults all categories to shouldEnrich: false", async () => {
+    await enrichProfile({ personId: 42, cdpPort: 9222 });
+
+    const defaults = { shouldEnrich: false };
+    expect(executeEphemeralAction).toHaveBeenCalledWith(
+      "DataEnrichment",
+      expect.any(Object),
+      expect.objectContaining({
+        profileInfo: defaults,
+        phones: defaults,
+        socials: defaults,
+        companies: defaults,
+      }),
+    );
+  });
+
+  it("defaults emails with personal and business types", async () => {
+    await enrichProfile({ personId: 42, cdpPort: 9222 });
+
+    expect(executeEphemeralAction).toHaveBeenCalledWith(
+      "DataEnrichment",
+      expect.any(Object),
+      expect.objectContaining({
+        emails: { shouldEnrich: false, types: ["personal", "business"] },
+      }),
+    );
+  });
+
+  it("passes explicit profileInfo category", async () => {
+    const profileInfo = { shouldEnrich: true };
+
+    await enrichProfile({ personId: 42, cdpPort: 9222, profileInfo });
+
+    expect(executeEphemeralAction).toHaveBeenCalledWith(
+      "DataEnrichment",
+      expect.any(Object),
+      expect.objectContaining({ profileInfo }),
+    );
+  });
+
+  it("passes explicit phones category", async () => {
+    const phones = { shouldEnrich: true };
+
+    await enrichProfile({ personId: 42, cdpPort: 9222, phones });
+
+    expect(executeEphemeralAction).toHaveBeenCalledWith(
+      "DataEnrichment",
+      expect.any(Object),
+      expect.objectContaining({ phones }),
+    );
+  });
+
+  it("passes explicit emails category", async () => {
+    const emails = { shouldEnrich: true, types: ["personal"] };
+
+    await enrichProfile({ personId: 42, cdpPort: 9222, emails });
+
+    expect(executeEphemeralAction).toHaveBeenCalledWith(
+      "DataEnrichment",
+      expect.any(Object),
+      expect.objectContaining({ emails }),
+    );
+  });
+
+  it("passes explicit socials category", async () => {
+    const socials = { shouldEnrich: true };
+
+    await enrichProfile({ personId: 42, cdpPort: 9222, socials });
+
+    expect(executeEphemeralAction).toHaveBeenCalledWith(
+      "DataEnrichment",
+      expect.any(Object),
+      expect.objectContaining({ socials }),
+    );
+  });
+
+  it("passes explicit companies category", async () => {
+    const companies = { shouldEnrich: true, actualDate: 1700000000 };
+
+    await enrichProfile({ personId: 42, cdpPort: 9222, companies });
+
+    expect(executeEphemeralAction).toHaveBeenCalledWith(
+      "DataEnrichment",
+      expect.any(Object),
+      expect.objectContaining({ companies }),
+    );
+  });
+
+  it("returns the result from executeEphemeralAction", async () => {
+    const result = await enrichProfile({ personId: 42, cdpPort: 9222 });
+
+    expect(result).toBe(MOCK_RESULT);
+  });
+
+  it("propagates errors from executeEphemeralAction", async () => {
+    vi.mocked(executeEphemeralAction).mockRejectedValue(
+      new Error("action failed"),
+    );
+
+    await expect(
+      enrichProfile({ personId: 42, cdpPort: 9222 }),
+    ).rejects.toThrow("action failed");
+  });
+});

--- a/packages/core/src/operations/ephemeral-action.test.ts
+++ b/packages/core/src/operations/ephemeral-action.test.ts
@@ -1,0 +1,215 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../services/account-resolution.js", () => ({
+  resolveAccount: vi.fn(),
+}));
+
+vi.mock("../services/instance-context.js", () => ({
+  withInstanceDatabase: vi.fn(),
+}));
+
+vi.mock("../services/ephemeral-campaign.js", () => ({
+  EphemeralCampaignService: vi.fn(),
+}));
+
+import type { InstanceDatabaseContext } from "../services/instance-context.js";
+import { resolveAccount } from "../services/account-resolution.js";
+import { withInstanceDatabase } from "../services/instance-context.js";
+import { EphemeralCampaignService } from "../services/ephemeral-campaign.js";
+import { executeEphemeralAction } from "./ephemeral-action.js";
+
+const MOCK_RESULT = {
+  success: true,
+  personId: 42,
+  results: [{ result: 1 }],
+};
+
+const mockExecute = vi.fn().mockResolvedValue(MOCK_RESULT);
+
+function setupMocks() {
+  vi.mocked(resolveAccount).mockResolvedValue(1);
+
+  vi.mocked(withInstanceDatabase).mockImplementation(
+    async (_cdpPort, _accountId, callback) =>
+      callback({
+        accountId: 1,
+        instance: {},
+        db: {},
+      } as unknown as InstanceDatabaseContext),
+  );
+
+  vi.mocked(EphemeralCampaignService).mockImplementation(function () {
+    return { execute: mockExecute } as unknown as EphemeralCampaignService;
+  });
+}
+
+describe("executeEphemeralAction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("throws when neither personId nor url is provided", async () => {
+    await expect(
+      executeEphemeralAction("Follow", { cdpPort: 9222 }),
+    ).rejects.toThrow("Exactly one of personId or url must be provided");
+  });
+
+  it("throws when both personId and url are provided", async () => {
+    await expect(
+      executeEphemeralAction("Follow", {
+        personId: 42,
+        url: "https://www.linkedin.com/in/test",
+        cdpPort: 9222,
+      }),
+    ).rejects.toThrow("Exactly one of personId or url must be provided");
+  });
+
+  it("resolves account and executes action with personId target", async () => {
+    setupMocks();
+
+    const result = await executeEphemeralAction("Follow", {
+      personId: 42,
+      cdpPort: 9222,
+    });
+
+    expect(resolveAccount).toHaveBeenCalledWith(9222, {});
+    expect(withInstanceDatabase).toHaveBeenCalledWith(
+      9222,
+      1,
+      expect.any(Function),
+    );
+    expect(mockExecute).toHaveBeenCalledWith("Follow", 42, undefined, {});
+    expect(result).toBe(MOCK_RESULT);
+  });
+
+  it("passes url as target when personId is not provided", async () => {
+    setupMocks();
+
+    await executeEphemeralAction("Follow", {
+      url: "https://www.linkedin.com/in/test",
+      cdpPort: 9222,
+    });
+
+    expect(mockExecute).toHaveBeenCalledWith(
+      "Follow",
+      "https://www.linkedin.com/in/test",
+      undefined,
+      {},
+    );
+  });
+
+  it("forwards actionSettings to execute", async () => {
+    setupMocks();
+
+    const settings = { skipIfUnfollowable: true, mode: "follow" };
+
+    await executeEphemeralAction(
+      "Follow",
+      { personId: 42, cdpPort: 9222 },
+      settings,
+    );
+
+    expect(mockExecute).toHaveBeenCalledWith("Follow", 42, settings, {});
+  });
+
+  it("forwards keepCampaign option when provided", async () => {
+    setupMocks();
+
+    await executeEphemeralAction("Follow", {
+      personId: 42,
+      cdpPort: 9222,
+      keepCampaign: true,
+    });
+
+    expect(mockExecute).toHaveBeenCalledWith("Follow", 42, undefined, {
+      keepCampaign: true,
+    });
+  });
+
+  it("omits keepCampaign from options when undefined", async () => {
+    setupMocks();
+
+    await executeEphemeralAction("Follow", {
+      personId: 42,
+      cdpPort: 9222,
+    });
+
+    expect(mockExecute).toHaveBeenCalledWith("Follow", 42, undefined, {});
+  });
+
+  it("passes connection options to resolveAccount", async () => {
+    setupMocks();
+
+    await executeEphemeralAction("Follow", {
+      personId: 42,
+      cdpPort: 1234,
+      cdpHost: "192.168.1.1",
+      allowRemote: true,
+    });
+
+    expect(resolveAccount).toHaveBeenCalledWith(1234, {
+      host: "192.168.1.1",
+      allowRemote: true,
+    });
+  });
+
+  it("omits undefined connection options from resolveAccount", async () => {
+    setupMocks();
+
+    await executeEphemeralAction("Follow", {
+      personId: 42,
+      cdpPort: 9222,
+    });
+
+    expect(resolveAccount).toHaveBeenCalledWith(9222, {});
+  });
+
+  it("propagates resolveAccount errors", async () => {
+    vi.mocked(resolveAccount).mockRejectedValue(
+      new Error("connection refused"),
+    );
+
+    await expect(
+      executeEphemeralAction("Follow", { personId: 42, cdpPort: 9222 }),
+    ).rejects.toThrow("connection refused");
+  });
+
+  it("propagates withInstanceDatabase errors", async () => {
+    vi.mocked(resolveAccount).mockResolvedValue(1);
+    vi.mocked(withInstanceDatabase).mockRejectedValue(
+      new Error("instance not running"),
+    );
+
+    await expect(
+      executeEphemeralAction("Follow", { personId: 42, cdpPort: 9222 }),
+    ).rejects.toThrow("instance not running");
+  });
+
+  it("propagates EphemeralCampaignService.execute errors", async () => {
+    vi.mocked(resolveAccount).mockResolvedValue(1);
+    vi.mocked(withInstanceDatabase).mockImplementation(
+      async (_cdpPort, _accountId, callback) =>
+        callback({
+          accountId: 1,
+          instance: {},
+          db: {},
+        } as unknown as InstanceDatabaseContext),
+    );
+    vi.mocked(EphemeralCampaignService).mockImplementation(function () {
+      return {
+        execute: vi.fn().mockRejectedValue(new Error("campaign failed")),
+      } as unknown as EphemeralCampaignService;
+    });
+
+    await expect(
+      executeEphemeralAction("Follow", { personId: 42, cdpPort: 9222 }),
+    ).rejects.toThrow("campaign failed");
+  });
+});

--- a/packages/core/src/operations/follow-person.test.ts
+++ b/packages/core/src/operations/follow-person.test.ts
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./ephemeral-action.js", () => ({
+  executeEphemeralAction: vi.fn(),
+}));
+
+import { executeEphemeralAction } from "./ephemeral-action.js";
+import { followPerson } from "./follow-person.js";
+
+const MOCK_RESULT = { success: true, personId: 42, results: [] };
+
+describe("followPerson", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(executeEphemeralAction).mockResolvedValue(MOCK_RESULT);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("calls executeEphemeralAction with Follow action type", async () => {
+    const input = { personId: 42, cdpPort: 9222 };
+
+    await followPerson(input);
+
+    expect(executeEphemeralAction).toHaveBeenCalledWith(
+      "Follow",
+      input,
+      expect.any(Object),
+    );
+  });
+
+  it("defaults skipIfUnfollowable to true", async () => {
+    await followPerson({ personId: 42, cdpPort: 9222 });
+
+    expect(executeEphemeralAction).toHaveBeenCalledWith(
+      "Follow",
+      expect.any(Object),
+      expect.objectContaining({ skipIfUnfollowable: true }),
+    );
+  });
+
+  it("passes explicit skipIfUnfollowable value", async () => {
+    await followPerson({
+      personId: 42,
+      cdpPort: 9222,
+      skipIfUnfollowable: false,
+    });
+
+    expect(executeEphemeralAction).toHaveBeenCalledWith(
+      "Follow",
+      expect.any(Object),
+      expect.objectContaining({ skipIfUnfollowable: false }),
+    );
+  });
+
+  it("includes mode when provided", async () => {
+    await followPerson({
+      personId: 42,
+      cdpPort: 9222,
+      mode: "unfollow",
+    });
+
+    expect(executeEphemeralAction).toHaveBeenCalledWith(
+      "Follow",
+      expect.any(Object),
+      expect.objectContaining({ mode: "unfollow" }),
+    );
+  });
+
+  it("omits mode when undefined", async () => {
+    await followPerson({ personId: 42, cdpPort: 9222 });
+
+    const settings = vi.mocked(executeEphemeralAction).mock.calls[0]?.[2] as Record<string, unknown>;
+    expect(settings).not.toHaveProperty("mode");
+  });
+
+  it("returns the result from executeEphemeralAction", async () => {
+    const result = await followPerson({ personId: 42, cdpPort: 9222 });
+
+    expect(result).toBe(MOCK_RESULT);
+  });
+
+  it("propagates errors from executeEphemeralAction", async () => {
+    vi.mocked(executeEphemeralAction).mockRejectedValue(
+      new Error("action failed"),
+    );
+
+    await expect(
+      followPerson({ personId: 42, cdpPort: 9222 }),
+    ).rejects.toThrow("action failed");
+  });
+});

--- a/packages/core/src/operations/like-person-posts.test.ts
+++ b/packages/core/src/operations/like-person-posts.test.ts
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./ephemeral-action.js", () => ({
+  executeEphemeralAction: vi.fn(),
+}));
+
+import { executeEphemeralAction } from "./ephemeral-action.js";
+import { likePersonPosts } from "./like-person-posts.js";
+
+const MOCK_RESULT = { success: true, personId: 42, results: [] };
+
+describe("likePersonPosts", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(executeEphemeralAction).mockResolvedValue(MOCK_RESULT);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("calls executeEphemeralAction with PersonPostsLiker action type", async () => {
+    const input = { personId: 42, cdpPort: 9222 };
+
+    await likePersonPosts(input);
+
+    expect(executeEphemeralAction).toHaveBeenCalledWith(
+      "PersonPostsLiker",
+      input,
+      expect.any(Object),
+    );
+  });
+
+  it("defaults skipIfNotLiked to true", async () => {
+    await likePersonPosts({ personId: 42, cdpPort: 9222 });
+
+    expect(executeEphemeralAction).toHaveBeenCalledWith(
+      "PersonPostsLiker",
+      expect.any(Object),
+      expect.objectContaining({ skipIfNotLiked: true }),
+    );
+  });
+
+  it("passes explicit skipIfNotLiked value", async () => {
+    await likePersonPosts({
+      personId: 42,
+      cdpPort: 9222,
+      skipIfNotLiked: false,
+    });
+
+    expect(executeEphemeralAction).toHaveBeenCalledWith(
+      "PersonPostsLiker",
+      expect.any(Object),
+      expect.objectContaining({ skipIfNotLiked: false }),
+    );
+  });
+
+  it("includes numberOfArticles when provided", async () => {
+    await likePersonPosts({
+      personId: 42,
+      cdpPort: 9222,
+      numberOfArticles: 3,
+    });
+
+    expect(executeEphemeralAction).toHaveBeenCalledWith(
+      "PersonPostsLiker",
+      expect.any(Object),
+      expect.objectContaining({ numberOfArticles: 3 }),
+    );
+  });
+
+  it("includes numberOfPosts when provided", async () => {
+    await likePersonPosts({
+      personId: 42,
+      cdpPort: 9222,
+      numberOfPosts: 5,
+    });
+
+    expect(executeEphemeralAction).toHaveBeenCalledWith(
+      "PersonPostsLiker",
+      expect.any(Object),
+      expect.objectContaining({ numberOfPosts: 5 }),
+    );
+  });
+
+  it("includes maxAgeOfArticles when provided", async () => {
+    await likePersonPosts({
+      personId: 42,
+      cdpPort: 9222,
+      maxAgeOfArticles: 30,
+    });
+
+    expect(executeEphemeralAction).toHaveBeenCalledWith(
+      "PersonPostsLiker",
+      expect.any(Object),
+      expect.objectContaining({ maxAgeOfArticles: 30 }),
+    );
+  });
+
+  it("includes maxAgeOfPosts when provided", async () => {
+    await likePersonPosts({
+      personId: 42,
+      cdpPort: 9222,
+      maxAgeOfPosts: 14,
+    });
+
+    expect(executeEphemeralAction).toHaveBeenCalledWith(
+      "PersonPostsLiker",
+      expect.any(Object),
+      expect.objectContaining({ maxAgeOfPosts: 14 }),
+    );
+  });
+
+  it("includes shouldAddComment when provided", async () => {
+    await likePersonPosts({
+      personId: 42,
+      cdpPort: 9222,
+      shouldAddComment: true,
+    });
+
+    expect(executeEphemeralAction).toHaveBeenCalledWith(
+      "PersonPostsLiker",
+      expect.any(Object),
+      expect.objectContaining({ shouldAddComment: true }),
+    );
+  });
+
+  it("includes messageTemplate when provided", async () => {
+    const messageTemplate = { type: "variants", variants: [{ text: "Great post!" }] };
+
+    await likePersonPosts({
+      personId: 42,
+      cdpPort: 9222,
+      messageTemplate,
+    });
+
+    expect(executeEphemeralAction).toHaveBeenCalledWith(
+      "PersonPostsLiker",
+      expect.any(Object),
+      expect.objectContaining({ messageTemplate }),
+    );
+  });
+
+  it("omits optional fields when undefined", async () => {
+    await likePersonPosts({ personId: 42, cdpPort: 9222 });
+
+    const settings = vi.mocked(executeEphemeralAction).mock.calls[0]?.[2] as Record<string, unknown>;
+    expect(settings).not.toHaveProperty("numberOfArticles");
+    expect(settings).not.toHaveProperty("numberOfPosts");
+    expect(settings).not.toHaveProperty("maxAgeOfArticles");
+    expect(settings).not.toHaveProperty("maxAgeOfPosts");
+    expect(settings).not.toHaveProperty("shouldAddComment");
+    expect(settings).not.toHaveProperty("messageTemplate");
+  });
+
+  it("returns the result from executeEphemeralAction", async () => {
+    const result = await likePersonPosts({ personId: 42, cdpPort: 9222 });
+
+    expect(result).toBe(MOCK_RESULT);
+  });
+
+  it("propagates errors from executeEphemeralAction", async () => {
+    vi.mocked(executeEphemeralAction).mockRejectedValue(
+      new Error("action failed"),
+    );
+
+    await expect(
+      likePersonPosts({ personId: 42, cdpPort: 9222 }),
+    ).rejects.toThrow("action failed");
+  });
+});

--- a/packages/core/src/operations/message-person.test.ts
+++ b/packages/core/src/operations/message-person.test.ts
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./ephemeral-action.js", () => ({
+  executeEphemeralAction: vi.fn(),
+}));
+
+import { executeEphemeralAction } from "./ephemeral-action.js";
+import { messagePerson } from "./message-person.js";
+
+const MOCK_RESULT = { success: true, personId: 42, results: [] };
+
+const MOCK_TEMPLATE = { type: "variants", variants: [{ text: "Hello!" }] };
+
+describe("messagePerson", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(executeEphemeralAction).mockResolvedValue(MOCK_RESULT);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("calls executeEphemeralAction with MessageToPerson action type", async () => {
+    const input = {
+      personId: 42,
+      cdpPort: 9222,
+      messageTemplate: MOCK_TEMPLATE,
+    };
+
+    await messagePerson(input);
+
+    expect(executeEphemeralAction).toHaveBeenCalledWith(
+      "MessageToPerson",
+      input,
+      expect.any(Object),
+    );
+  });
+
+  it("includes messageTemplate in action settings", async () => {
+    await messagePerson({
+      personId: 42,
+      cdpPort: 9222,
+      messageTemplate: MOCK_TEMPLATE,
+    });
+
+    expect(executeEphemeralAction).toHaveBeenCalledWith(
+      "MessageToPerson",
+      expect.any(Object),
+      expect.objectContaining({ messageTemplate: MOCK_TEMPLATE }),
+    );
+  });
+
+  it("includes subjectTemplate when provided", async () => {
+    const subjectTemplate = { type: "variants", variants: [{ text: "Subject" }] };
+
+    await messagePerson({
+      personId: 42,
+      cdpPort: 9222,
+      messageTemplate: MOCK_TEMPLATE,
+      subjectTemplate,
+    });
+
+    expect(executeEphemeralAction).toHaveBeenCalledWith(
+      "MessageToPerson",
+      expect.any(Object),
+      expect.objectContaining({ subjectTemplate }),
+    );
+  });
+
+  it("omits subjectTemplate when undefined", async () => {
+    await messagePerson({
+      personId: 42,
+      cdpPort: 9222,
+      messageTemplate: MOCK_TEMPLATE,
+    });
+
+    const settings = vi.mocked(executeEphemeralAction).mock.calls[0]?.[2] as Record<string, unknown>;
+    expect(settings).not.toHaveProperty("subjectTemplate");
+  });
+
+  it("includes rejectIfReplied when provided", async () => {
+    await messagePerson({
+      personId: 42,
+      cdpPort: 9222,
+      messageTemplate: MOCK_TEMPLATE,
+      rejectIfReplied: true,
+    });
+
+    expect(executeEphemeralAction).toHaveBeenCalledWith(
+      "MessageToPerson",
+      expect.any(Object),
+      expect.objectContaining({ rejectIfReplied: true }),
+    );
+  });
+
+  it("omits rejectIfReplied when undefined", async () => {
+    await messagePerson({
+      personId: 42,
+      cdpPort: 9222,
+      messageTemplate: MOCK_TEMPLATE,
+    });
+
+    const settings = vi.mocked(executeEphemeralAction).mock.calls[0]?.[2] as Record<string, unknown>;
+    expect(settings).not.toHaveProperty("rejectIfReplied");
+  });
+
+  it("includes rejectIfMessaged when provided", async () => {
+    await messagePerson({
+      personId: 42,
+      cdpPort: 9222,
+      messageTemplate: MOCK_TEMPLATE,
+      rejectIfMessaged: false,
+    });
+
+    expect(executeEphemeralAction).toHaveBeenCalledWith(
+      "MessageToPerson",
+      expect.any(Object),
+      expect.objectContaining({ rejectIfMessaged: false }),
+    );
+  });
+
+  it("omits rejectIfMessaged when undefined", async () => {
+    await messagePerson({
+      personId: 42,
+      cdpPort: 9222,
+      messageTemplate: MOCK_TEMPLATE,
+    });
+
+    const settings = vi.mocked(executeEphemeralAction).mock.calls[0]?.[2] as Record<string, unknown>;
+    expect(settings).not.toHaveProperty("rejectIfMessaged");
+  });
+
+  it("returns the result from executeEphemeralAction", async () => {
+    const result = await messagePerson({
+      personId: 42,
+      cdpPort: 9222,
+      messageTemplate: MOCK_TEMPLATE,
+    });
+
+    expect(result).toBe(MOCK_RESULT);
+  });
+
+  it("propagates errors from executeEphemeralAction", async () => {
+    vi.mocked(executeEphemeralAction).mockRejectedValue(
+      new Error("action failed"),
+    );
+
+    await expect(
+      messagePerson({
+        personId: 42,
+        cdpPort: 9222,
+        messageTemplate: MOCK_TEMPLATE,
+      }),
+    ).rejects.toThrow("action failed");
+  });
+});

--- a/packages/core/src/operations/navigate-away.test.ts
+++ b/packages/core/src/operations/navigate-away.test.ts
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CDPClient } from "../cdp/client.js";
+import { navigateAwayIf } from "./navigate-away.js";
+
+const mockClient = {
+  evaluate: vi.fn(),
+  navigate: vi.fn().mockResolvedValue(undefined),
+};
+
+describe("navigateAwayIf", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("navigates away when pathname contains the prefix", async () => {
+    mockClient.evaluate.mockResolvedValue("/in/some-profile/");
+
+    await navigateAwayIf(mockClient as unknown as CDPClient, "/in/");
+
+    expect(mockClient.navigate).toHaveBeenCalledWith(
+      "https://www.linkedin.com/mynetwork/",
+    );
+  });
+
+  it("does not navigate when pathname does not contain the prefix", async () => {
+    mockClient.evaluate.mockResolvedValue("/feed/");
+
+    await navigateAwayIf(mockClient as unknown as CDPClient, "/in/");
+
+    expect(mockClient.navigate).not.toHaveBeenCalled();
+  });
+
+  it("evaluates location.pathname via CDP", async () => {
+    mockClient.evaluate.mockResolvedValue("/feed/");
+
+    await navigateAwayIf(mockClient as unknown as CDPClient, "/in/");
+
+    expect(mockClient.evaluate).toHaveBeenCalledWith("location.pathname");
+  });
+
+  it("handles exact prefix match", async () => {
+    mockClient.evaluate.mockResolvedValue("/mynetwork/");
+
+    await navigateAwayIf(mockClient as unknown as CDPClient, "/mynetwork/");
+
+    expect(mockClient.navigate).toHaveBeenCalled();
+  });
+
+  it("handles partial prefix match within longer path", async () => {
+    mockClient.evaluate.mockResolvedValue("/in/john-doe/detail/experience/");
+
+    await navigateAwayIf(mockClient as unknown as CDPClient, "/in/");
+
+    expect(mockClient.navigate).toHaveBeenCalledWith(
+      "https://www.linkedin.com/mynetwork/",
+    );
+  });
+
+  it("propagates evaluate errors", async () => {
+    mockClient.evaluate.mockRejectedValue(new Error("CDP disconnected"));
+
+    await expect(
+      navigateAwayIf(mockClient as unknown as CDPClient, "/in/"),
+    ).rejects.toThrow("CDP disconnected");
+  });
+
+  it("propagates navigate errors", async () => {
+    mockClient.evaluate.mockResolvedValue("/in/some-profile/");
+    mockClient.navigate.mockRejectedValue(new Error("navigation failed"));
+
+    await expect(
+      navigateAwayIf(mockClient as unknown as CDPClient, "/in/"),
+    ).rejects.toThrow("navigation failed");
+  });
+});

--- a/packages/core/src/operations/remove-connection.test.ts
+++ b/packages/core/src/operations/remove-connection.test.ts
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./ephemeral-action.js", () => ({
+  executeEphemeralAction: vi.fn(),
+}));
+
+import { executeEphemeralAction } from "./ephemeral-action.js";
+import { removeConnection } from "./remove-connection.js";
+
+const MOCK_RESULT = { success: true, personId: 42, results: [] };
+
+describe("removeConnection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(executeEphemeralAction).mockResolvedValue(MOCK_RESULT);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("calls executeEphemeralAction with RemoveFromFirstConnection action type", async () => {
+    const input = { personId: 42, cdpPort: 9222 };
+
+    await removeConnection(input);
+
+    expect(executeEphemeralAction).toHaveBeenCalledWith(
+      "RemoveFromFirstConnection",
+      input,
+    );
+  });
+
+  it("does not pass action settings", async () => {
+    await removeConnection({ personId: 42, cdpPort: 9222 });
+
+    expect(executeEphemeralAction).toHaveBeenCalledWith(
+      "RemoveFromFirstConnection",
+      expect.any(Object),
+    );
+    expect(vi.mocked(executeEphemeralAction).mock.calls[0]).toHaveLength(2);
+  });
+
+  it("forwards url-based input", async () => {
+    const input = {
+      url: "https://www.linkedin.com/in/test",
+      cdpPort: 9222,
+    };
+
+    await removeConnection(input);
+
+    expect(executeEphemeralAction).toHaveBeenCalledWith(
+      "RemoveFromFirstConnection",
+      input,
+    );
+  });
+
+  it("returns the result from executeEphemeralAction", async () => {
+    const result = await removeConnection({ personId: 42, cdpPort: 9222 });
+
+    expect(result).toBe(MOCK_RESULT);
+  });
+
+  it("propagates errors from executeEphemeralAction", async () => {
+    vi.mocked(executeEphemeralAction).mockRejectedValue(
+      new Error("action failed"),
+    );
+
+    await expect(
+      removeConnection({ personId: 42, cdpPort: 9222 }),
+    ).rejects.toThrow("action failed");
+  });
+});

--- a/packages/core/src/operations/resolve-linkedin-entity.test.ts
+++ b/packages/core/src/operations/resolve-linkedin-entity.test.ts
@@ -1,0 +1,430 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../cdp/index.js", () => ({
+  resolveInstancePort: vi.fn(),
+}));
+
+vi.mock("../cdp/client.js", () => ({
+  CDPClient: vi.fn(),
+}));
+
+vi.mock("../cdp/discovery.js", () => ({
+  discoverTargets: vi.fn(),
+}));
+
+import { resolveInstancePort } from "../cdp/index.js";
+import { CDPClient } from "../cdp/client.js";
+import { discoverTargets } from "../cdp/discovery.js";
+import { resolveLinkedInEntity } from "./resolve-linkedin-entity.js";
+
+const LINKEDIN_TARGET = {
+  id: "target-1",
+  type: "page" as const,
+  title: "LinkedIn",
+  url: "https://www.linkedin.com/feed/",
+  description: "",
+  devtoolsFrontendUrl: "",
+};
+
+const mockClient = {
+  connect: vi.fn().mockResolvedValue(undefined),
+  evaluate: vi.fn(),
+  disconnect: vi.fn(),
+};
+
+function setupVoyagerMocks() {
+  vi.mocked(resolveInstancePort).mockResolvedValue(9222);
+  vi.mocked(CDPClient).mockImplementation(function () {
+    return mockClient as unknown as CDPClient;
+  });
+  vi.mocked(discoverTargets).mockResolvedValue([LINKEDIN_TARGET]);
+}
+
+describe("resolveLinkedInEntity", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("public typeahead (COMPANY/GEO)", () => {
+    it("uses public strategy when public endpoint succeeds", async () => {
+      vi.mocked(resolveInstancePort).mockResolvedValue(9222);
+
+      const mockResponse = {
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          elements: [
+            {
+              hitInfo: {
+                id: "1234",
+                displayName: "Acme Corp",
+              },
+            },
+          ],
+        }),
+      };
+      vi.spyOn(globalThis, "fetch").mockResolvedValue(
+        mockResponse as unknown as Response,
+      );
+
+      const result = await resolveLinkedInEntity({
+        query: "Acme",
+        entityType: "COMPANY",
+        cdpPort: 9222,
+      });
+
+      expect(result.strategy).toBe("public");
+      expect(result.matches).toEqual([
+        { id: "1234", name: "Acme Corp", type: "COMPANY" },
+      ]);
+    });
+
+    it("returns empty matches when public endpoint returns no elements", async () => {
+      vi.mocked(resolveInstancePort).mockResolvedValue(9222);
+
+      vi.spyOn(globalThis, "fetch").mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({ elements: [] }),
+      } as unknown as Response);
+
+      const result = await resolveLinkedInEntity({
+        query: "NonexistentCorp",
+        entityType: "COMPANY",
+        cdpPort: 9222,
+      });
+
+      expect(result.strategy).toBe("public");
+      expect(result.matches).toEqual([]);
+    });
+
+    it("falls back to Voyager when public endpoint fails", async () => {
+      setupVoyagerMocks();
+
+      vi.spyOn(globalThis, "fetch").mockResolvedValue({
+        ok: false,
+        status: 500,
+      } as unknown as Response);
+
+      mockClient.evaluate.mockResolvedValue({
+        data: {
+          elements: [
+            {
+              targetUrn: "urn:li:organization:5678",
+              title: { text: "Fallback Corp" },
+            },
+          ],
+        },
+      });
+
+      const result = await resolveLinkedInEntity({
+        query: "Fallback",
+        entityType: "COMPANY",
+        cdpPort: 9222,
+      });
+
+      expect(result.strategy).toBe("voyager");
+      expect(result.matches).toEqual([
+        { id: "5678", name: "Fallback Corp", type: "COMPANY" },
+      ]);
+    });
+
+    it("falls back to Voyager when public fetch throws", async () => {
+      setupVoyagerMocks();
+
+      vi.spyOn(globalThis, "fetch").mockRejectedValue(
+        new Error("network error"),
+      );
+
+      mockClient.evaluate.mockResolvedValue({
+        data: { elements: [] },
+      });
+
+      const result = await resolveLinkedInEntity({
+        query: "test",
+        entityType: "GEO",
+        cdpPort: 9222,
+      });
+
+      expect(result.strategy).toBe("voyager");
+    });
+
+    it("uses GEO typeahead type for public endpoint", async () => {
+      vi.mocked(resolveInstancePort).mockResolvedValue(9222);
+
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          elements: [
+            { hitInfo: { id: "101", locationName: "San Francisco" } },
+          ],
+        }),
+      } as unknown as Response);
+
+      await resolveLinkedInEntity({
+        query: "San Francisco",
+        entityType: "GEO",
+        cdpPort: 9222,
+      });
+
+      const url = fetchSpy.mock.calls[0]?.[0] as string;
+      expect(url).toContain("typeaheadType=GEO");
+      expect(url).toContain("query=San+Francisco");
+    });
+
+    it("limits public results to 10", async () => {
+      vi.mocked(resolveInstancePort).mockResolvedValue(9222);
+
+      const elements = Array.from({ length: 15 }, (_, i) => ({
+        hitInfo: { id: String(i), displayName: `Company ${String(i)}` },
+      }));
+
+      vi.spyOn(globalThis, "fetch").mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({ elements }),
+      } as unknown as Response);
+
+      const result = await resolveLinkedInEntity({
+        query: "test",
+        entityType: "COMPANY",
+        cdpPort: 9222,
+      });
+
+      expect(result.matches).toHaveLength(10);
+    });
+
+    it("filters out elements without hitInfo.id", async () => {
+      vi.mocked(resolveInstancePort).mockResolvedValue(9222);
+
+      vi.spyOn(globalThis, "fetch").mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          elements: [
+            { hitInfo: { id: "1", displayName: "Valid" } },
+            { hitInfo: { displayName: "No ID" } },
+            { hitInfo: { id: "3", companyName: "Also Valid" } },
+          ],
+        }),
+      } as unknown as Response);
+
+      const result = await resolveLinkedInEntity({
+        query: "test",
+        entityType: "COMPANY",
+        cdpPort: 9222,
+      });
+
+      expect(result.matches).toHaveLength(2);
+      expect(result.matches[0]?.id).toBe("1");
+      expect(result.matches[1]?.id).toBe("3");
+    });
+  });
+
+  describe("Voyager typeahead (SCHOOL)", () => {
+    it("goes directly to Voyager for SCHOOL entity type", async () => {
+      setupVoyagerMocks();
+
+      const fetchSpy = vi.spyOn(globalThis, "fetch");
+
+      mockClient.evaluate.mockResolvedValue({
+        data: {
+          elements: [
+            {
+              targetUrn: "urn:li:school:12345",
+              title: { text: "MIT" },
+            },
+          ],
+        },
+      });
+
+      const result = await resolveLinkedInEntity({
+        query: "MIT",
+        entityType: "SCHOOL",
+        cdpPort: 9222,
+      });
+
+      // Public endpoint should NOT be called for SCHOOL
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(result.strategy).toBe("voyager");
+      expect(result.matches).toEqual([
+        { id: "12345", name: "MIT", type: "SCHOOL" },
+      ]);
+    });
+
+    it("extracts ID from tracking URN when targetUrn is missing", async () => {
+      setupVoyagerMocks();
+
+      mockClient.evaluate.mockResolvedValue({
+        data: {
+          elements: [
+            {
+              trackingUrn: "urn:li:school:99999",
+              title: { text: "Stanford" },
+            },
+          ],
+        },
+      });
+
+      const result = await resolveLinkedInEntity({
+        query: "Stanford",
+        entityType: "SCHOOL",
+        cdpPort: 9222,
+      });
+
+      expect(result.matches[0]?.id).toBe("99999");
+    });
+
+    it("disconnects client after Voyager request", async () => {
+      setupVoyagerMocks();
+
+      mockClient.evaluate.mockResolvedValue({
+        data: { elements: [] },
+      });
+
+      await resolveLinkedInEntity({
+        query: "test",
+        entityType: "SCHOOL",
+        cdpPort: 9222,
+      });
+
+      expect(mockClient.disconnect).toHaveBeenCalled();
+    });
+
+    it("disconnects client even when Voyager request fails", async () => {
+      setupVoyagerMocks();
+
+      mockClient.evaluate.mockResolvedValue({
+        error: "HTTP 403: Forbidden",
+      });
+
+      await expect(
+        resolveLinkedInEntity({
+          query: "test",
+          entityType: "SCHOOL",
+          cdpPort: 9222,
+        }),
+      ).rejects.toThrow("Voyager typeahead request failed");
+
+      expect(mockClient.disconnect).toHaveBeenCalled();
+    });
+
+    it("throws when no LinkedIn page is found", async () => {
+      vi.mocked(resolveInstancePort).mockResolvedValue(9222);
+      vi.mocked(CDPClient).mockImplementation(function () {
+        return mockClient as unknown as CDPClient;
+      });
+      vi.mocked(discoverTargets).mockResolvedValue([
+        {
+          id: "target-1",
+          type: "page",
+          title: "Example",
+          url: "https://example.com",
+          description: "",
+          devtoolsFrontendUrl: "",
+        },
+      ]);
+
+      await expect(
+        resolveLinkedInEntity({
+          query: "test",
+          entityType: "SCHOOL",
+          cdpPort: 9222,
+        }),
+      ).rejects.toThrow("No LinkedIn page found");
+    });
+  });
+
+  describe("security", () => {
+    it("rejects non-loopback host without allowRemote", async () => {
+      vi.mocked(resolveInstancePort).mockResolvedValue(9222);
+      vi.mocked(discoverTargets).mockResolvedValue([LINKEDIN_TARGET]);
+
+      await expect(
+        resolveLinkedInEntity({
+          query: "test",
+          entityType: "SCHOOL",
+          cdpPort: 9222,
+          cdpHost: "192.168.1.100",
+        }),
+      ).rejects.toThrow("requires --allow-remote");
+    });
+
+    it("allows non-loopback host with allowRemote", async () => {
+      setupVoyagerMocks();
+
+      mockClient.evaluate.mockResolvedValue({
+        data: { elements: [] },
+      });
+
+      const result = await resolveLinkedInEntity({
+        query: "test",
+        entityType: "SCHOOL",
+        cdpPort: 9222,
+        cdpHost: "192.168.1.100",
+        allowRemote: true,
+      });
+
+      expect(result.strategy).toBe("voyager");
+    });
+
+    it("allows localhost without allowRemote", async () => {
+      setupVoyagerMocks();
+
+      mockClient.evaluate.mockResolvedValue({
+        data: { elements: [] },
+      });
+
+      const result = await resolveLinkedInEntity({
+        query: "test",
+        entityType: "SCHOOL",
+        cdpPort: 9222,
+        cdpHost: "localhost",
+      });
+
+      expect(result.strategy).toBe("voyager");
+    });
+  });
+
+  describe("connection options", () => {
+    it("defaults cdpHost to 127.0.0.1", async () => {
+      setupVoyagerMocks();
+
+      mockClient.evaluate.mockResolvedValue({
+        data: { elements: [] },
+      });
+
+      await resolveLinkedInEntity({
+        query: "test",
+        entityType: "SCHOOL",
+        cdpPort: 9222,
+      });
+
+      expect(discoverTargets).toHaveBeenCalledWith(9222, "127.0.0.1");
+    });
+
+    it("uses resolveInstancePort to determine actual port", async () => {
+      vi.mocked(resolveInstancePort).mockResolvedValue(35000);
+      vi.mocked(CDPClient).mockImplementation(function () {
+        return mockClient as unknown as CDPClient;
+      });
+      vi.mocked(discoverTargets).mockResolvedValue([LINKEDIN_TARGET]);
+
+      mockClient.evaluate.mockResolvedValue({
+        data: { elements: [] },
+      });
+
+      await resolveLinkedInEntity({
+        query: "test",
+        entityType: "SCHOOL",
+        cdpPort: 9222,
+      });
+
+      expect(resolveInstancePort).toHaveBeenCalledWith(9222, undefined);
+      expect(discoverTargets).toHaveBeenCalledWith(35000, "127.0.0.1");
+    });
+  });
+});

--- a/packages/core/src/operations/send-inmail.test.ts
+++ b/packages/core/src/operations/send-inmail.test.ts
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./ephemeral-action.js", () => ({
+  executeEphemeralAction: vi.fn(),
+}));
+
+import { executeEphemeralAction } from "./ephemeral-action.js";
+import { sendInmail } from "./send-inmail.js";
+
+const MOCK_RESULT = { success: true, personId: 42, results: [] };
+
+const MOCK_TEMPLATE = { type: "variants", variants: [{ text: "Hello!" }] };
+
+describe("sendInmail", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(executeEphemeralAction).mockResolvedValue(MOCK_RESULT);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("calls executeEphemeralAction with InMail action type", async () => {
+    const input = {
+      personId: 42,
+      cdpPort: 9222,
+      messageTemplate: MOCK_TEMPLATE,
+    };
+
+    await sendInmail(input);
+
+    expect(executeEphemeralAction).toHaveBeenCalledWith(
+      "InMail",
+      input,
+      expect.any(Object),
+    );
+  });
+
+  it("includes messageTemplate in action settings", async () => {
+    await sendInmail({
+      personId: 42,
+      cdpPort: 9222,
+      messageTemplate: MOCK_TEMPLATE,
+    });
+
+    expect(executeEphemeralAction).toHaveBeenCalledWith(
+      "InMail",
+      expect.any(Object),
+      expect.objectContaining({ messageTemplate: MOCK_TEMPLATE }),
+    );
+  });
+
+  it("includes subjectTemplate when provided", async () => {
+    const subjectTemplate = { type: "variants", variants: [{ text: "Subject" }] };
+
+    await sendInmail({
+      personId: 42,
+      cdpPort: 9222,
+      messageTemplate: MOCK_TEMPLATE,
+      subjectTemplate,
+    });
+
+    expect(executeEphemeralAction).toHaveBeenCalledWith(
+      "InMail",
+      expect.any(Object),
+      expect.objectContaining({ subjectTemplate }),
+    );
+  });
+
+  it("omits subjectTemplate when undefined", async () => {
+    await sendInmail({
+      personId: 42,
+      cdpPort: 9222,
+      messageTemplate: MOCK_TEMPLATE,
+    });
+
+    const settings = vi.mocked(executeEphemeralAction).mock.calls[0]?.[2] as Record<string, unknown>;
+    expect(settings).not.toHaveProperty("subjectTemplate");
+  });
+
+  it("includes rejectIfReplied when provided", async () => {
+    await sendInmail({
+      personId: 42,
+      cdpPort: 9222,
+      messageTemplate: MOCK_TEMPLATE,
+      rejectIfReplied: true,
+    });
+
+    expect(executeEphemeralAction).toHaveBeenCalledWith(
+      "InMail",
+      expect.any(Object),
+      expect.objectContaining({ rejectIfReplied: true }),
+    );
+  });
+
+  it("omits rejectIfReplied when undefined", async () => {
+    await sendInmail({
+      personId: 42,
+      cdpPort: 9222,
+      messageTemplate: MOCK_TEMPLATE,
+    });
+
+    const settings = vi.mocked(executeEphemeralAction).mock.calls[0]?.[2] as Record<string, unknown>;
+    expect(settings).not.toHaveProperty("rejectIfReplied");
+  });
+
+  it("includes proceedOnOutOfCredits when provided", async () => {
+    await sendInmail({
+      personId: 42,
+      cdpPort: 9222,
+      messageTemplate: MOCK_TEMPLATE,
+      proceedOnOutOfCredits: false,
+    });
+
+    expect(executeEphemeralAction).toHaveBeenCalledWith(
+      "InMail",
+      expect.any(Object),
+      expect.objectContaining({ proceedOnOutOfCredits: false }),
+    );
+  });
+
+  it("omits proceedOnOutOfCredits when undefined", async () => {
+    await sendInmail({
+      personId: 42,
+      cdpPort: 9222,
+      messageTemplate: MOCK_TEMPLATE,
+    });
+
+    const settings = vi.mocked(executeEphemeralAction).mock.calls[0]?.[2] as Record<string, unknown>;
+    expect(settings).not.toHaveProperty("proceedOnOutOfCredits");
+  });
+
+  it("returns the result from executeEphemeralAction", async () => {
+    const result = await sendInmail({
+      personId: 42,
+      cdpPort: 9222,
+      messageTemplate: MOCK_TEMPLATE,
+    });
+
+    expect(result).toBe(MOCK_RESULT);
+  });
+
+  it("propagates errors from executeEphemeralAction", async () => {
+    vi.mocked(executeEphemeralAction).mockRejectedValue(
+      new Error("action failed"),
+    );
+
+    await expect(
+      sendInmail({
+        personId: 42,
+        cdpPort: 9222,
+        messageTemplate: MOCK_TEMPLATE,
+      }),
+    ).rejects.toThrow("action failed");
+  });
+});

--- a/packages/core/src/operations/send-invite.test.ts
+++ b/packages/core/src/operations/send-invite.test.ts
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./ephemeral-action.js", () => ({
+  executeEphemeralAction: vi.fn(),
+}));
+
+import { executeEphemeralAction } from "./ephemeral-action.js";
+import { sendInvite } from "./send-invite.js";
+
+const MOCK_RESULT = { success: true, personId: 42, results: [] };
+
+describe("sendInvite", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(executeEphemeralAction).mockResolvedValue(MOCK_RESULT);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("calls executeEphemeralAction with InvitePerson action type", async () => {
+    const input = { personId: 42, cdpPort: 9222 };
+
+    await sendInvite(input);
+
+    expect(executeEphemeralAction).toHaveBeenCalledWith(
+      "InvitePerson",
+      input,
+      expect.any(Object),
+    );
+  });
+
+  it("defaults messageTemplate to empty variants", async () => {
+    await sendInvite({ personId: 42, cdpPort: 9222 });
+
+    expect(executeEphemeralAction).toHaveBeenCalledWith(
+      "InvitePerson",
+      expect.any(Object),
+      expect.objectContaining({
+        messageTemplate: { type: "variants", variants: [] },
+      }),
+    );
+  });
+
+  it("passes explicit messageTemplate", async () => {
+    const messageTemplate = { type: "variants", variants: [{ text: "Hi!" }] };
+
+    await sendInvite({
+      personId: 42,
+      cdpPort: 9222,
+      messageTemplate,
+    });
+
+    expect(executeEphemeralAction).toHaveBeenCalledWith(
+      "InvitePerson",
+      expect.any(Object),
+      expect.objectContaining({ messageTemplate }),
+    );
+  });
+
+  it("defaults saveAsLeadSN to false", async () => {
+    await sendInvite({ personId: 42, cdpPort: 9222 });
+
+    expect(executeEphemeralAction).toHaveBeenCalledWith(
+      "InvitePerson",
+      expect.any(Object),
+      expect.objectContaining({ saveAsLeadSN: false }),
+    );
+  });
+
+  it("passes explicit saveAsLeadSN value", async () => {
+    await sendInvite({
+      personId: 42,
+      cdpPort: 9222,
+      saveAsLeadSN: true,
+    });
+
+    expect(executeEphemeralAction).toHaveBeenCalledWith(
+      "InvitePerson",
+      expect.any(Object),
+      expect.objectContaining({ saveAsLeadSN: true }),
+    );
+  });
+
+  it("returns the result from executeEphemeralAction", async () => {
+    const result = await sendInvite({ personId: 42, cdpPort: 9222 });
+
+    expect(result).toBe(MOCK_RESULT);
+  });
+
+  it("propagates errors from executeEphemeralAction", async () => {
+    vi.mocked(executeEphemeralAction).mockRejectedValue(
+      new Error("action failed"),
+    );
+
+    await expect(
+      sendInvite({ personId: 42, cdpPort: 9222 }),
+    ).rejects.toThrow("action failed");
+  });
+});


### PR DESCRIPTION
## Summary

- Add unit tests for the `ephemeral-action` base module (personId/url validation, resolveAccount delegation, EphemeralCampaignService forwarding, connection options, error propagation)
- Add unit tests for 8 ephemeral action wrappers: follow-person, endorse-skills, enrich-profile, like-person-posts, message-person, remove-connection, send-inmail, send-invite (parameter assembly, defaults, error propagation)
- Add unit tests for `navigate-away` (CDP client interactions, pathname matching)
- Add unit tests for `build-linkedin-url` (dispatch logic for search, SN search, parameterised, fixed URL types)
- Add unit tests for `resolve-linkedin-entity` (public/Voyager two-strategy approach, SCHOOL direct routing, security guard, cleanup)
- **116 new tests** across 12 files, all following established mocking patterns

Closes #599

## Test plan

- [x] `pnpm test` — all 1384 core tests pass
- [x] `pnpm lint` — no lint errors
- [x] Each of the 12 files has a corresponding `.test.ts`
- [x] Tests follow established mocking pattern (mock resolveAccount/withInstanceDatabase/executeEphemeralAction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)