### PR TITLE
Pass LHREMOTE_E2E_PERSON_ID through Turbo to test:e2e tasks

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -11,6 +11,7 @@
     },
     "test:e2e": {
       "dependsOn": ["build", "^test:e2e"],
+      "passThroughEnv": ["LHREMOTE_E2E_PERSON_ID"],
       "cache": false
     },
     "lint": {


### PR DESCRIPTION
## Summary

- Add `passThroughEnv: ["LHREMOTE_E2E_PERSON_ID"]` to the `test:e2e` task in `turbo.json`
- Turbo was stripping this env var, causing `scrape-messaging-history` and `check-replies` E2E tests to fail with "LHREMOTE_E2E_PERSON_ID must be set" when run via `pnpm test:e2e`

Closes #639

## Test plan

- [x] Verified `pnpm test:e2e` now passes the env var through (previously failed with "expected undefined to be truthy")
- [x] `pnpm lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)