### PR TITLE
(fix) core: use kebab-case internal types and pass campaignId in collection IPC

### DIFF
--- a/packages/core/src/services/collection.test.ts
+++ b/packages/core/src/services/collection.test.ts
@@ -60,20 +60,21 @@ describe("CollectionService", () => {
       const stateExpr = mockEvaluateUI.mock.calls[0]?.[0] as string;
       expect(stateExpr).toContain("mainWindowService.mainWindow.state");
 
-      // 2. canCollect
+      // 2. canCollect — uses internal kebab-case type
       const canCollectExpr = mockEvaluateUI.mock.calls[1]?.[0] as string;
       expect(canCollectExpr).toContain("canCollect");
-      expect(canCollectExpr).toContain("SearchPage");
+      expect(canCollectExpr).toContain("search-page");
 
-      // 3. prepareCollecting
+      // 3. prepareCollecting — uses internal kebab-case type
       const prepareExpr = mockEvaluateUI.mock.calls[2]?.[0] as string;
       expect(prepareExpr).toContain("prepareCollecting");
-      expect(prepareExpr).toContain("SearchPage");
+      expect(prepareExpr).toContain("search-page");
       expect(prepareExpr).toContain("AutoCollectPeople");
 
-      // 4. collect
+      // 4. collect — includes campaignId
       const collectExpr = mockEvaluateUI.mock.calls[3]?.[0] as string;
       expect(collectExpr).toContain("mws.call('collect'");
+      expect(collectExpr).toContain('"campaignId":1');
     });
 
     it("passes limit, maxPages, pageSize to collect call", async () => {
@@ -120,10 +121,10 @@ describe("CollectionService", () => {
       await service.collect(ORG_PEOPLE_URL, 1);
 
       const canCollectExpr = mockEvaluateUI.mock.calls[1]?.[0] as string;
-      expect(canCollectExpr).toContain("OrganizationPeople");
+      expect(canCollectExpr).toContain("organization-people");
 
       const prepareExpr = mockEvaluateUI.mock.calls[2]?.[0] as string;
-      expect(prepareExpr).toContain("OrganizationPeople");
+      expect(prepareExpr).toContain("organization-people");
     });
 
     it("throws CollectionError for unrecognized source URL", async () => {
@@ -305,7 +306,7 @@ describe("CollectionService", () => {
   });
 
   describe("canCollect", () => {
-    it("calls canCollect IPC method via CDP", async () => {
+    it("calls canCollect IPC method via CDP with internal kebab-case type", async () => {
       mockEvaluateUI.mockResolvedValueOnce(true);
 
       const result = await service.canCollect("SearchPage");
@@ -313,7 +314,7 @@ describe("CollectionService", () => {
       expect(result).toBe(true);
       const expr = mockEvaluateUI.mock.calls[0]?.[0] as string;
       expect(expr).toContain("canCollect");
-      expect(expr).toContain("SearchPage");
+      expect(expr).toContain("search-page");
     });
 
     it("returns false when LinkedHelper reports false", async () => {

--- a/packages/core/src/services/collection.ts
+++ b/packages/core/src/services/collection.ts
@@ -5,7 +5,7 @@ import type { SourceType } from "../types/index.js";
 import type { RunnerState } from "../types/index.js";
 import { delay } from "../utils/delay.js";
 import { errorMessage } from "../utils/error-message.js";
-import { detectSourceType } from "./source-type-registry.js";
+import { detectSourceType, toInternalSourceType } from "./source-type-registry.js";
 import type { InstanceService } from "./instance.js";
 import { CollectionBusyError, CollectionError } from "./errors.js";
 
@@ -64,7 +64,7 @@ export class CollectionService {
    */
   async collect(
     sourceUrl: string,
-    _campaignId: number,
+    campaignId: number,
     options?: CollectOptions,
   ): Promise<void> {
     const sourceType = detectSourceType(sourceUrl);
@@ -101,7 +101,7 @@ export class CollectionService {
     }
 
     try {
-      await this.startCollecting(options);
+      await this.startCollecting(campaignId, options);
     } catch (error) {
       if (error instanceof CollectionError) throw error;
       const message = errorMessage(error);
@@ -119,10 +119,11 @@ export class CollectionService {
    * LinkedHelper browser is currently on a matching source page.
    */
   async canCollect(sourceType: SourceType): Promise<boolean> {
+    const internalType = toInternalSourceType(sourceType);
     return this.instance.evaluateUI<boolean>(
       `(async () => {
         const mws = window.mainWindowService;
-        return await mws.call('canCollect', ${JSON.stringify(sourceType)});
+        return await mws.call('canCollect', ${JSON.stringify(internalType)});
       })()`,
     );
   }
@@ -186,11 +187,12 @@ export class CollectionService {
    * @throws {CollectionError} if the call returns `false`.
    */
   private async prepareCollecting(sourceType: SourceType): Promise<void> {
+    const internalType = toInternalSourceType(sourceType);
     const result = await this.instance.evaluateUI<boolean>(
       `(async () => {
         const mws = window.mainWindowService;
         return await mws.call('prepareCollecting', ${JSON.stringify({
-          type: sourceType,
+          type: internalType,
           actionType: "AutoCollectPeople",
         })});
       })()`,
@@ -208,8 +210,8 @@ export class CollectionService {
    *
    * @throws {CollectionError} if the call returns `false`.
    */
-  private async startCollecting(options?: CollectOptions): Promise<void> {
-    const params: Record<string, number> = {};
+  private async startCollecting(campaignId: number, options?: CollectOptions): Promise<void> {
+    const params: Record<string, number> = { campaignId };
     if (options?.limit !== undefined) params.limit = options.limit;
     if (options?.maxPages !== undefined) params.maxPages = options.maxPages;
     if (options?.pageSize !== undefined) params.pageSize = options.pageSize;

--- a/packages/core/src/services/index.ts
+++ b/packages/core/src/services/index.ts
@@ -30,7 +30,7 @@ export {
   type DatabaseContext,
   type InstanceDatabaseContext,
 } from "./instance-context.js";
-export { detectSourceType, validateSourceType } from "./source-type-registry.js";
+export { detectSourceType, toInternalSourceType, validateSourceType } from "./source-type-registry.js";
 export { buildBooleanExpression } from "./boolean-expression.js";
 export { buildBasicSearchUrl } from "./url-builder.js";
 export { buildSNSearchUrl } from "./sn-url-builder.js";

--- a/packages/core/src/services/source-type-registry.test.ts
+++ b/packages/core/src/services/source-type-registry.test.ts
@@ -2,7 +2,7 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import { describe, expect, it } from "vitest";
-import { detectSourceType, validateSourceType } from "./source-type-registry.js";
+import { detectSourceType, toInternalSourceType, validateSourceType } from "./source-type-registry.js";
 
 describe("detectSourceType", () => {
   describe("Free tier", () => {
@@ -149,6 +149,41 @@ describe("detectSourceType", () => {
     it("should handle raw pathnames without hostname", () => {
       expect(detectSourceType("/search/results/people/")).toBe("SearchPage");
     });
+  });
+});
+
+describe("toInternalSourceType", () => {
+  it("should convert PascalCase source types to kebab-case internal identifiers", () => {
+    expect(toInternalSourceType("SearchPage")).toBe("search-page");
+    expect(toInternalSourceType("MyConnections")).toBe("my-connections");
+    expect(toInternalSourceType("OrganizationPeople")).toBe("organization-people");
+    expect(toInternalSourceType("SentInvitationPage")).toBe("sent-invitation-page");
+  });
+
+  it("should convert single-word types to lowercase", () => {
+    expect(toInternalSourceType("Alumni")).toBe("alumni");
+    expect(toInternalSourceType("Group")).toBe("group");
+    expect(toInternalSourceType("Event")).toBe("event");
+  });
+
+  it("should convert acronym types to lowercase", () => {
+    expect(toInternalSourceType("LWVYPP")).toBe("lwvypp");
+  });
+
+  it("should convert prefixed types correctly", () => {
+    expect(toInternalSourceType("SNSearchPage")).toBe("sn-search-page");
+    expect(toInternalSourceType("SNListPage")).toBe("sn-list-page");
+    expect(toInternalSourceType("SNOrgsPage")).toBe("sn-orgs-page");
+    expect(toInternalSourceType("SNOrgsListsPage")).toBe("sn-orgs-lists-page");
+    expect(toInternalSourceType("TSearchPage")).toBe("t-search-page");
+    expect(toInternalSourceType("TProjectPage")).toBe("t-project-page");
+    expect(toInternalSourceType("RSearchPage")).toBe("r-search-page");
+    expect(toInternalSourceType("RProjectPage")).toBe("r-project-page");
+  });
+
+  it("should convert Page suffix types correctly", () => {
+    expect(toInternalSourceType("FollowersPage")).toBe("followers-page");
+    expect(toInternalSourceType("FollowingPage")).toBe("following-page");
   });
 });
 

--- a/packages/core/src/services/source-type-registry.ts
+++ b/packages/core/src/services/source-type-registry.ts
@@ -38,6 +38,32 @@ const SOURCE_TYPE_PATTERNS: SourceTypePattern[] = [
 ];
 
 /**
+ * Mapping from public PascalCase source types to LinkedHelper's internal
+ * kebab-case type identifiers used by the `CollectingController` IPC methods
+ * (`canCollect`, `prepareCollecting`).
+ */
+const SOURCE_TYPE_INTERNAL: Readonly<Record<SourceType, string>> = {
+  SearchPage: "search-page",
+  MyConnections: "my-connections",
+  Alumni: "alumni",
+  OrganizationPeople: "organization-people",
+  Group: "group",
+  Event: "event",
+  LWVYPP: "lwvypp",
+  SentInvitationPage: "sent-invitation-page",
+  FollowersPage: "followers-page",
+  FollowingPage: "following-page",
+  SNSearchPage: "sn-search-page",
+  SNListPage: "sn-list-page",
+  SNOrgsPage: "sn-orgs-page",
+  SNOrgsListsPage: "sn-orgs-lists-page",
+  TSearchPage: "t-search-page",
+  TProjectPage: "t-project-page",
+  RSearchPage: "r-search-page",
+  RProjectPage: "r-project-page",
+};
+
+/**
  * Set of all valid source type strings for fast validation.
  */
 const VALID_SOURCE_TYPES: ReadonlySet<string> = new Set<string>(
@@ -69,6 +95,21 @@ export function detectSourceType(url: string): SourceType | undefined {
   }
 
   return undefined;
+}
+
+/**
+ * Convert a public {@link SourceType} to LinkedHelper's internal kebab-case
+ * identifier expected by `CollectingController` IPC methods.
+ *
+ * @param sourceType - Public PascalCase source type
+ * @returns The internal kebab-case identifier (e.g., `"search-page"`)
+ */
+export function toInternalSourceType(sourceType: SourceType): string {
+  const internal = SOURCE_TYPE_INTERNAL[sourceType];
+  if (!internal) {
+    throw new Error(`No internal type mapping for source type: ${String(sourceType)}`);
+  }
+  return internal;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Add `SOURCE_TYPE_INTERNAL` mapping (PascalCase → kebab-case) and `toInternalSourceType()` for LinkedHelper's `CollectingController` IPC calls
- Use internal kebab-case types in `canCollect` and `prepareCollecting` IPC calls (e.g., `"search-page"` not `"SearchPage"`)
- Pass `campaignId` to the `collect` IPC call — previously ignored via `_campaignId`

## Test plan

- [x] All 1527 unit/integration tests pass
- [x] Lint clean
- [ ] Run `pnpm test:e2e:file collect-people` locally to verify end-to-end

Closes #653

🤖 Generated with [Claude Code](https://claude.com/claude-code)