### PR TITLE
(fix) e2e: stabilize quit() test with initial delay and longer deadline

### DIFF
--- a/packages/e2e/src/app-service.e2e.test.ts
+++ b/packages/e2e/src/app-service.e2e.test.ts
@@ -54,7 +54,10 @@ describeE2E("AppService", () => {
       async () => {
         await app.quit();
 
-        const deadline = Date.now() + 15_000;
+        // Allow the process to begin shutting down before probing
+        await new Promise<void>((r) => setTimeout(r, 1_000));
+
+        const deadline = Date.now() + 30_000;
         const probe = new AppService(port);
         while (Date.now() < deadline) {
           if (!(await probe.isRunning())) {
@@ -68,7 +71,7 @@ describeE2E("AppService", () => {
         // Prevent top-level afterAll from trying to quit again
         app = new AppService();
       },
-      30_000,
+      60_000,
     );
 
     it("quit() is a no-op when not running", async () => {


### PR DESCRIPTION
## Summary

- Add 1s initial delay after `quit()` before polling `isRunning()` to let the process begin shutting down
- Increase polling deadline from 15s to 30s to accommodate variable shutdown times (SIGTERM → SIGKILL fallback)
- Increase test timeout from 30s to 60s to cover the longer polling window

Closes #642

## Test plan

- [ ] Run `pnpm --filter @lhremote/e2e test:e2e:file app-service` multiple times locally to verify the quit test passes reliably

🤖 Generated with [Claude Code](https://claude.com/claude-code)