### PR TITLE
Export CDPClient from @lhremote/core

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -206,6 +206,7 @@ export {
 } from "./db/index.js";
 
 export {
+  CDPClient,
   CDPConnectionError,
   CDPError,
   CDPEvaluationError,


### PR DESCRIPTION
## Summary

- Add `CDPClient` to the CDP re-exports in `packages/core/src/index.ts`
- Fixes `selectors.e2e.test.ts` failing with `CDPClient is not a constructor` (17 tests blocked)

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm build` passes
- [x] `pnpm test` passes (468 tests)
- [ ] `selectors.e2e.test.ts` suite runs successfully (requires local LinkedHelper)

Closes #646

🤖 Generated with [Claude Code](https://claude.com/claude-code)