### PR TITLE
(feat) humanize: add Gaussian delay distribution and page settling

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -460,4 +460,4 @@ export {
 export { DEFAULT_CDP_PORT } from "./constants.js";
 
 // Utilities
-export { delay, randomDelay, errorMessage, isCdpPort, isLoopbackAddress } from "./utils/index.js";
+export { delay, randomDelay, gaussianRandom, gaussianDelay, gaussianBetween, errorMessage, isCdpPort, isLoopbackAddress } from "./utils/index.js";

--- a/packages/core/src/linkedin/dom-automation.ts
+++ b/packages/core/src/linkedin/dom-automation.ts
@@ -3,7 +3,7 @@
 
 import type { CDPClient } from "../cdp/client.js";
 import { CDPEvaluationError, CDPTimeoutError } from "../cdp/errors.js";
-import { delay, randomDelay } from "../utils/delay.js";
+import { delay, gaussianDelay } from "../utils/delay.js";
 import type { HumanizedMouse } from "./humanized-mouse.js";
 
 /** Default timeout for DOM operations (ms). */
@@ -57,6 +57,66 @@ export async function waitForElement(
   throw new CDPTimeoutError(
     `Timed out waiting for element "${selector}" after ${timeout.toString()}ms`,
   );
+}
+
+/**
+ * Wait until the DOM stops mutating for `quietMs` milliseconds.
+ *
+ * Installs a `MutationObserver` via `Runtime.evaluate` that tracks
+ * the timestamp of the last mutation.  Polls until no mutations have
+ * occurred for the configured quiet period, then adds a "visual
+ * scanning" Gaussian delay to simulate a human pausing to read.
+ *
+ * @param client  - Connected CDP client targeting the page.
+ * @param quietMs - Milliseconds of mutation silence required (default: 500).
+ */
+export async function waitForDOMStable(
+  client: CDPClient,
+  quietMs = 500,
+): Promise<void> {
+  // Install a MutationObserver that stamps window.__lhLastMutation on every DOM change
+  await client.evaluate(
+    `(() => {
+      window.__lhLastMutation = Date.now();
+      const observer = new MutationObserver(() => {
+        window.__lhLastMutation = Date.now();
+      });
+      observer.observe(document.body, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        characterData: true,
+      });
+      window.__lhDOMObserver = observer;
+    })()`,
+  );
+
+  // Poll until the DOM has been quiet for quietMs
+  const pollInterval = 100;
+  const maxWait = 30_000;
+  const deadline = Date.now() + maxWait;
+
+  while (Date.now() < deadline) {
+    const elapsed = await client.evaluate<number>(
+      `Date.now() - (window.__lhLastMutation || 0)`,
+    );
+    if (elapsed >= quietMs) break;
+    await delay(pollInterval);
+  }
+
+  // Disconnect the observer
+  await client.evaluate(
+    `(() => {
+      if (window.__lhDOMObserver) {
+        window.__lhDOMObserver.disconnect();
+        delete window.__lhDOMObserver;
+        delete window.__lhLastMutation;
+      }
+    })()`,
+  );
+
+  // Simulate "visual scanning" — a human pausing to read the page
+  await gaussianDelay(1_200, 400, 600, 2_500);
 }
 
 /**
@@ -197,10 +257,7 @@ export async function typeText(
           key: char,
         });
 
-        const keystrokeDelay =
-          MIN_KEYSTROKE_DELAY +
-          Math.random() * (MAX_KEYSTROKE_DELAY - MIN_KEYSTROKE_DELAY);
-        await delay(keystrokeDelay);
+        await gaussianDelay(100, 25, MIN_KEYSTROKE_DELAY, MAX_KEYSTROKE_DELAY);
       }
       break;
   }
@@ -299,7 +356,7 @@ async function scrollToElementLoop(
 
     const deltaY = elementCenter - viewportCenter;
     await humanizedScrollY(client, deltaY, 300, 400, mouse);
-    await randomDelay(200, 400);
+    await gaussianDelay(300, 50, 200, 400);
   }
 
   return false;
@@ -416,18 +473,18 @@ export async function humanizedClick(
   selector: string,
   mouse?: HumanizedMouse | null,
 ): Promise<void> {
-  await randomDelay(0, 50); // Pre-click approach hesitation
+  await gaussianDelay(25, 12, 0, 50); // Pre-click approach hesitation
   if (mouse?.isAvailable) {
     const center = await getElementCenter(client, selector);
     if (center) {
       await mouse.click(center.x, center.y);
-      await randomDelay(50, 150); // Post-click visual confirmation
+      await gaussianDelay(100, 25, 50, 150); // Post-click visual confirmation
       return;
     }
   }
   // Fallback to JS click
   await click(client, selector);
-  await randomDelay(50, 150); // Post-click visual confirmation
+  await gaussianDelay(100, 25, 50, 150); // Post-click visual confirmation
 }
 
 /**
@@ -448,7 +505,7 @@ export async function humanizedHover(
   selector: string,
   mouse?: HumanizedMouse | null,
 ): Promise<void> {
-  await randomDelay(0, 50); // Pre-hover approach hesitation
+  await gaussianDelay(25, 12, 0, 50); // Pre-hover approach hesitation
   if (mouse?.isAvailable) {
     const center = await getElementCenter(client, selector);
     if (center) {

--- a/packages/core/src/linkedin/index.ts
+++ b/packages/core/src/linkedin/index.ts
@@ -11,6 +11,7 @@ export {
   scrollTo,
   typeText,
   type TypeMethod,
+  waitForDOMStable,
   waitForElement,
   type WaitForElementOptions,
 } from "./dom-automation.js";

--- a/packages/core/src/operations/comment-on-post.test.ts
+++ b/packages/core/src/operations/comment-on-post.test.ts
@@ -33,7 +33,7 @@ vi.mock("../linkedin/dom-automation.js", () => ({
 
 vi.mock("../utils/delay.js", () => ({
   delay: vi.fn().mockResolvedValue(undefined),
-  randomDelay: vi.fn().mockResolvedValue(undefined),
+  gaussianDelay: vi.fn().mockResolvedValue(undefined),
 }));
 
 import type { DatabaseContext } from "../services/instance-context.js";

--- a/packages/core/src/operations/comment-on-post.ts
+++ b/packages/core/src/operations/comment-on-post.ts
@@ -11,7 +11,7 @@ import { COMMENT_INPUT, COMMENT_SUBMIT_BUTTON } from "../linkedin/selectors.js";
 import { resolveAccount } from "../services/account-resolution.js";
 import { BudgetExceededError } from "../services/errors.js";
 import { withDatabase } from "../services/instance-context.js";
-import { randomDelay } from "../utils/delay.js";
+import { gaussianDelay } from "../utils/delay.js";
 import { buildCdpOptions, type ConnectionOptions } from "./types.js";
 
 /** Pattern matching supported LinkedIn post URL formats. */
@@ -135,7 +135,7 @@ export async function commentOnPost(
     await waitForElement(client, COMMENT_INPUT);
     await humanizedScrollTo(client, COMMENT_INPUT, mouse);
     await humanizedClick(client, COMMENT_INPUT, mouse);
-    await randomDelay(400, 700);
+    await gaussianDelay(550, 75, 400, 700);
 
     // Type comment text character-by-character
     await typeText(client, COMMENT_INPUT, input.text);
@@ -145,7 +145,7 @@ export async function commentOnPost(
     await humanizedClick(client, COMMENT_SUBMIT_BUTTON, mouse);
 
     // Brief wait for the comment to post
-    await randomDelay(1_500, 2_500);
+    await gaussianDelay(2_000, 250, 1_500, 2_500);
 
     return {
       success: true as const,

--- a/packages/core/src/operations/get-feed.test.ts
+++ b/packages/core/src/operations/get-feed.test.ts
@@ -17,8 +17,8 @@ vi.mock("./navigate-away.js", () => ({
 
 vi.mock("../utils/delay.js", () => ({
   delay: vi.fn().mockResolvedValue(undefined),
-  randomDelay: vi.fn().mockResolvedValue(undefined),
-  randomBetween: vi.fn().mockReturnValue(800),
+  gaussianDelay: vi.fn().mockResolvedValue(undefined),
+  gaussianBetween: vi.fn().mockReturnValue(800),
   maybeHesitate: vi.fn().mockResolvedValue(undefined),
 }));
 
@@ -393,7 +393,7 @@ describe("getFeed", () => {
     const result = await getFeed({ cdpPort: CDP_PORT, count: 4 });
 
     expect(result.posts).toHaveLength(4);
-    // scrollFeed uses randomBetween (mocked to return 800)
+    // scrollFeed uses gaussianBetween (mocked to return 800)
     expect(send).toHaveBeenCalledWith("Input.dispatchMouseEvent", {
       type: "mouseWheel",
       x: 300,

--- a/packages/core/src/operations/get-feed.ts
+++ b/packages/core/src/operations/get-feed.ts
@@ -7,7 +7,7 @@ import { CDPClient } from "../cdp/client.js";
 import { discoverTargets } from "../cdp/discovery.js";
 import { humanizedScrollY, humanizedScrollToByIndex } from "../linkedin/dom-automation.js";
 import type { HumanizedMouse } from "../linkedin/humanized-mouse.js";
-import { delay as utilsDelay, randomDelay, randomBetween, maybeHesitate } from "../utils/delay.js";
+import { delay as utilsDelay, gaussianDelay, gaussianBetween, maybeHesitate } from "../utils/delay.js";
 import type { ConnectionOptions } from "./types.js";
 import { navigateAwayIf } from "./navigate-away.js";
 
@@ -247,7 +247,7 @@ async function capturePostUrl(
 
     if (!clicked) return null; // No menu button — structural, retrying won't help
 
-    await randomDelay(500, 900);
+    await gaussianDelay(700, 100, 500, 900);
 
     // Click "Copy link to post" menu item
     await client.evaluate(`(() => {
@@ -259,7 +259,7 @@ async function capturePostUrl(
       }
     })()`);
 
-    await randomDelay(400, 700);
+    await gaussianDelay(550, 75, 400, 700);
 
     // Read captured URL
     const postUrl =
@@ -274,7 +274,7 @@ async function capturePostUrl(
     await client.evaluate(`(() => {
       document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
     })()`);
-    await randomDelay(300, 500);
+    await gaussianDelay(400, 50, 300, 500);
   }
 
   return null;
@@ -389,7 +389,7 @@ export async function scrollFeed(
   client: CDPClient,
   mouse?: HumanizedMouse | null,
 ): Promise<void> {
-  const distance = Math.round(randomBetween(600, 1_000));
+  const distance = Math.round(gaussianBetween(800, 100, 600, 1_000));
   await humanizedScrollY(client, distance, 300, 400, mouse);
 }
 
@@ -511,10 +511,12 @@ export async function getFeed(
         // Scale delay by newly visible content volume
         const newPostCount = allPosts.length - countBeforeScroll;
         const contentBonus = Math.min(
-          newPostCount * randomBetween(200, 500),
+          newPostCount * gaussianBetween(350, 75, 200, 500),
           3_000,
         );
-        await randomDelay(
+        await gaussianDelay(
+          1_500 * fatigueMultiplier + contentBonus,
+          150 * fatigueMultiplier,
           1_200 * fatigueMultiplier + contentBonus,
           1_800 * fatigueMultiplier + contentBonus,
         );
@@ -530,7 +532,7 @@ export async function getFeed(
     for (let i = 0; i < allPosts.length; i++) {
       const post = allPosts[i];
       if (!post) continue;
-      if (i > 0) await randomDelay(300, 800); // Inter-post delay
+      if (i > 0) await gaussianDelay(550, 125, 300, 800); // Inter-post delay
       const url = await capturePostUrl(client, i, mouse);
       if (url) {
         post.url = url;

--- a/packages/core/src/operations/get-post-engagers.test.ts
+++ b/packages/core/src/operations/get-post-engagers.test.ts
@@ -21,8 +21,8 @@ vi.mock("./get-feed.js", () => ({
 
 vi.mock("../utils/delay.js", () => ({
   delay: vi.fn().mockResolvedValue(undefined),
-  randomDelay: vi.fn().mockResolvedValue(undefined),
-  randomBetween: vi.fn().mockReturnValue(500),
+  gaussianDelay: vi.fn().mockResolvedValue(undefined),
+  gaussianBetween: vi.fn().mockReturnValue(500),
   maybeHesitate: vi.fn().mockResolvedValue(undefined),
 }));
 

--- a/packages/core/src/operations/get-post-engagers.ts
+++ b/packages/core/src/operations/get-post-engagers.ts
@@ -7,7 +7,7 @@ import { CDPClient } from "../cdp/client.js";
 import { discoverTargets } from "../cdp/discovery.js";
 import type { ConnectionOptions } from "./types.js";
 import { extractPostUrn, resolvePostDetailUrl } from "./get-post-stats.js";
-import { delay, randomDelay, randomBetween, maybeHesitate } from "../utils/delay.js";
+import { delay, gaussianDelay, gaussianBetween, maybeHesitate } from "../utils/delay.js";
 import { humanizedScrollTo, humanizedClick } from "../linkedin/dom-automation.js";
 import type { HumanizedMouse } from "../linkedin/humanized-mouse.js";
 import { navigateAwayIf } from "./navigate-away.js";
@@ -364,11 +364,11 @@ export async function getPostEngagers(
       if (allEngagers.length >= targetCount) break;
 
       if (scroll < maxScrollAttempts) {
-        const modalDistance = Math.round(randomBetween(350, 650));
+        const modalDistance = Math.round(gaussianBetween(500, 75, 350, 650));
         const scrolled =
           await client.evaluate<boolean>(createScrollModalScript(modalDistance));
         if (!scrolled) break;
-        await randomDelay(800, 1_200);
+        await gaussianDelay(1_000, 100, 800, 1_200);
       }
     }
 

--- a/packages/core/src/operations/get-profile-activity.test.ts
+++ b/packages/core/src/operations/get-profile-activity.test.ts
@@ -27,8 +27,8 @@ vi.mock("./get-feed.js", async (importOriginal) => {
 
 vi.mock("../utils/delay.js", () => ({
   delay: vi.fn().mockResolvedValue(undefined),
-  randomDelay: vi.fn().mockResolvedValue(undefined),
-  randomBetween: vi.fn().mockReturnValue(800),
+  gaussianDelay: vi.fn().mockResolvedValue(undefined),
+  gaussianBetween: vi.fn().mockReturnValue(800),
   maybeHesitate: vi.fn().mockResolvedValue(undefined),
 }));
 

--- a/packages/core/src/operations/get-profile-activity.ts
+++ b/packages/core/src/operations/get-profile-activity.ts
@@ -7,7 +7,7 @@ import { CDPClient } from "../cdp/client.js";
 import { discoverTargets } from "../cdp/discovery.js";
 import type { ConnectionOptions } from "./types.js";
 import { navigateAwayIf } from "./navigate-away.js";
-import { randomDelay, randomBetween, maybeHesitate } from "../utils/delay.js";
+import { gaussianDelay, gaussianBetween, maybeHesitate } from "../utils/delay.js";
 import { humanizedScrollToByIndex } from "../linkedin/dom-automation.js";
 import type { HumanizedMouse } from "../linkedin/humanized-mouse.js";
 import {
@@ -262,7 +262,7 @@ async function captureActivityPostUrl(
 
     if (!clicked) return null; // No menu button — structural, retrying won't help
 
-    await randomDelay(500, 900);
+    await gaussianDelay(700, 100, 500, 900);
 
     // Click "Copy link to post" menu item
     await client.evaluate(`(() => {
@@ -274,7 +274,7 @@ async function captureActivityPostUrl(
       }
     })()`);
 
-    await randomDelay(400, 700);
+    await gaussianDelay(550, 75, 400, 700);
 
     // Read captured URL
     const postUrl =
@@ -289,7 +289,7 @@ async function captureActivityPostUrl(
     await client.evaluate(`(() => {
       document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
     })()`);
-    await randomDelay(300, 500);
+    await gaussianDelay(400, 50, 300, 500);
   }
 
   return null;
@@ -385,10 +385,12 @@ export async function getProfileActivity(
         // Scale delay by newly visible content volume
         const newPostCount = allPosts.length - countBeforeScroll;
         const contentBonus = Math.min(
-          newPostCount * randomBetween(200, 500),
+          newPostCount * gaussianBetween(350, 75, 200, 500),
           3_000,
         );
-        await randomDelay(
+        await gaussianDelay(
+          1_500 * fatigueMultiplier + contentBonus,
+          150 * fatigueMultiplier,
           1_200 * fatigueMultiplier + contentBonus,
           1_800 * fatigueMultiplier + contentBonus,
         );
@@ -407,7 +409,7 @@ export async function getProfileActivity(
     for (let i = 0; i < allPosts.length; i++) {
       const post = allPosts[i];
       if (!post) continue;
-      if (i > 0) await randomDelay(300, 800); // Inter-post delay
+      if (i > 0) await gaussianDelay(550, 125, 300, 800); // Inter-post delay
       const url = await captureActivityPostUrl(client, i, mouse);
       if (url) {
         post.url = url;

--- a/packages/core/src/operations/navigate-away.ts
+++ b/packages/core/src/operations/navigate-away.ts
@@ -2,6 +2,7 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import type { CDPClient } from "../cdp/client.js";
+import { gaussianDelay } from "../utils/delay.js";
 
 /** Lightweight LinkedIn page used as a navigation-away target. */
 const AWAY_URL = "https://www.linkedin.com/mynetwork/";
@@ -12,6 +13,9 @@ const AWAY_URL = "https://www.linkedin.com/mynetwork/";
  * fire fresh API requests) on the subsequent navigation, even when the
  * browser is already on the target page.
  *
+ * After navigating, a Gaussian-distributed delay simulates the human
+ * wait for the page transition to settle.
+ *
  * No-op when the current pathname does NOT contain `pathPrefix`.
  */
 export async function navigateAwayIf(
@@ -21,5 +25,6 @@ export async function navigateAwayIf(
   const pathname = await client.evaluate<string>("location.pathname");
   if (pathname.includes(pathPrefix)) {
     await client.navigate(AWAY_URL);
+    await gaussianDelay(1_500, 500, 800, 3_000);
   }
 }

--- a/packages/core/src/operations/react-to-post.test.ts
+++ b/packages/core/src/operations/react-to-post.test.ts
@@ -21,7 +21,7 @@ vi.mock("../linkedin/dom-automation.js", () => ({
 
 vi.mock("../utils/delay.js", () => ({
   delay: vi.fn().mockResolvedValue(undefined),
-  randomDelay: vi.fn().mockResolvedValue(undefined),
+  gaussianDelay: vi.fn().mockResolvedValue(undefined),
 }));
 
 import { CDPClient } from "../cdp/client.js";

--- a/packages/core/src/operations/react-to-post.ts
+++ b/packages/core/src/operations/react-to-post.ts
@@ -16,7 +16,7 @@ import {
   REACTION_TRIGGER,
   REACTIONS_MENU,
 } from "../linkedin/selectors.js";
-import { randomDelay } from "../utils/delay.js";
+import { gaussianDelay } from "../utils/delay.js";
 import type { ConnectionOptions } from "./types.js";
 
 /**
@@ -127,7 +127,7 @@ export async function reactToPost(
 
     // Hover over the reaction trigger to expand the reactions menu
     await humanizedHover(client, REACTION_TRIGGER, mouse);
-    await randomDelay(1_200, 1_800);
+    await gaussianDelay(1_500, 150, 1_200, 1_800);
 
     // Wait for the reactions menu to appear
     await waitForElement(client, REACTIONS_MENU, { timeout: 5_000 });
@@ -138,7 +138,7 @@ export async function reactToPost(
     await humanizedClick(client, reactionSelector, mouse);
 
     // Let the UI settle
-    await randomDelay(400, 700);
+    await gaussianDelay(550, 75, 400, 700);
 
     return {
       success: true as const,

--- a/packages/core/src/operations/search-posts.test.ts
+++ b/packages/core/src/operations/search-posts.test.ts
@@ -17,8 +17,8 @@ vi.mock("./navigate-away.js", () => ({
 
 vi.mock("../utils/delay.js", () => ({
   delay: vi.fn().mockResolvedValue(undefined),
-  randomDelay: vi.fn().mockResolvedValue(undefined),
-  randomBetween: vi.fn().mockReturnValue(800),
+  gaussianDelay: vi.fn().mockResolvedValue(undefined),
+  gaussianBetween: vi.fn().mockReturnValue(800),
   maybeHesitate: vi.fn().mockResolvedValue(undefined),
 }));
 

--- a/packages/core/src/operations/search-posts.ts
+++ b/packages/core/src/operations/search-posts.ts
@@ -7,7 +7,7 @@ import { CDPClient } from "../cdp/client.js";
 import { discoverTargets } from "../cdp/discovery.js";
 import type { ConnectionOptions } from "./types.js";
 import { navigateAwayIf } from "./navigate-away.js";
-import { randomDelay, randomBetween, maybeHesitate } from "../utils/delay.js";
+import { gaussianDelay, gaussianBetween, maybeHesitate } from "../utils/delay.js";
 import { humanizedScrollToByIndex } from "../linkedin/dom-automation.js";
 import type { HumanizedMouse } from "../linkedin/humanized-mouse.js";
 import {
@@ -400,10 +400,12 @@ export async function searchPosts(
         // Scale delay by newly visible content volume
         const newPostCount = allPosts.length - countBeforeScroll;
         const contentBonus = Math.min(
-          newPostCount * randomBetween(200, 500),
+          newPostCount * gaussianBetween(350, 75, 200, 500),
           3_000,
         );
-        await randomDelay(
+        await gaussianDelay(
+          1_500 * fatigueMultiplier + contentBonus,
+          150 * fatigueMultiplier,
           1_200 * fatigueMultiplier + contentBonus,
           1_800 * fatigueMultiplier + contentBonus,
         );
@@ -438,7 +440,7 @@ export async function searchPosts(
         const post = allPosts[i];
         if (!post || post.url) continue;
 
-        if (i > 0) await randomDelay(300, 800); // Inter-post delay
+        if (i > 0) await gaussianDelay(550, 125, 300, 800); // Inter-post delay
         await maybeHesitate(); // Probabilistic pause before menu interaction
 
         // Reset capture
@@ -459,7 +461,7 @@ export async function searchPosts(
         })()`);
         if (!clicked) continue;
 
-        await randomDelay(500, 900);
+        await gaussianDelay(700, 100, 500, 900);
 
         // Click "Copy link to post" menu item
         await client.evaluate(`(() => {
@@ -471,7 +473,7 @@ export async function searchPosts(
           }
         })()`);
 
-        await randomDelay(400, 700);
+        await gaussianDelay(550, 75, 400, 700);
 
         // Read captured URL
         const postUrl =

--- a/packages/core/src/utils/delay.test.ts
+++ b/packages/core/src/utils/delay.test.ts
@@ -2,7 +2,13 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import { describe, expect, it } from "vitest";
-import { delay, randomBetween, maybeHesitate } from "./delay.js";
+import {
+  delay,
+  randomBetween,
+  maybeHesitate,
+  gaussianRandom,
+  gaussianBetween,
+} from "./delay.js";
 
 describe("delay", () => {
   it("should resolve after the given time", async () => {
@@ -29,6 +35,59 @@ describe("randomBetween", () => {
 
   it("returns min when range is zero", () => {
     expect(randomBetween(5, 5)).toBe(5);
+  });
+});
+
+describe("gaussianRandom", () => {
+  it("produces values with approximately correct mean and stdDev over many samples", () => {
+    const mean = 100;
+    const stdDev = 25;
+    const n = 10_000;
+    const samples: number[] = [];
+
+    for (let i = 0; i < n; i++) {
+      samples.push(gaussianRandom(mean, stdDev));
+    }
+
+    const sampleMean = samples.reduce((a, b) => a + b, 0) / n;
+    const sampleVariance =
+      samples.reduce((sum, x) => sum + (x - sampleMean) ** 2, 0) / (n - 1);
+    const sampleStdDev = Math.sqrt(sampleVariance);
+
+    // Allow ±5% tolerance on mean and ±10% on stdDev
+    expect(sampleMean).toBeGreaterThan(mean * 0.95);
+    expect(sampleMean).toBeLessThan(mean * 1.05);
+    expect(sampleStdDev).toBeGreaterThan(stdDev * 0.9);
+    expect(sampleStdDev).toBeLessThan(stdDev * 1.1);
+  });
+
+  it("centers on the given mean when stdDev is 0", () => {
+    for (let i = 0; i < 100; i++) {
+      expect(gaussianRandom(42, 0)).toBe(42);
+    }
+  });
+});
+
+describe("gaussianBetween", () => {
+  it("always returns values within [min, max]", () => {
+    for (let i = 0; i < 1_000; i++) {
+      const value = gaussianBetween(500, 100, 300, 700);
+      expect(value).toBeGreaterThanOrEqual(300);
+      expect(value).toBeLessThanOrEqual(700);
+    }
+  });
+
+  it("returns min when range is zero", () => {
+    expect(gaussianBetween(5, 0, 5, 5)).toBe(5);
+  });
+
+  it("clamps values that would exceed bounds", () => {
+    // With a very large stdDev, values should still be clamped
+    for (let i = 0; i < 100; i++) {
+      const value = gaussianBetween(50, 1_000, 0, 100);
+      expect(value).toBeGreaterThanOrEqual(0);
+      expect(value).toBeLessThanOrEqual(100);
+    }
   });
 });
 

--- a/packages/core/src/utils/delay.ts
+++ b/packages/core/src/utils/delay.ts
@@ -38,7 +38,72 @@ export function randomBetween(min: number, max: number): number {
  */
 export function maybeHesitate(probability = 0.12): Promise<void> {
   if (Math.random() < probability) {
-    return randomDelay(500, 2_000);
+    return gaussianDelay(1_250, 375, 500, 2_000);
   }
   return Promise.resolve();
+}
+
+/**
+ * Return a normally-distributed random number using the Box-Muller transform.
+ *
+ * The result is centered on `mean` with the given `stdDev`.  Unlike
+ * uniform `Math.random()`, this produces a bell-curve distribution
+ * that more closely models human timing variance.
+ */
+export function gaussianRandom(mean: number, stdDev: number): number {
+  // Box-Muller transform: two uniform samples → one normal sample
+  let u1: number;
+  let u2: number;
+  do {
+    u1 = Math.random();
+    u2 = Math.random();
+  } while (u1 === 0); // avoid log(0)
+
+  const z = Math.sqrt(-2.0 * Math.log(u1)) * Math.cos(2.0 * Math.PI * u2);
+  return mean + z * stdDev;
+}
+
+/**
+ * Return a promise that resolves after a Gaussian-distributed delay.
+ *
+ * The delay is drawn from a normal distribution centered on `mean` with
+ * the given `stdDev`, then clamped to `[min, max]`.  This produces more
+ * human-like timing than uniform random — most delays cluster near the
+ * mean with occasional faster or slower outliers.
+ *
+ * @param mean   - Center of the distribution in milliseconds.
+ * @param stdDev - Standard deviation in milliseconds.
+ * @param min    - Minimum delay in milliseconds (default: 0).
+ * @param max    - Maximum delay in milliseconds (default: Infinity).
+ */
+export function gaussianDelay(
+  mean: number,
+  stdDev: number,
+  min = 0,
+  max = Infinity,
+): Promise<void> {
+  const raw = gaussianRandom(mean, stdDev);
+  const clamped = Math.max(min, Math.min(max, raw));
+  return delay(clamped);
+}
+
+/**
+ * Return a Gaussian-distributed numeric value clamped to `[min, max]`.
+ *
+ * Useful for randomising scroll distances, coordinate offsets, and other
+ * non-delay numeric values that benefit from human-like variation.
+ *
+ * @param mean   - Center of the distribution.
+ * @param stdDev - Standard deviation.
+ * @param min    - Minimum value.
+ * @param max    - Maximum value.
+ */
+export function gaussianBetween(
+  mean: number,
+  stdDev: number,
+  min: number,
+  max: number,
+): number {
+  const raw = gaussianRandom(mean, stdDev);
+  return Math.max(min, Math.min(max, raw));
 }

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -2,6 +2,6 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 export { isCdpPort } from "./cdp-port.js";
-export { delay, randomDelay } from "./delay.js";
+export { delay, randomDelay, gaussianRandom, gaussianDelay, gaussianBetween } from "./delay.js";
 export { errorMessage } from "./error-message.js";
 export { isLoopbackAddress } from "./loopback.js";


### PR DESCRIPTION
## Summary

- Add `gaussianRandom()`, `gaussianDelay()`, `gaussianBetween()` utilities using Box-Muller transform for bell-curve timing
- Add `waitForDOMStable()` — MutationObserver-based DOM settling with visual scanning delay
- Add post-navigation Gaussian delay to `navigateAwayIf()`
- Migrate all 19 call sites from uniform `randomDelay`/`randomBetween` to Gaussian equivalents
- Statistical unit tests verify correct mean/stdDev over N=10,000 samples

## Motivation

Uniform `Math.random()` delay distribution is statistically distinguishable from human timing (which follows a bell curve). Immediate interaction after `client.navigate()` is a strong automation signal.

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm test` passes (2,388 tests across all packages)
- [x] New `gaussianRandom` tests verify mean within ±5% and stdDev within ±10% over 10k samples
- [x] `gaussianBetween` always returns clamped values within `[min, max]`

Closes #621

🤖 Generated with [Claude Code](https://claude.com/claude-code)