### PR TITLE
E2E tests: collect-people

### DIFF
--- a/packages/core/src/operations/collect-people.test.ts
+++ b/packages/core/src/operations/collect-people.test.ts
@@ -15,11 +15,16 @@ vi.mock("../services/collection.js", () => ({
   CollectionService: vi.fn(),
 }));
 
+vi.mock("../db/index.js", () => ({
+  CampaignRepository: vi.fn(),
+}));
+
 import type { InstanceDatabaseContext } from "../services/instance-context.js";
 import { resolveAccount } from "../services/account-resolution.js";
 import { withInstanceDatabase } from "../services/instance-context.js";
 import { CollectionService } from "../services/collection.js";
 import { CollectionError } from "../services/errors.js";
+import { CampaignRepository } from "../db/index.js";
 import { collectPeople } from "./collect-people.js";
 
 function setupMocks() {
@@ -38,6 +43,12 @@ function setupMocks() {
     return {
       collect: vi.fn().mockResolvedValue(undefined),
     } as unknown as CollectionService;
+  });
+
+  vi.mocked(CampaignRepository).mockImplementation(function () {
+    return {
+      getCampaignActions: vi.fn().mockReturnValue([{ id: 10, campaignId: 42, name: "VisitAndExtract" }]),
+    } as unknown as CampaignRepository;
   });
 }
 
@@ -100,7 +111,7 @@ describe("collectPeople", () => {
     ).rejects.toThrow(CollectionError);
   });
 
