### PR TITLE
(docs) cdp: document evaluate<T> trust assertion in JSDoc

### DIFF
--- a/packages/core/src/cdp/client.ts
+++ b/packages/core/src/cdp/client.ts
@@ -133,13 +133,20 @@ export class CDPClient {
   /**
    * Evaluate a JavaScript expression via `Runtime.evaluate`.
    *
+   * **Type safety note:** The type parameter `T` is a *trust assertion*, not a
+   * runtime guarantee.  The value returned by the remote JavaScript context is
+   * cast to `T` via `as T` without any runtime validation.  Callers are
+   * responsible for validating the shape of the returned data when correctness
+   * is critical.
+   *
+   * @typeParam T - Expected return type.  Defaults to `unknown`.
    * @param expression  - JavaScript source to evaluate.
    * @param awaitPromise - Whether to await a Promise result (default `false`).
    * @param contextId - Optional execution context ID. When provided the
    *   expression runs in that context instead of the default (main world).
    *   Use this to evaluate in the Electron preload context when
    *   `nodeIntegration` is disabled in the renderer.
-   * @returns The deserialized value from the remote context.
+   * @returns The deserialized value from the remote context, cast to `T`.
    */
   async evaluate<T = unknown>(
     expression: string,


### PR DESCRIPTION
## Summary

- Add JSDoc documentation to `CDPClient.evaluate<T>` explaining that `T` is a trust assertion (compile-time cast via `as T`), not a runtime guarantee
- Document that callers are responsible for validating returned data on critical paths
- Add `@typeParam` and update `@returns` tag for completeness

Closes #606

## Test plan

- [x] `pnpm lint` passes
- [ ] CI build + lint + test pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)