### PR TITLE
Retry fetchPostUrlFromFeed in get-post E2E test setup

### DIFF
--- a/packages/e2e/src/get-post-stats.e2e.test.ts
+++ b/packages/e2e/src/get-post-stats.e2e.test.ts
@@ -75,8 +75,15 @@ describeE2E("get-post-stats operation", () => {
       { retries: 30, delay: 2_000 },
     );
 
-    // Pre-fetch a live post URN from the feed
-    capturedPostUrl = await fetchPostUrlFromFeed(cdpPort);
+    // Pre-fetch a live post URL from the feed (retry — feed may not render immediately)
+    capturedPostUrl = await retryAsync(
+      async () => {
+        const url = await fetchPostUrlFromFeed(cdpPort);
+        if (url === undefined) throw new Error("Feed returned no posts yet");
+        return url;
+      },
+      { retries: 5, delay: 3_000 },
+    );
   }, 120_000);
 
   afterAll(async () => {

--- a/packages/e2e/src/get-post.e2e.test.ts
+++ b/packages/e2e/src/get-post.e2e.test.ts
@@ -75,8 +75,15 @@ describeE2E("get-post operation", () => {
       { retries: 30, delay: 2_000 },
     );
 
-    // Pre-fetch a live post URN from the feed
-    capturedPostUrl = await fetchPostUrlFromFeed(cdpPort);
+    // Pre-fetch a live post URL from the feed (retry — feed may not render immediately)
+    capturedPostUrl = await retryAsync(
+      async () => {
+        const url = await fetchPostUrlFromFeed(cdpPort);
+        if (url === undefined) throw new Error("Feed returned no posts yet");
+        return url;
+      },
+      { retries: 5, delay: 3_000 },
+    );
   }, 120_000);
 
   afterAll(async () => {


### PR DESCRIPTION
## Summary

- Wraps `fetchPostUrlFromFeed()` in `retryAsync()` in both `get-post.e2e.test.ts` and `get-post-stats.e2e.test.ts` `beforeAll` blocks
- Retries up to 5 times with 3s delay, throwing when the feed returns no posts so retry logic can kick in
- Consistent with how other transient setup operations (CDP discovery, LinkedIn target wait) already use `retryAsync()`

## Test plan

- [ ] Run `pnpm --filter @lhremote/e2e test:e2e:file get-post` locally — should pass reliably even with slow feed rendering

Closes #643

🤖 Generated with [Claude Code](https://claude.com/claude-code)