-  it("passes collection options to CollectionService.collect", async () => {
+  it("passes campaignId and actionId to CollectionService.collect", async () => {
     const mockCollect = vi.fn().mockResolvedValue(undefined);
     vi.mocked(resolveAccount).mockResolvedValue(1);
     vi.mocked(withInstanceDatabase).mockImplementation(
@@ -114,20 +125,22 @@ describe("collectPeople", () => {
     vi.mocked(CollectionService).mockImplementation(function () {
       return { collect: mockCollect } as unknown as CollectionService;
     });
+    vi.mocked(CampaignRepository).mockImplementation(function () {
+      return {
+        getCampaignActions: vi.fn().mockReturnValue([{ id: 10, campaignId: 42, name: "VisitAndExtract" }]),
+      } as unknown as CampaignRepository;
+    });
 
     await collectPeople({
       sourceUrl: "https://www.linkedin.com/search/results/people/",
       campaignId: 42,
-      limit: 100,
-      maxPages: 5,
-      pageSize: 25,
       cdpPort: 9222,
     });
 
     expect(mockCollect).toHaveBeenCalledWith(
       "https://www.linkedin.com/search/results/people/",
       42,
-      { limit: 100, maxPages: 5, pageSize: 25 },
+      10,
     );
   });
 
@@ -197,6 +210,11 @@ describe("collectPeople", () => {
           db: {},
         } as unknown as InstanceDatabaseContext),
     );
+    vi.mocked(CampaignRepository).mockImplementation(function () {
+      return {
+        getCampaignActions: vi.fn().mockReturnValue([{ id: 10, campaignId: 42, name: "VisitAndExtract" }]),
+      } as unknown as CampaignRepository;
+    });
     vi.mocked(CollectionService).mockImplementation(function () {
       return {
         collect: vi.fn().mockRejectedValue(

--- a/packages/core/src/operations/collect-people.ts
+++ b/packages/core/src/operations/collect-people.ts
@@ -6,6 +6,7 @@ import { resolveAccount } from "../services/account-resolution.js";
 import { withInstanceDatabase } from "../services/instance-context.js";
 import { CollectionService } from "../services/collection.js";
 import { CollectionError } from "../services/errors.js";
+import { CampaignRepository } from "../db/index.js";
 import { detectSourceType, validateSourceType } from "../services/source-type-registry.js";
 import { buildCdpOptions, type ConnectionOptions } from "./types.js";
 
@@ -73,13 +74,26 @@ export async function collectPeople(
 
   const accountId = await resolveAccount(cdpPort, buildCdpOptions(input));
 
-  return withInstanceDatabase(cdpPort, accountId, async ({ instance }) => {
+  return withInstanceDatabase(cdpPort, accountId, async ({ instance, db }) => {
+    // Look up the first action in the campaign — the collect IPC call
+    // requires an actionId to associate collected people with.
+    const campaignRepo = new CampaignRepository(db);
+    const actions = campaignRepo.getCampaignActions(input.campaignId);
+    if (actions.length === 0) {
+      throw new CollectionError(
+        `Campaign ${String(input.campaignId)} has no actions — cannot collect people`,
+      );
+    }
+    const firstAction = actions[0];
+    if (!firstAction) {
+      throw new CollectionError(
+        `Campaign ${String(input.campaignId)} has no actions — cannot collect people`,
+      );
+    }
+    const actionId = firstAction.id;
+
     const collectionService = new CollectionService(instance);
-    await collectionService.collect(input.sourceUrl, input.campaignId, {
-      ...(input.limit !== undefined && { limit: input.limit }),
-      ...(input.maxPages !== undefined && { maxPages: input.maxPages }),
-      ...(input.pageSize !== undefined && { pageSize: input.pageSize }),
-    });
+    await collectionService.collect(input.sourceUrl, input.campaignId, actionId);
 
     return {
       success: true as const,

--- a/packages/core/src/services/collection.test.ts
+++ b/packages/core/src/services/collection.test.ts
@@ -46,15 +46,14 @@ describe("CollectionService", () => {
       mockEvaluateUI
         .mockResolvedValueOnce("idle")  // getRunnerState
         .mockResolvedValueOnce(true)    // canCollect
-        .mockResolvedValueOnce(true)    // prepareCollecting
         .mockResolvedValueOnce(true);   // collect
 
-      await service.collect(SEARCH_URL, 1);
+      await service.collect(SEARCH_URL, 1, 10);
 
       // Navigation via LinkedIn webview
       expect(mockNavigateLinkedIn).toHaveBeenCalledWith(SEARCH_URL);
 
-      expect(mockEvaluateUI).toHaveBeenCalledTimes(4);
+      expect(mockEvaluateUI).toHaveBeenCalledTimes(3);
 
       // 1. Runner state check
       const stateExpr = mockEvaluateUI.mock.calls[0]?.[0] as string;
@@ -65,71 +64,45 @@ describe("CollectionService", () => {
       expect(canCollectExpr).toContain("canCollect");
       expect(canCollectExpr).toContain("search-page");
 
-      // 3. prepareCollecting — uses internal kebab-case type
-      const prepareExpr = mockEvaluateUI.mock.calls[2]?.[0] as string;
-      expect(prepareExpr).toContain("prepareCollecting");
-      expect(prepareExpr).toContain("search-page");
-      expect(prepareExpr).toContain("AutoCollectPeople");
-
-      // 4. collect — includes campaignId
-      const collectExpr = mockEvaluateUI.mock.calls[3]?.[0] as string;
+      // 3. collect — uses internal kebab-case type as first arg, config as second
+      const collectExpr = mockEvaluateUI.mock.calls[2]?.[0] as string;
       expect(collectExpr).toContain("mws.call('collect'");
+      expect(collectExpr).toContain("search-page");
       expect(collectExpr).toContain('"campaignId":1');
+      expect(collectExpr).toContain('"actionId":10');
     });
 
-    it("passes limit, maxPages, pageSize to collect call", async () => {
+    it("passes actionId and target in collect config", async () => {
       mockEvaluateUI
         .mockResolvedValueOnce("idle")
         .mockResolvedValueOnce(true)
-        .mockResolvedValueOnce(true)
         .mockResolvedValueOnce(true);
 
-      await service.collect(SEARCH_URL, 1, {
-        limit: 100,
-        maxPages: 5,
-        pageSize: 25,
-      });
+      await service.collect(SEARCH_URL, 1, 10);
 
-      const collectExpr = mockEvaluateUI.mock.calls[3]?.[0] as string;
-      expect(collectExpr).toContain('"limit":100');
-      expect(collectExpr).toContain('"maxPages":5');
-      expect(collectExpr).toContain('"pageSize":25');
-    });
-
-    it("omits undefined options from collect call", async () => {
-      mockEvaluateUI
-        .mockResolvedValueOnce("idle")
-        .mockResolvedValueOnce(true)
-        .mockResolvedValueOnce(true)
-        .mockResolvedValueOnce(true);
-
-      await service.collect(SEARCH_URL, 1, { limit: 50 });
-
-      const collectExpr = mockEvaluateUI.mock.calls[3]?.[0] as string;
-      expect(collectExpr).toContain('"limit":50');
-      expect(collectExpr).not.toContain("maxPages");
-      expect(collectExpr).not.toContain("pageSize");
+      const collectExpr = mockEvaluateUI.mock.calls[2]?.[0] as string;
+      expect(collectExpr).toContain('"actionId":10');
+      expect(collectExpr).toContain('"target":"target"');
     });
 
     it("detects OrganizationPeople source type from company URL", async () => {
       mockEvaluateUI
         .mockResolvedValueOnce("idle")
         .mockResolvedValueOnce(true)
-        .mockResolvedValueOnce(true)
         .mockResolvedValueOnce(true);
 
-      await service.collect(ORG_PEOPLE_URL, 1);
+      await service.collect(ORG_PEOPLE_URL, 1, 10);
 
       const canCollectExpr = mockEvaluateUI.mock.calls[1]?.[0] as string;
       expect(canCollectExpr).toContain("organization-people");
 
-      const prepareExpr = mockEvaluateUI.mock.calls[2]?.[0] as string;
-      expect(prepareExpr).toContain("organization-people");
+      const collectExpr = mockEvaluateUI.mock.calls[2]?.[0] as string;
+      expect(collectExpr).toContain("organization-people");
     });
 
     it("throws CollectionError for unrecognized source URL", async () => {
       const error = await service
-        .collect("https://www.linkedin.com/feed/", 1)
+        .collect("https://www.linkedin.com/feed/", 1, 10)
         .catch((e: unknown) => e);
 
       expect(error).toBeInstanceOf(CollectionError);
@@ -143,7 +116,7 @@ describe("CollectionService", () => {
       mockEvaluateUI.mockResolvedValueOnce("campaigns");
 
       await expect(
-        service.collect(SEARCH_URL, 1),
+        service.collect(SEARCH_URL, 1, 10),
       ).rejects.toThrow(CollectionBusyError);
 
       // Only the runner state check should be made
@@ -154,7 +127,7 @@ describe("CollectionService", () => {
       mockEvaluateUI.mockResolvedValueOnce("campaigns");
 
       try {
-        await service.collect(SEARCH_URL, 1);
+        await service.collect(SEARCH_URL, 1, 10);
         expect.unreachable("should have thrown");
       } catch (error) {
         expect(error).toBeInstanceOf(CollectionBusyError);
@@ -177,18 +150,16 @@ describe("CollectionService", () => {
           .mockResolvedValueOnce(false)     // canCollect attempt 1
           .mockResolvedValueOnce(false)     // canCollect attempt 2
           .mockResolvedValueOnce(true)      // canCollect attempt 3 — success
-          .mockResolvedValueOnce(true)      // prepareCollecting
           .mockResolvedValueOnce(true);     // collect
 
-        const promise = service.collect(SEARCH_URL, 1);
+        const promise = service.collect(SEARCH_URL, 1, 10);
         await vi.advanceTimersByTimeAsync(2000);
         await promise;
 
         // canCollect was called 3 times before success
         const canCollectCalls = mockEvaluateUI.mock.calls.filter(
           (call) =>
-            (call[0] as string).includes("canCollect") &&
-            !(call[0] as string).includes("prepareCollecting"),
+            (call[0] as string).includes("canCollect"),
         );
         expect(canCollectCalls).toHaveLength(3);
       });
@@ -197,18 +168,16 @@ describe("CollectionService", () => {
         mockEvaluateUI
           .mockResolvedValueOnce("idle")   // getRunnerState
           .mockResolvedValueOnce(true)      // canCollect — immediate success
-          .mockResolvedValueOnce(true)      // prepareCollecting
           .mockResolvedValueOnce(true);     // collect
 
-        const promise = service.collect(SEARCH_URL, 1);
+        const promise = service.collect(SEARCH_URL, 1, 10);
         await vi.advanceTimersByTimeAsync(0);
         await promise;
 
         // Only 1 canCollect call — no polling needed
         const canCollectCalls = mockEvaluateUI.mock.calls.filter(
           (call) =>
-            (call[0] as string).includes("canCollect") &&
-            !(call[0] as string).includes("prepareCollecting"),
+            (call[0] as string).includes("canCollect"),
         );
         expect(canCollectCalls).toHaveLength(1);
       });
@@ -219,7 +188,7 @@ describe("CollectionService", () => {
           .mockResolvedValue(false);        // canCollect always returns false
 
         // Attach catch before advancing timers to avoid unhandled rejection
-        const errorPromise = service.collect(SEARCH_URL, 1).catch((e: unknown) => e);
+        const errorPromise = service.collect(SEARCH_URL, 1, 10).catch((e: unknown) => e);
         await vi.advanceTimersByTimeAsync(11_000);
 
         const error = await errorPromise;
@@ -236,7 +205,7 @@ describe("CollectionService", () => {
       mockEvaluateUI.mockResolvedValueOnce("idle"); // getRunnerState
       mockNavigateLinkedIn.mockRejectedValueOnce(new Error("Page.navigate timeout"));
 
-      const error = await service.collect(SEARCH_URL, 1).catch((e: unknown) => e);
+      const error = await service.collect(SEARCH_URL, 1, 10).catch((e: unknown) => e);
       expect(error).toBeInstanceOf(CollectionError);
       expect((error as CollectionError).message).toContain("Failed to navigate to source URL");
       expect((error as CollectionError).cause).toBeInstanceOf(Error);
@@ -245,63 +214,16 @@ describe("CollectionService", () => {
       expect(mockEvaluateUI).toHaveBeenCalledTimes(1);
     });
 
-    it("throws CollectionError when prepareCollecting returns false", async () => {
-      mockEvaluateUI
-        .mockResolvedValueOnce("idle")
-        .mockResolvedValueOnce(true)
-        .mockResolvedValueOnce(false); // prepareCollecting returns false
-
-      await expect(
-        service.collect(SEARCH_URL, 1),
-      ).rejects.toThrow(CollectionError);
-    });
-
-    it("throws CollectionError when collect returns false", async () => {
-      mockEvaluateUI
-        .mockResolvedValueOnce("idle")
-        .mockResolvedValueOnce(true)
-        .mockResolvedValueOnce(true)
-        .mockResolvedValueOnce(false); // collect returns false
-
-      await expect(
-        service.collect(SEARCH_URL, 1),
-      ).rejects.toThrow(CollectionError);
-    });
-
-    it("wraps CDP errors in CollectionError for prepareCollecting", async () => {
-      mockEvaluateUI
-        .mockResolvedValueOnce("idle")
-        .mockResolvedValueOnce(true)
-        .mockRejectedValueOnce(new Error("CDP timeout"));
-
-      const error = await service.collect(SEARCH_URL, 1).catch((e: unknown) => e);
-      expect(error).toBeInstanceOf(CollectionError);
-      expect((error as CollectionError).message).toContain("Failed to prepare collection");
-      expect((error as CollectionError).cause).toBeInstanceOf(Error);
-    });
-
     it("wraps CDP errors in CollectionError for collect", async () => {
       mockEvaluateUI
         .mockResolvedValueOnce("idle")
         .mockResolvedValueOnce(true)
-        .mockResolvedValueOnce(true)
         .mockRejectedValueOnce(new Error("CDP timeout"));
 
-      const error = await service.collect(SEARCH_URL, 1).catch((e: unknown) => e);
+      const error = await service.collect(SEARCH_URL, 1, 10).catch((e: unknown) => e);
       expect(error).toBeInstanceOf(CollectionError);
       expect((error as CollectionError).message).toContain("Failed to start collection");
       expect((error as CollectionError).cause).toBeInstanceOf(Error);
-    });
-
-    it("does not wrap CollectionError from prepareCollecting", async () => {
-      mockEvaluateUI
-        .mockResolvedValueOnce("idle")
-        .mockResolvedValueOnce(true)
-        .mockResolvedValueOnce(false); // triggers CollectionError inside prepareCollecting
-
-      const error = await service.collect(SEARCH_URL, 1).catch((e: unknown) => e);
-      expect(error).toBeInstanceOf(CollectionError);
-      expect((error as CollectionError).message).toContain("prepareCollecting returned false");
     });
   });
 

--- a/packages/core/src/services/collection.ts
+++ b/packages/core/src/services/collection.ts
@@ -16,18 +16,6 @@ const CAN_COLLECT_TIMEOUT = 10_000;
 const CAN_COLLECT_POLL_INTERVAL = 500;
 
 /**
- * Options for initiating a collection operation.
- */
-export interface CollectOptions {
-  /** Maximum number of profiles to collect. */
-  readonly limit?: number;
-  /** Maximum number of pages to process. */
-  readonly maxPages?: number;
-  /** Number of results per page. */
-  readonly pageSize?: number;
-}
-
-/**
  * Manages people collection from LinkedIn pages via CDP.
  *
  * Collection uses the dedicated `prepareCollecting` → `collect` IPC
@@ -48,8 +36,9 @@ export class CollectionService {
    * Initiate people collection from a LinkedIn source URL.
    *
    * Validates that the source URL is a recognized LinkedIn page type,
-   * ensures the instance is idle, then calls `canCollect` →
-   * `prepareCollecting` → `collect` via CDP.
+   * ensures the instance is idle, navigates to the URL, verifies the
+   * page is recognized, then drives the LinkedHelper state machine
+   * through its Redux saga to start collection.
    *
    * Returns immediately after initiating collection — the actual
    * collection runs asynchronously in LinkedHelper. Poll the runner
@@ -65,7 +54,7 @@ export class CollectionService {
   async collect(
     sourceUrl: string,
     campaignId: number,
-    options?: CollectOptions,
+    actionId: number,
   ): Promise<void> {
     const sourceType = detectSourceType(sourceUrl);
     if (!sourceType) {
@@ -90,18 +79,7 @@ export class CollectionService {
     await this.assertCanCollect(sourceType);
 
     try {
-      await this.prepareCollecting(sourceType);
-    } catch (error) {
-      if (error instanceof CollectionError) throw error;
-      const message = errorMessage(error);
-      throw new CollectionError(
-        `Failed to prepare collection for ${sourceType}: ${message}`,
-        { cause: error },
-      );
-    }
-
-    try {
-      await this.startCollecting(campaignId, options);
+      await this.startCollecting(sourceType, campaignId, actionId);
     } catch (error) {
       if (error instanceof CollectionError) throw error;
       const message = errorMessage(error);
@@ -181,52 +159,44 @@ export class CollectionService {
   }
 
   /**
-   * Call `prepareCollecting` to transition the state machine from
-   * `idle` to `preparing-collecting`.
+   * Call `collect` on the main process with the correct two-argument
+   * signature discovered from LinkedHelper's renderer source:
+   *
+   * ```
+   * mainWindowService.call("collect", sourceType, {
+   *   campaignId, actionId, target, withoutScraping
+   * })
+   * ```
+   *
+   * The main process `collect` method expects the source type as the
+   * first argument and a config object as the second. The config must
+   * include `actionId` (the campaign action to collect into) and
+   * `target` (the collection target type).
    *
    * @throws {CollectionError} if the call returns `false`.
    */
-  private async prepareCollecting(sourceType: SourceType): Promise<void> {
+  private async startCollecting(
+    sourceType: SourceType,
+    campaignId: number,
+    actionId: number,
+  ): Promise<void> {
     const internalType = toInternalSourceType(sourceType);
-    const result = await this.instance.evaluateUI<boolean>(
-      `(async () => {
+    const config: Record<string, unknown> = {
+      campaignId,
+      actionId,
+      target: "target",
+    };
+
+    // Fire-and-forget: the collect IPC method blocks until collection
+    // finishes (which can take minutes). We start it without awaiting
+    // the result — callers poll getRunnerState() for progress.
+    await this.instance.evaluateUI<boolean>(
+      `(() => {
         const mws = window.mainWindowService;
-        return await mws.call('prepareCollecting', ${JSON.stringify({
-          type: internalType,
-          actionType: "AutoCollectPeople",
-        })});
+        mws.call('collect', ${JSON.stringify(internalType)}, ${JSON.stringify(config)});
+        return true;
       })()`,
+      false,
     );
-
-    if (!result) {
-      throw new CollectionError(
-        `prepareCollecting returned false for ${sourceType} — state machine did not transition`,
-      );
-    }
-  }
-
-  /**
-   * Call `collect` to start the actual collection process.
-   *
-   * @throws {CollectionError} if the call returns `false`.
-   */
-  private async startCollecting(campaignId: number, options?: CollectOptions): Promise<void> {
-    const params: Record<string, number> = { campaignId };
-    if (options?.limit !== undefined) params.limit = options.limit;
-    if (options?.maxPages !== undefined) params.maxPages = options.maxPages;
-    if (options?.pageSize !== undefined) params.pageSize = options.pageSize;
-
-    const result = await this.instance.evaluateUI<boolean>(
-      `(async () => {
-        const mws = window.mainWindowService;
-        return await mws.call('collect', ${JSON.stringify(params)});
-      })()`,
-    );
-
-    if (!result) {
-      throw new CollectionError(
-        "collect returned false — state machine was not in collecting state",
-      );
-    }
   }
 }

--- a/packages/e2e/src/collect-people.e2e.test.ts
+++ b/packages/e2e/src/collect-people.e2e.test.ts
@@ -1,0 +1,493 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { assertDefined, describeE2E, forceStopInstance, launchApp, quitApp, resolveAccountId, retryAsync } from "@lhremote/core/testing";
+import {
+  type AppService,
+  LauncherService,
+  startInstanceWithRecovery,
+} from "@lhremote/core";
+
+// CLI handlers
+import {
+  handleCampaignCreate,
+  handleCampaignDelete,
+  handleCampaignListPeople,
+  handleCampaignStatus,
+  handleCollectPeople,
+} from "@lhremote/cli/handlers";
+
+// MCP tool registration
+import {
+  registerCampaignCreate,
+  registerCampaignDelete,
+  registerCampaignListPeople,
+  registerCollectPeople,
+} from "@lhremote/mcp/tools";
+import { createMockServer } from "@lhremote/mcp/testing";
+
+/** Minimal campaign config for collect-people tests — needs at least one action. */
+const TEST_CAMPAIGN_YAML = `
+version: "1"
+name: E2E Collect People Campaign
+description: Created by E2E collect-people tests
+actions:
+  - type: VisitAndExtract
+`.trimStart();
+
+/**
+ * LinkedIn people search URL used for collection.
+ * Uses a narrow search to minimize collection time — broad searches
+ * like "software engineer" scrape hundreds of pages.
+ */
+const TEST_SOURCE_URL =
+  "https://www.linkedin.com/search/results/people/?keywords=ollybriz&origin=GLOBAL_SEARCH_HEADER";
+
+/** Maximum time to wait for collection to complete (ms). */
+const COLLECTION_TIMEOUT = 600_000;
+
+/** Interval between collection completion polls (ms). */
+const COLLECTION_POLL_INTERVAL = 3_000;
+
+/** Maximum retries for collect-people (page recognition can fail transiently). */
+const COLLECT_RETRIES = 3;
+
+/** Delay between collect-people retries (ms). */
+const COLLECT_RETRY_DELAY = 5_000;
+
+/** Maximum time to wait for the instance to reach idle after startup (ms). */
+const IDLE_TIMEOUT = 60_000;
+
+/** Interval between idle-state polls (ms). */
+const IDLE_POLL_INTERVAL = 2_000;
+
+/**
+ * Poll campaign-status via CLI until the runner reaches idle state.
+ * Used both after instance startup (waiting for initialization to complete)
+ * and after collect-people (waiting for collection to finish).
+ */
+async function waitForRunnerIdle(
+  campaignId: number,
+  port: number,
+  timeout: number = COLLECTION_TIMEOUT,
+  interval: number = COLLECTION_POLL_INTERVAL,
+): Promise<void> {
+  await retryAsync(
+    async () => {
+      const previousExitCode = process.exitCode;
+      process.exitCode = undefined;
+      const stdoutSpy = vi
+        .spyOn(process.stdout, "write")
+        .mockReturnValue(true);
+      try {
+        await handleCampaignStatus(campaignId, { cdpPort: port, json: true });
+
+        if (typeof process.exitCode === "number" && process.exitCode !== 0) {
+          throw new Error(
+            `campaign-status failed with exit code ${String(process.exitCode)}`,
+          );
+        }
+
+        const output = stdoutSpy.mock.calls
+          .map((call) => String(call[0]))
+          .join("");
+        const parsed = JSON.parse(output) as {
+          runnerState: string;
+        };
+
+        if (parsed.runnerState !== "idle") {
+          throw new Error(
+            `Runner still active (state: ${parsed.runnerState})`,
+          );
+        }
+      } finally {
+        stdoutSpy.mockRestore();
+        process.exitCode = previousExitCode;
+      }
+    },
+    {
+      retries: Math.ceil(timeout / interval),
+      delay: interval,
+    },
+  );
+}
+
+describeE2E("collect-people operation", () => {
+  let app: AppService;
+  let port: number;
+  let accountId: number;
+
+  beforeAll(async () => {
+    const launched = await launchApp();
+    app = launched.app;
+    port = launched.port;
+
+    accountId = await resolveAccountId(port);
+
+    // Start an account instance — required by collection operations
+    const launcher = new LauncherService(port);
+    await retryAsync(() => launcher.connect(), { retries: 3, delay: 1_000 });
+    await startInstanceWithRecovery(launcher, accountId, port);
+    launcher.disconnect();
+  }, 120_000);
+
+  afterAll(async () => {
+    // Stop the instance before quitting
+    const launcher = new LauncherService(port);
+    try {
+      await launcher.connect();
+      await forceStopInstance(launcher, accountId, port);
+    } catch {
+      // Best-effort cleanup
+    } finally {
+      launcher.disconnect();
+    }
+    await quitApp(app);
+  }, 60_000);
+
+  // -----------------------------------------------------------------------
+  // CLI handlers
+  // -----------------------------------------------------------------------
+
+  describe("CLI handlers", () => {
+    const originalExitCode = process.exitCode;
+
+    /** Campaign ID created during the test — used across sequential steps. */
+    let campaignId: number | undefined;
+
+    afterAll(async () => {
+      // Cleanup: archive the test campaign if it was created but not deleted
+      if (campaignId !== undefined) {
+        const previousExitCode = process.exitCode;
+        try {
+          process.exitCode = undefined;
+          vi.spyOn(process.stdout, "write").mockReturnValue(true);
+          await handleCampaignDelete(campaignId, { cdpPort: port });
+        } catch {
+          // Best-effort cleanup
+        } finally {
+          process.exitCode = previousExitCode;
+          vi.restoreAllMocks();
+        }
+      }
+    });
+
+    beforeEach(() => {
+      process.exitCode = undefined;
+    });
+
+    afterEach(() => {
+      process.exitCode = originalExitCode;
+      vi.restoreAllMocks();
+    });
+
+    it("campaign-create creates a test campaign with one action", async () => {
+      const stdoutSpy = vi
+        .spyOn(process.stdout, "write")
+        .mockReturnValue(true);
+
+      await handleCampaignCreate({
+        yaml: TEST_CAMPAIGN_YAML,
+        cdpPort: port,
+        json: true,
+      });
+
+      expect(process.exitCode).toBeUndefined();
+      expect(stdoutSpy).toHaveBeenCalled();
+
+      const output = stdoutSpy.mock.calls
+        .map((call) => String(call[0]))
+        .join("");
+      const parsed = JSON.parse(output) as {
+        id: number;
+        name: string;
+        state: string;
+      };
+
+      expect(parsed.id).toBeGreaterThan(0);
+      campaignId = parsed.id;
+
+      expect(parsed.name).toBe("E2E Collect People Campaign");
+      expect(parsed.state).toBe("paused");
+    }, 30_000);
+
+    it("collect-people --json starts collection from LinkedIn search URL", async () => {
+      assertDefined(campaignId, "campaign-create must run first");
+
+      // Wait for instance to finish initializing before attempting collection
+      await waitForRunnerIdle(campaignId, port, IDLE_TIMEOUT, IDLE_POLL_INTERVAL);
+
+      // Retry collect-people — page recognition can fail transiently if the
+      // LinkedIn browser session isn't fully warmed up after instance startup.
+      let lastOutput = "";
+      await retryAsync(
+        async () => {
+          const previousExitCode = process.exitCode;
+          process.exitCode = undefined;
+          const stdoutSpy = vi
+            .spyOn(process.stdout, "write")
+            .mockReturnValue(true);
+          try {
+            await handleCollectPeople(campaignId, TEST_SOURCE_URL, {
+              cdpPort: port,
+              json: true,
+            });
+            if (typeof process.exitCode === "number" && process.exitCode !== 0) {
+              throw new Error("collect-people exited with non-zero exit code");
+            }
+            lastOutput = stdoutSpy.mock.calls
+              .map((call) => String(call[0]))
+              .join("");
+          } finally {
+            stdoutSpy.mockRestore();
+            process.exitCode = previousExitCode;
+          }
+        },
+        { retries: COLLECT_RETRIES, delay: COLLECT_RETRY_DELAY },
+      );
+
+      const parsed = JSON.parse(lastOutput) as {
+        success: boolean;
+        campaignId: number;
+        sourceType: string;
+      };
+
+      expect(parsed.success).toBe(true);
+      expect(parsed.campaignId).toBe(campaignId);
+      expect(parsed.sourceType).toBe("SearchPage");
+    }, 60_000 + COLLECT_RETRIES * (COLLECT_RETRY_DELAY + 30_000));
+
+    it("campaign-list-people shows collected people after completion", async () => {
+      assertDefined(campaignId, "campaign-create must run first");
+
+      // Wait for collection to finish (runner returns to idle)
+      await waitForRunnerIdle(campaignId, port);
+
+      const stdoutSpy = vi
+        .spyOn(process.stdout, "write")
+        .mockReturnValue(true);
+
+      await handleCampaignListPeople(campaignId, {
+        cdpPort: port,
+        json: true,
+      });
+
+      expect(process.exitCode).toBeUndefined();
+      expect(stdoutSpy).toHaveBeenCalled();
+
+      const output = stdoutSpy.mock.calls
+        .map((call) => String(call[0]))
+        .join("");
+      const parsed = JSON.parse(output) as {
+        campaignId: number;
+        people: { personId: number }[];
+        total: number;
+      };
+
+      expect(parsed.campaignId).toBe(campaignId);
+      expect(parsed.total).toBeGreaterThanOrEqual(1);
+      expect(parsed.people.length).toBeGreaterThanOrEqual(1);
+    }, COLLECTION_TIMEOUT + 30_000);
+
+    it("campaign-delete archives the test campaign", async () => {
+      assertDefined(campaignId, "campaign-create must run first");
+
+      const stdoutSpy = vi
+        .spyOn(process.stdout, "write")
+        .mockReturnValue(true);
+
+      await handleCampaignDelete(campaignId, { cdpPort: port, json: true });
+
+      expect(process.exitCode).toBeUndefined();
+      expect(stdoutSpy).toHaveBeenCalled();
+
+      const output = stdoutSpy.mock.calls
+        .map((call) => String(call[0]))
+        .join("");
+      const parsed = JSON.parse(output) as {
+        success: boolean;
+        campaignId: number;
+        action: string;
+      };
+
+      expect(parsed.success).toBe(true);
+      expect(parsed.campaignId).toBe(campaignId);
+      expect(parsed.action).toBe("archived");
+
+      // Prevent afterAll cleanup from trying again
+      campaignId = undefined;
+    }, 30_000);
+  });
+
+  // -----------------------------------------------------------------------
+  // MCP tools
+  // -----------------------------------------------------------------------
+
+  describe("MCP tools", () => {
+    /** Campaign ID created during the test — used across sequential steps. */
+    let campaignId: number | undefined;
+
+    afterAll(async () => {
+      // Cleanup: archive the test campaign if it was created but not deleted
+      if (campaignId !== undefined) {
+        const { server, getHandler } = createMockServer();
+        registerCampaignDelete(server);
+        try {
+          await getHandler("campaign-delete")({ campaignId, cdpPort: port });
+        } catch {
+          // Best-effort cleanup
+        }
+      }
+    });
+
+    it("campaign-create tool creates a test campaign with one action", async () => {
+      const { server, getHandler } = createMockServer();
+      registerCampaignCreate(server);
+
+      const handler = getHandler("campaign-create");
+      const result = (await handler({
+        config: TEST_CAMPAIGN_YAML,
+        format: "yaml",
+        cdpPort: port,
+      })) as {
+        isError?: boolean;
+        content: { type: string; text: string }[];
+      };
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content).toHaveLength(1);
+
+      const parsed = JSON.parse(
+        (result.content[0] as { text: string }).text,
+      ) as {
+        id: number;
+        name: string;
+        state: string;
+      };
+
+      expect(parsed.id).toBeGreaterThan(0);
+      campaignId = parsed.id;
+
+      expect(parsed.name).toBe("E2E Collect People Campaign");
+      expect(parsed.state).toBe("paused");
+    }, 30_000);
+
+    it("collect-people tool starts collection from LinkedIn search URL", async () => {
+      assertDefined(campaignId, "campaign-create must run first");
+
+      // Wait for instance to finish initializing before attempting collection
+      await waitForRunnerIdle(campaignId, port, IDLE_TIMEOUT, IDLE_POLL_INTERVAL);
+
+      // Retry collect-people — page recognition can fail transiently
+      let lastResult: { isError?: boolean; content: { type: string; text: string }[] } | undefined;
+      await retryAsync(
+        async () => {
+          const { server, getHandler } = createMockServer();
+          registerCollectPeople(server);
+
+          const handler = getHandler("collect-people");
+          const result = (await handler({
+            campaignId,
+            sourceUrl: TEST_SOURCE_URL,
+            cdpPort: port,
+          })) as {
+            isError?: boolean;
+            content: { type: string; text: string }[];
+          };
+
+          if (result.isError) {
+            throw new Error(
+              `collect-people returned error: ${(result.content[0] as { text: string }).text}`,
+            );
+          }
+          lastResult = result;
+        },
+        { retries: COLLECT_RETRIES, delay: COLLECT_RETRY_DELAY },
+      );
+
+      assertDefined(lastResult, "collect-people must succeed");
+      expect(lastResult.content).toHaveLength(1);
+
+      const parsed = JSON.parse(
+        (lastResult.content[0] as { text: string }).text,
+      ) as {
+        success: boolean;
+        campaignId: number;
+        sourceType: string;
+      };
+
+      expect(parsed.success).toBe(true);
+      expect(parsed.campaignId).toBe(campaignId);
+      expect(parsed.sourceType).toBe("SearchPage");
+    }, 60_000 + COLLECT_RETRIES * (COLLECT_RETRY_DELAY + 30_000));
+
+    it("campaign-list-people tool shows collected people after completion", async () => {
+      assertDefined(campaignId, "campaign-create must run first");
+
+      // Wait for collection to finish (runner returns to idle)
+      await waitForRunnerIdle(campaignId, port);
+
+      const { server, getHandler } = createMockServer();
+      registerCampaignListPeople(server);
+
+      const handler = getHandler("campaign-list-people");
+      const result = (await handler({
+        campaignId,
+        cdpPort: port,
+      })) as {
+        isError?: boolean;
+        content: { type: string; text: string }[];
+      };
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content).toHaveLength(1);
+
+      const parsed = JSON.parse(
+        (result.content[0] as { text: string }).text,
+      ) as {
+        campaignId: number;
+        people: { personId: number }[];
+        total: number;
+      };
+
+      expect(parsed.campaignId).toBe(campaignId);
+      expect(parsed.total).toBeGreaterThanOrEqual(1);
+      expect(parsed.people.length).toBeGreaterThanOrEqual(1);
+    }, COLLECTION_TIMEOUT + 30_000);
+
+    it("campaign-delete tool archives the test campaign", async () => {
+      assertDefined(campaignId, "campaign-create must run first");
+
+      const { server, getHandler } = createMockServer();
+      registerCampaignDelete(server);
+
+      const handler = getHandler("campaign-delete");
+      const result = (await handler({
+        campaignId,
+        cdpPort: port,
+      })) as {
+        isError?: boolean;
+        content: { type: string; text: string }[];
+      };
+
+      expect(result.isError).toBeUndefined();
+      expect(result.content).toHaveLength(1);
+
+      const parsed = JSON.parse(
+        (result.content[0] as { text: string }).text,
+      ) as {
+        success: boolean;
+        campaignId: number;
+        action: string;
+      };
+
+      expect(parsed.success).toBe(true);
+      expect(parsed.campaignId).toBe(campaignId);
+      expect(parsed.action).toBe("archived");
+
+      // Prevent afterAll cleanup from trying again
+      campaignId = undefined;
+    }, 30_000);
+  });
+});


### PR DESCRIPTION
## Summary

- Add E2E tests for the `collect-people` operation covering both CLI handlers and MCP tools
- Fix the collect-people core operation: reverse-engineered the correct LinkedHelper IPC protocol from the ASAR bundle — `collect` takes two arguments (sourceType + config with campaignId/actionId/target)
- Remove unused `CollectOptions` (limit/maxPages/pageSize not supported by the collect IPC)
- Look up campaign action ID from DB for the collect call
- Use fire-and-forget pattern for the blocking collect IPC call

Closes #492

## Test plan

- [x] All unit tests pass (2411 tests)
- [x] Lint passes
- [x] E2E tests pass (8/8) — campaign create, collect-people, verify via campaign-list-people, cleanup via campaign-delete for both CLI and MCP

🤖 Generated with [Claude Code](https://claude.com/claude-code)