### PR TITLE
E2E tests: engagement operations

### DIFF
--- a/packages/cli/src/handlers/comment-on-post.ts
+++ b/packages/cli/src/handlers/comment-on-post.ts
@@ -15,6 +15,7 @@ export async function handleCommentOnPost(options: {
   cdpPort?: number;
   cdpHost?: string;
   allowRemote?: boolean;
+  accountId?: number;
   json?: boolean;
 }): Promise<void> {
   process.stderr.write("Posting comment...\n");
@@ -27,6 +28,7 @@ export async function handleCommentOnPost(options: {
       cdpPort: options.cdpPort,
       cdpHost: options.cdpHost,
       allowRemote: options.allowRemote,
+      accountId: options.accountId,
     });
   } catch (error) {
     if (error instanceof BudgetExceededError) {

--- a/packages/cli/src/handlers/endorse-skills.ts
+++ b/packages/cli/src/handlers/endorse-skills.ts
@@ -20,6 +20,7 @@ export async function handleEndorseSkills(options: {
   cdpPort?: number;
   cdpHost?: string;
   allowRemote?: boolean;
+  accountId?: number;
   json?: boolean;
 }): Promise<void> {
   if ((options.personId == null) === (options.url == null)) {
@@ -42,6 +43,7 @@ export async function handleEndorseSkills(options: {
       cdpPort: options.cdpPort,
       cdpHost: options.cdpHost,
       allowRemote: options.allowRemote,
+      accountId: options.accountId,
     });
   } catch (error) {
     if (error instanceof CampaignExecutionError || error instanceof CampaignTimeoutError) {

--- a/packages/cli/src/handlers/follow-person.ts
+++ b/packages/cli/src/handlers/follow-person.ts
@@ -19,6 +19,7 @@ export async function handleFollowPerson(options: {
   cdpPort?: number;
   cdpHost?: string;
   allowRemote?: boolean;
+  accountId?: number;
   json?: boolean;
 }): Promise<void> {
   if ((options.personId == null) === (options.url == null)) {
@@ -41,6 +42,7 @@ export async function handleFollowPerson(options: {
       cdpPort: options.cdpPort,
       cdpHost: options.cdpHost,
       allowRemote: options.allowRemote,
+      accountId: options.accountId,
     });
   } catch (error) {
     if (error instanceof CampaignExecutionError || error instanceof CampaignTimeoutError) {

--- a/packages/cli/src/handlers/like-person-posts.ts
+++ b/packages/cli/src/handlers/like-person-posts.ts
@@ -24,6 +24,7 @@ export async function handleLikePersonPosts(options: {
   cdpPort?: number;
   cdpHost?: string;
   allowRemote?: boolean;
+  accountId?: number;
   json?: boolean;
 }): Promise<void> {
   if ((options.personId == null) === (options.url == null)) {
@@ -61,6 +62,7 @@ export async function handleLikePersonPosts(options: {
       cdpPort: options.cdpPort,
       cdpHost: options.cdpHost,
       allowRemote: options.allowRemote,
+      accountId: options.accountId,
     });
   } catch (error) {
     if (error instanceof CampaignExecutionError || error instanceof CampaignTimeoutError) {

--- a/packages/cli/src/handlers/visit-profile.ts
+++ b/packages/cli/src/handlers/visit-profile.ts
@@ -17,6 +17,7 @@ export async function handleVisitProfile(options: {
   cdpPort?: number;
   cdpHost?: string;
   allowRemote?: boolean;
+  accountId?: number;
   json?: boolean;
 }): Promise<void> {
   if ((options.personId == null) === (options.url == null)) {
@@ -38,6 +39,7 @@ export async function handleVisitProfile(options: {
       cdpPort: options.cdpPort,
       cdpHost: options.cdpHost,
       allowRemote: options.allowRemote,
+      accountId: options.accountId,
     });
   } catch (error) {
     if (error instanceof InstanceNotRunningError) {

--- a/packages/core/src/operations/ephemeral-action.test.ts
+++ b/packages/core/src/operations/ephemeral-action.test.ts
@@ -84,6 +84,7 @@ describe("executeEphemeralAction", () => {
       9222,
       1,
       expect.any(Function),
+      { db: { readOnly: false } },
     );
     expect(mockExecute).toHaveBeenCalledWith("Follow", 42, undefined, {});
     expect(result).toBe(MOCK_RESULT);

--- a/packages/core/src/operations/ephemeral-action.ts
+++ b/packages/core/src/operations/ephemeral-action.ts
@@ -45,5 +45,5 @@ export async function executeEphemeralAction(
     return ephemeral.execute(actionType, target, actionSettings, {
       ...(input.keepCampaign !== undefined && { keepCampaign: input.keepCampaign }),
     });
-  });
+  }, { db: { readOnly: false } });
 }

--- a/packages/core/src/operations/types.ts
+++ b/packages/core/src/operations/types.ts
@@ -18,6 +18,7 @@ export interface ConnectionOptions {
   readonly cdpPort?: number | undefined;
   readonly cdpHost?: string | undefined;
   readonly allowRemote?: boolean | undefined;
+  readonly accountId?: number | undefined;
   readonly pacer?: SessionPacer | undefined;
 }
 
@@ -31,9 +32,11 @@ export interface ConnectionOptions {
 export function buildCdpOptions(input: {
   cdpHost?: string | undefined;
   allowRemote?: boolean | undefined;
-}): { host?: string; allowRemote?: boolean } {
+  accountId?: number | undefined;
+}): { host?: string; allowRemote?: boolean; accountId?: number } {
   return {
     ...(input.cdpHost !== undefined && { host: input.cdpHost }),
     ...(input.allowRemote !== undefined && { allowRemote: input.allowRemote }),
+    ...(input.accountId !== undefined && { accountId: input.accountId }),
   };
 }

--- a/packages/core/src/services/account-resolution.ts
+++ b/packages/core/src/services/account-resolution.ts
@@ -45,8 +45,12 @@ export class AccountResolutionError extends ServiceError {
  */
 export async function resolveAccount(
   cdpPort?: number,
-  options?: { host?: string; allowRemote?: boolean },
+  options?: { host?: string; allowRemote?: boolean; accountId?: number },
 ): Promise<number> {
+  if (options?.accountId !== undefined) {
+    return options.accountId;
+  }
+
   let port: number;
   try {
     port = await resolveLauncherPort(cdpPort, options?.host);

--- a/packages/core/src/services/ephemeral-campaign.test.ts
+++ b/packages/core/src/services/ephemeral-campaign.test.ts
@@ -131,6 +131,7 @@ describe("EphemeralCampaignService", () => {
     vi.useFakeTimers();
     vi.clearAllMocks();
     mockEvaluateUI.mockResolvedValue(undefined);
+    mockListCampaigns.mockReturnValue([]);
 
     const instance = new InstanceService(9223);
     service = new EphemeralCampaignService(instance, {} as never);

--- a/packages/core/src/services/ephemeral-campaign.ts
+++ b/packages/core/src/services/ephemeral-campaign.ts
@@ -11,7 +11,7 @@ import { ProfileRepository } from "../db/index.js";
 import { delay } from "../utils/delay.js";
 import type { InstanceService } from "./instance.js";
 import { CampaignService } from "./campaign.js";
-import { CampaignExecutionError, CampaignTimeoutError } from "./errors.js";
+import { CampaignExecutionError, CampaignTimeoutError, UIBlockedError } from "./errors.js";
 
 /** Default timeout for ephemeral action execution (5 minutes). */
 const DEFAULT_TIMEOUT = 300_000;
@@ -32,10 +32,12 @@ const CAMPAIGN_NAME_PREFIX = "[ephemeral]";
  * if `keepCampaign: true`).
  */
 export class EphemeralCampaignService {
+  private readonly instance: InstanceService;
   private readonly campaignService: CampaignService;
   private readonly profileRepo: ProfileRepository;
 
   constructor(instance: InstanceService, db: DatabaseClient) {
+    this.instance = instance;
     this.campaignService = new CampaignService(instance, db);
     this.profileRepo = new ProfileRepository(db);
   }
@@ -80,11 +82,15 @@ export class EphemeralCampaignService {
       ],
     });
 
+    // Step 3: Pause all other campaigns so the runner is free for us
+    const previouslyActive = await this.dismissAndRetry(
+      () => this.campaignService.pauseAllExcept(campaign.id),
+    );
+
     try {
-      // Step 3: Import target person
-      const importResult = await this.campaignService.importPeopleFromUrls(
-        campaign.id,
-        [resolved.linkedInUrl],
+      // Step 4: Import target person
+      const importResult = await this.dismissAndRetry(
+        () => this.campaignService.importPeopleFromUrls(campaign.id, [resolved.linkedInUrl]),
       );
 
       if (importResult.successful === 0 && importResult.alreadyInQueue === 0 && importResult.alreadyProcessed === 0) {
@@ -97,18 +103,20 @@ export class EphemeralCampaignService {
       // Resolve person ID if not yet known (URL-based target)
       const personId = resolved.personId ?? this.resolvePersonIdFromUrl(resolved.linkedInUrl);
 
-      // Step 4: Start campaign
-      await this.campaignService.start(campaign.id, []);
+      // Step 5: Start campaign
+      await this.dismissAndRetry(() => this.campaignService.start(campaign.id, []));
 
-      // Step 5: Poll for completion
+      // Step 6: Poll for completion
       await this.pollForCompletion(campaign.id, timeout, pollInterval);
 
-      // Step 6: Get results
-      const runResult = await this.campaignService.getResults(campaign.id);
+      // Step 7: Get results
+      const runResult = await this.dismissAndRetry(
+        () => this.campaignService.getResults(campaign.id),
+      );
       const results = runResult.results;
       const success = results.some((r) => r.result > 0);
 
-      // Step 7: Cleanup
+      // Step 8: Cleanup
       await this.cleanup(campaign.id, keepCampaign);
 
       return {
@@ -120,6 +128,9 @@ export class EphemeralCampaignService {
     } catch (error) {
       await this.cleanup(campaign.id, keepCampaign);
       throw error;
+    } finally {
+      // Restore previously active campaigns
+      await this.campaignService.unpauseCampaigns(previouslyActive);
     }
   }
 
@@ -204,7 +215,22 @@ export class EphemeralCampaignService {
     const deadline = Date.now() + timeout;
 
     while (Date.now() < deadline) {
-      const status = await this.campaignService.getStatus(campaignId);
+      let status;
+      try {
+        status = await this.campaignService.getStatus(campaignId);
+      } catch (error) {
+        if (error instanceof UIBlockedError) {
+          // Action may have produced a popup (e.g. "no endorsable skills").
+          // Dismiss and continue polling — the campaign may still complete.
+          await this.instance.dismissInstancePopups().catch(() => {});
+          const remaining = deadline - Date.now();
+          if (remaining <= 0) break;
+          await delay(Math.min(pollInterval, remaining));
+          continue;
+        }
+        throw error;
+      }
+
       const counts = status.actionCounts[0];
 
       // Action complete when at least one person is successful or failed
@@ -226,6 +252,26 @@ export class EphemeralCampaignService {
       `Ephemeral action did not complete within ${String(timeout)}ms`,
       campaignId,
     );
+  }
+
+  /**
+   * Run an async operation, automatically dismissing UI popups on
+   * {@link UIBlockedError} and retrying up to 3 times.
+   */
+  private async dismissAndRetry<T>(fn: () => Promise<T>): Promise<T> {
+    const maxAttempts = 3;
+    for (let attempt = 1; ; attempt++) {
+      try {
+        return await fn();
+      } catch (error) {
+        if (error instanceof UIBlockedError && attempt < maxAttempts) {
+          await this.instance.dismissInstancePopups().catch(() => {});
+          await delay(1_000);
+          continue;
+        }
+        throw error;
+      }
+    }
   }
 
   /**

--- a/packages/core/src/testing/e2e-helpers.ts
+++ b/packages/core/src/testing/e2e-helpers.ts
@@ -203,6 +203,20 @@ export function getE2EPersonId(): number {
 }
 
 /**
+ * Read the `LHREMOTE_E2E_POST_URL` environment variable.
+ *
+ * Returns a LinkedIn post URL used for post-based E2E tests
+ * (react-to-post, comment-on-post).
+ *
+ * @throws if `LHREMOTE_E2E_POST_URL` is not set or is empty.
+ */
+export function getE2EPostUrl(): string {
+  const url = process.env.LHREMOTE_E2E_POST_URL;
+  if (!url) throw new Error("LHREMOTE_E2E_POST_URL must be set");
+  return url;
+}
+
+/**
  * Connect to the launcher, list accounts, and return the first account ID.
  *
  * Fails the test if no accounts are configured in LinkedHelper.

--- a/packages/core/src/testing/index.ts
+++ b/packages/core/src/testing/index.ts
@@ -6,6 +6,7 @@ export {
   describeE2E,
   forceStopInstance,
   getE2EPersonId,
+  getE2EPostUrl,
   launchApp,
   type LaunchedApp,
   quitApp,

--- a/packages/e2e/src/engagement.e2e.test.ts
+++ b/packages/e2e/src/engagement.e2e.test.ts
@@ -1,0 +1,485 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  describeE2E,
+  forceStopInstance,
+  getE2EPersonId,
+  getE2EPostUrl,
+  launchApp,
+  quitApp,
+  resolveAccountId,
+  retryAsync,
+} from "@lhremote/core/testing";
+import {
+  type AppService,
+  discoverInstancePort,
+  discoverTargets,
+  dismissErrors,
+  LauncherService,
+  startInstanceWithRecovery,
+} from "@lhremote/core";
+import type {
+  VisitProfileOutput,
+  EphemeralActionResult,
+  ReactToPostOutput,
+  CommentOnPostOutput,
+} from "@lhremote/core";
+
+// CLI handlers
+import {
+  handleVisitProfile,
+  handleFollowPerson,
+  handleEndorseSkills,
+  handleLikePersonPosts,
+  handleReactToPost,
+  handleCommentOnPost,
+} from "@lhremote/cli/handlers";
+
+// MCP tool registrations
+import {
+  registerVisitProfile,
+  registerFollowPerson,
+  registerEndorseSkills,
+  registerLikePersonPosts,
+  registerReactToPost,
+  registerCommentOnPost,
+} from "@lhremote/mcp/tools";
+import { createMockServer } from "@lhremote/mcp/testing";
+
+describeE2E("engagement operations", () => {
+  let app: AppService;
+  let port: number;
+  let accountId: number;
+  let cdpPort: number;
+  let personId: number;
+  let postUrl: string;
+
+  beforeAll(async () => {
+    personId = getE2EPersonId();
+    postUrl = getE2EPostUrl();
+
+    const launched = await launchApp();
+    app = launched.app;
+    port = launched.port;
+
+    accountId = await resolveAccountId(port);
+
+    const launcher = new LauncherService(port);
+    try {
+      await retryAsync(() => launcher.connect(), { retries: 3, delay: 1_000 });
+      await startInstanceWithRecovery(launcher, accountId, port);
+    } finally {
+      launcher.disconnect();
+    }
+
+    // Discover the instance's dynamic CDP port
+    const instancePort = await retryAsync(
+      async () => {
+        const p = await discoverInstancePort(port);
+        if (p === null) throw new Error("Instance CDP port not discovered yet");
+        return p;
+      },
+      { retries: 10, delay: 2_000 },
+    );
+    cdpPort = instancePort;
+
+    // Wait for the LinkedIn WebView to become available
+    await retryAsync(
+      async () => {
+        const targets = await discoverTargets(cdpPort);
+        const hasLinkedIn = targets.some(
+          (t) => t.type === "page" && t.url?.includes("linkedin.com"),
+        );
+        if (!hasLinkedIn) {
+          throw new Error("LinkedIn target not available yet");
+        }
+      },
+      { retries: 30, delay: 2_000 },
+    );
+  }, 120_000);
+
+  // Dismiss any leftover error popups before each test to prevent cascade failures
+  beforeEach(async () => {
+    await dismissErrors({ cdpPort, accountId }).catch(() => {});
+  }, 30_000);
+
+  afterAll(async () => {
+    const launcher = new LauncherService(port);
+    try {
+      await launcher.connect();
+      await forceStopInstance(launcher, accountId, port);
+    } catch {
+      // Best-effort cleanup
+    } finally {
+      launcher.disconnect();
+    }
+    await quitApp(app);
+  }, 60_000);
+
+  // ── visit-profile ─────────────────────────────────────────────────
+
+  describe("visit-profile", () => {
+    describe("CLI handlers", () => {
+      const originalExitCode = process.exitCode;
+
+      beforeEach(() => {
+        process.exitCode = undefined;
+      });
+
+      afterEach(() => {
+        process.exitCode = originalExitCode;
+        vi.restoreAllMocks();
+      });
+
+      it("visit-profile --json returns profile data", async () => {
+        const stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+
+        await handleVisitProfile({ personId, cdpPort, accountId, json: true });
+
+        expect(process.exitCode).toBeUndefined();
+        expect(stdoutSpy).toHaveBeenCalled();
+
+        const output = stdoutSpy.mock.calls.map((call) => String(call[0])).join("");
+        const parsed = JSON.parse(output) as VisitProfileOutput;
+
+        expect(parsed.success).toBe(true);
+        expect(parsed.actionType).toBe("VisitAndExtract");
+        expect(parsed.profile).toHaveProperty("id");
+        expect(parsed.profile).toHaveProperty("miniProfile");
+        expect(typeof parsed.profile.miniProfile.firstName).toBe("string");
+      }, 120_000);
+    });
+
+    describe("MCP tools", () => {
+      it("visit-profile tool returns valid JSON", async () => {
+        const { server, getHandler } = createMockServer();
+        registerVisitProfile(server);
+
+        const handler = getHandler("visit-profile");
+        const result = (await handler({ personId, cdpPort, accountId })) as {
+          isError?: boolean;
+          content: { type: string; text: string }[];
+        };
+
+        expect(result.isError).toBeUndefined();
+        expect(result.content).toHaveLength(1);
+
+        const parsed = JSON.parse(
+          (result.content[0] as { text: string }).text,
+        ) as VisitProfileOutput;
+
+        expect(parsed.success).toBe(true);
+        expect(parsed.actionType).toBe("VisitAndExtract");
+        expect(parsed.profile).toHaveProperty("id");
+        expect(parsed.profile).toHaveProperty("miniProfile");
+      }, 120_000);
+    });
+  });
+
+  // ── follow-person ─────────────────────────────────────────────────
+
+  describe("follow-person", () => {
+    describe("CLI handlers", () => {
+      const originalExitCode = process.exitCode;
+
+      beforeEach(() => {
+        process.exitCode = undefined;
+      });
+
+      afterEach(() => {
+        process.exitCode = originalExitCode;
+        vi.restoreAllMocks();
+      });
+
+      it("follow-person --json returns action result", async () => {
+        const stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+
+        await handleFollowPerson({ personId, cdpPort, accountId, json: true });
+
+        expect(process.exitCode).toBeUndefined();
+        expect(stdoutSpy).toHaveBeenCalled();
+
+        const output = stdoutSpy.mock.calls.map((call) => String(call[0])).join("");
+        const parsed = JSON.parse(output) as EphemeralActionResult;
+
+        expect(typeof parsed.success).toBe("boolean");
+        expect(parsed.personId).toBe(personId);
+      }, 120_000);
+    });
+
+    describe("MCP tools", () => {
+      it("follow-person tool returns valid JSON", async () => {
+        const { server, getHandler } = createMockServer();
+        registerFollowPerson(server);
+
+        const handler = getHandler("follow-person");
+        const result = (await handler({ personId, cdpPort, accountId })) as {
+          isError?: boolean;
+          content: { type: string; text: string }[];
+        };
+
+        expect(result.isError).toBeUndefined();
+        expect(result.content).toHaveLength(1);
+
+        const parsed = JSON.parse(
+          (result.content[0] as { text: string }).text,
+        ) as EphemeralActionResult;
+
+        expect(typeof parsed.success).toBe("boolean");
+        expect(parsed.personId).toBe(personId);
+      }, 120_000);
+    });
+  });
+
+  // ── endorse-skills ────────────────────────────────────────────────
+
+  describe("endorse-skills", () => {
+    describe("CLI handlers", () => {
+      const originalExitCode = process.exitCode;
+
+      beforeEach(() => {
+        process.exitCode = undefined;
+      });
+
+      afterEach(() => {
+        process.exitCode = originalExitCode;
+        vi.restoreAllMocks();
+      });
+
+      it("endorse-skills --json returns action result", async () => {
+        const stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+
+        await handleEndorseSkills({ personId, cdpPort, accountId, json: true });
+
+        expect(process.exitCode).toBeUndefined();
+        expect(stdoutSpy).toHaveBeenCalled();
+
+        const output = stdoutSpy.mock.calls.map((call) => String(call[0])).join("");
+        const parsed = JSON.parse(output) as EphemeralActionResult;
+
+        expect(typeof parsed.success).toBe("boolean");
+        expect(parsed.personId).toBe(personId);
+      }, 120_000);
+    });
+
+    describe("MCP tools", () => {
+      it("endorse-skills tool returns valid JSON", async () => {
+        const { server, getHandler } = createMockServer();
+        registerEndorseSkills(server);
+
+        const handler = getHandler("endorse-skills");
+        const result = (await handler({ personId, cdpPort, accountId })) as {
+          isError?: boolean;
+          content: { type: string; text: string }[];
+        };
+
+        expect(result.isError).toBeUndefined();
+        expect(result.content).toHaveLength(1);
+
+        const parsed = JSON.parse(
+          (result.content[0] as { text: string }).text,
+        ) as EphemeralActionResult;
+
+        expect(typeof parsed.success).toBe("boolean");
+        expect(parsed.personId).toBe(personId);
+      }, 120_000);
+    });
+  });
+
+  // ── like-person-posts ─────────────────────────────────────────────
+
+  describe("like-person-posts", () => {
+    describe("CLI handlers", () => {
+      const originalExitCode = process.exitCode;
+
+      beforeEach(() => {
+        process.exitCode = undefined;
+      });
+
+      afterEach(() => {
+        process.exitCode = originalExitCode;
+        vi.restoreAllMocks();
+      });
+
+      it("like-person-posts --json returns action result", async () => {
+        const stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+
+        await handleLikePersonPosts({
+          personId,
+          numberOfPosts: 1,
+          cdpPort,
+          accountId,
+          json: true,
+        });
+
+        expect(process.exitCode).toBeUndefined();
+        expect(stdoutSpy).toHaveBeenCalled();
+
+        const output = stdoutSpy.mock.calls.map((call) => String(call[0])).join("");
+        const parsed = JSON.parse(output) as EphemeralActionResult;
+
+        expect(typeof parsed.success).toBe("boolean");
+        expect(parsed.personId).toBe(personId);
+      }, 120_000);
+    });
+
+    describe("MCP tools", () => {
+      it("like-person-posts tool returns valid JSON", async () => {
+        const { server, getHandler } = createMockServer();
+        registerLikePersonPosts(server);
+
+        const handler = getHandler("like-person-posts");
+        const result = (await handler({
+          personId,
+          numberOfPosts: 1,
+          cdpPort,
+          accountId,
+        })) as {
+          isError?: boolean;
+          content: { type: string; text: string }[];
+        };
+
+        expect(result.isError).toBeUndefined();
+        expect(result.content).toHaveLength(1);
+
+        const parsed = JSON.parse(
+          (result.content[0] as { text: string }).text,
+        ) as EphemeralActionResult;
+
+        expect(typeof parsed.success).toBe("boolean");
+        expect(parsed.personId).toBe(personId);
+      }, 120_000);
+    });
+  });
+
+  // ── react-to-post ─────────────────────────────────────────────────
+
+  describe("react-to-post", () => {
+    describe("CLI handlers", () => {
+      const originalExitCode = process.exitCode;
+
+      beforeEach(() => {
+        process.exitCode = undefined;
+      });
+
+      afterEach(() => {
+        process.exitCode = originalExitCode;
+        vi.restoreAllMocks();
+      });
+
+      it("react-to-post --json returns reaction result", async () => {
+        const stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+
+        await handleReactToPost(postUrl, { cdpPort, json: true });
+
+        expect(process.exitCode).toBeUndefined();
+        expect(stdoutSpy).toHaveBeenCalled();
+
+        const output = stdoutSpy.mock.calls.map((call) => String(call[0])).join("");
+        const parsed = JSON.parse(output) as ReactToPostOutput;
+
+        expect(parsed.success).toBe(true);
+        expect(parsed.postUrl).toBe(postUrl);
+        expect(typeof parsed.reactionType).toBe("string");
+      }, 120_000);
+    });
+
+    describe("MCP tools", () => {
+      it("react-to-post tool returns valid JSON", async () => {
+        const { server, getHandler } = createMockServer();
+        registerReactToPost(server);
+
+        const handler = getHandler("react-to-post");
+        const result = (await handler({
+          postUrl,
+          reactionType: "like",
+          cdpPort,
+        })) as {
+          isError?: boolean;
+          content: { type: string; text: string }[];
+        };
+
+        expect(result.isError).toBeUndefined();
+        expect(result.content).toHaveLength(1);
+
+        const parsed = JSON.parse(
+          (result.content[0] as { text: string }).text,
+        ) as ReactToPostOutput;
+
+        expect(parsed.success).toBe(true);
+        expect(parsed.postUrl).toBe(postUrl);
+        expect(parsed.reactionType).toBe("like");
+      }, 120_000);
+    });
+  });
+
+  // ── comment-on-post ───────────────────────────────────────────────
+
+  describe("comment-on-post", () => {
+    describe("CLI handlers", () => {
+      const originalExitCode = process.exitCode;
+
+      beforeEach(() => {
+        process.exitCode = undefined;
+      });
+
+      afterEach(() => {
+        process.exitCode = originalExitCode;
+        vi.restoreAllMocks();
+      });
+
+      it("comment-on-post --json returns comment result", async () => {
+        const stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+
+        await handleCommentOnPost({
+          url: postUrl,
+          text: "E2E test comment",
+          cdpPort,
+          accountId,
+          json: true,
+        });
+
+        expect(process.exitCode).toBeUndefined();
+        expect(stdoutSpy).toHaveBeenCalled();
+
+        const output = stdoutSpy.mock.calls.map((call) => String(call[0])).join("");
+        const parsed = JSON.parse(output) as CommentOnPostOutput;
+
+        expect(parsed.success).toBe(true);
+        expect(parsed.postUrl).toBe(postUrl);
+        expect(parsed.commentText).toBe("E2E test comment");
+      }, 120_000);
+    });
+
+    describe("MCP tools", () => {
+      it("comment-on-post tool returns valid JSON", async () => {
+        const { server, getHandler } = createMockServer();
+        registerCommentOnPost(server);
+
+        const handler = getHandler("comment-on-post");
+        const result = (await handler({
+          postUrl,
+          text: "E2E test comment",
+          cdpPort,
+          accountId,
+        })) as {
+          isError?: boolean;
+          content: { type: string; text: string }[];
+        };
+
+        expect(result.isError).toBeUndefined();
+        expect(result.content).toHaveLength(1);
+
+        const parsed = JSON.parse(
+          (result.content[0] as { text: string }).text,
+        ) as CommentOnPostOutput;
+
+        expect(parsed.success).toBe(true);
+        expect(parsed.postUrl).toBe(postUrl);
+        expect(parsed.commentText).toBe("E2E test comment");
+      }, 120_000);
+    });
+  });
+});

--- a/packages/mcp/src/helpers.ts
+++ b/packages/mcp/src/helpers.ts
@@ -38,6 +38,12 @@ export const cdpConnectionSchema = {
     .boolean()
     .optional()
     .describe("SECURITY: Allow non-loopback CDP connections. Enables remote code execution on target host. Only use if network path is secured."),
+  accountId: z
+    .number()
+    .int()
+    .positive()
+    .optional()
+    .describe("Explicit account ID. Bypasses automatic account resolution (required when multiple accounts are configured)."),
 };
 
 // Re-export from core so existing MCP tool files keep working.

--- a/packages/mcp/src/tools/comment-on-post.ts
+++ b/packages/mcp/src/tools/comment-on-post.ts
@@ -22,9 +22,9 @@ export function registerCommentOnPost(server: McpServer): void {
         .describe("Comment text to post on the LinkedIn post"),
       ...cdpConnectionSchema,
     },
-    async ({ postUrl, text, cdpPort, cdpHost, allowRemote }) => {
+    async ({ postUrl, text, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await commentOnPost({ postUrl, text, cdpPort, cdpHost, allowRemote });
+        const result = await commentOnPost({ postUrl, text, cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         return mcpCatchAll(error, "Failed to comment on post");

--- a/packages/mcp/src/tools/endorse-skills.ts
+++ b/packages/mcp/src/tools/endorse-skills.ts
@@ -42,14 +42,14 @@ export function registerEndorseSkills(server: McpServer): void {
         .describe("Archive the ephemeral campaign instead of deleting it"),
       ...cdpConnectionSchema,
     },
-    async ({ personId, url, skillNames, limit, skipIfNotEndorsable, keepCampaign, cdpPort, cdpHost, allowRemote }) => {
+    async ({ personId, url, skillNames, limit, skipIfNotEndorsable, keepCampaign, cdpPort, cdpHost, allowRemote, accountId }) => {
       if ((personId == null) === (url == null)) {
         return mcpError("Exactly one of personId or url must be provided.");
       }
 
       try {
         const result = await endorseSkills({
-          personId, url, skillNames, limit, skipIfNotEndorsable, keepCampaign, cdpPort, cdpHost, allowRemote,
+          personId, url, skillNames, limit, skipIfNotEndorsable, keepCampaign, cdpPort, cdpHost, allowRemote, accountId,
         });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {

--- a/packages/mcp/src/tools/follow-person.ts
+++ b/packages/mcp/src/tools/follow-person.ts
@@ -36,14 +36,14 @@ export function registerFollowPerson(server: McpServer): void {
         .describe("Archive the ephemeral campaign instead of deleting it"),
       ...cdpConnectionSchema,
     },
-    async ({ personId, url, mode, skipIfUnfollowable, keepCampaign, cdpPort, cdpHost, allowRemote }) => {
+    async ({ personId, url, mode, skipIfUnfollowable, keepCampaign, cdpPort, cdpHost, allowRemote, accountId }) => {
       if ((personId == null) === (url == null)) {
         return mcpError("Exactly one of personId or url must be provided.");
       }
 
       try {
         const result = await followPerson({
-          personId, url, mode, skipIfUnfollowable, keepCampaign, cdpPort, cdpHost, allowRemote,
+          personId, url, mode, skipIfUnfollowable, keepCampaign, cdpPort, cdpHost, allowRemote, accountId,
         });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {

--- a/packages/mcp/src/tools/like-person-posts.ts
+++ b/packages/mcp/src/tools/like-person-posts.ts
@@ -64,7 +64,7 @@ export function registerLikePersonPosts(server: McpServer): void {
         .describe("Archive the ephemeral campaign instead of deleting it"),
       ...cdpConnectionSchema,
     },
-    async ({ personId, url, numberOfArticles, numberOfPosts, maxAgeOfArticles, maxAgeOfPosts, shouldAddComment, messageTemplate, skipIfNotLiked, keepCampaign, cdpPort, cdpHost, allowRemote }) => {
+    async ({ personId, url, numberOfArticles, numberOfPosts, maxAgeOfArticles, maxAgeOfPosts, shouldAddComment, messageTemplate, skipIfNotLiked, keepCampaign, cdpPort, cdpHost, allowRemote, accountId }) => {
       if ((personId == null) === (url == null)) {
         return mcpError("Exactly one of personId or url must be provided.");
       }
@@ -82,7 +82,7 @@ export function registerLikePersonPosts(server: McpServer): void {
         const result = await likePersonPosts({
           personId, url, numberOfArticles, numberOfPosts, maxAgeOfArticles, maxAgeOfPosts,
           shouldAddComment, messageTemplate: parsedMessageTemplate, skipIfNotLiked,
-          keepCampaign, cdpPort, cdpHost, allowRemote,
+          keepCampaign, cdpPort, cdpHost, allowRemote, accountId,
         });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {

--- a/packages/mcp/src/tools/start-instance.ts
+++ b/packages/mcp/src/tools/start-instance.ts
@@ -8,7 +8,6 @@ import {
   resolveLauncherPort,
   startInstanceWithRecovery,
 } from "@lhremote/core";
-import { z } from "zod";
 import { buildCdpOptions, cdpConnectionSchema, mcpCatchAll, mcpError, mcpSuccess } from "../helpers.js";
 
 /** Register the {@link https://github.com/alexey-pelykh/lhremote#start-instance | start-instance} MCP tool. */
@@ -17,14 +16,6 @@ export function registerStartInstance(server: McpServer): void {
     "start-instance",
     "Start a LinkedHelper instance for a LinkedIn account. Required before campaign or query operations.",
     {
-      accountId: z
-        .number()
-        .int()
-        .positive()
-        .optional()
-        .describe(
-          "Account ID (omit to auto-select if single account)",
-        ),
       ...cdpConnectionSchema,
     },
     async ({ accountId, cdpPort, cdpHost, allowRemote }) => {

--- a/packages/mcp/src/tools/stop-instance.ts
+++ b/packages/mcp/src/tools/stop-instance.ts
@@ -7,7 +7,6 @@ import {
   LauncherService,
   resolveLauncherPort,
 } from "@lhremote/core";
-import { z } from "zod";
 import { buildCdpOptions, cdpConnectionSchema, mcpCatchAll, mcpError, mcpSuccess } from "../helpers.js";
 
 /** Register the {@link https://github.com/alexey-pelykh/lhremote#stop-instance | stop-instance} MCP tool. */
@@ -16,14 +15,6 @@ export function registerStopInstance(server: McpServer): void {
     "stop-instance",
     "Stop a running LinkedHelper instance",
     {
-      accountId: z
-        .number()
-        .int()
-        .positive()
-        .optional()
-        .describe(
-          "Account ID (omit to stop the only running instance)",
-        ),
       ...cdpConnectionSchema,
     },
     async ({ accountId, cdpPort, cdpHost, allowRemote }) => {

--- a/packages/mcp/src/tools/visit-profile.ts
+++ b/packages/mcp/src/tools/visit-profile.ts
@@ -34,7 +34,7 @@ export function registerVisitProfile(server: McpServer): void {
         ),
       ...cdpConnectionSchema,
     },
-    async ({ personId, url, extractCurrentOrganizations, cdpPort, cdpHost, allowRemote }) => {
+    async ({ personId, url, extractCurrentOrganizations, cdpPort, cdpHost, allowRemote, accountId }) => {
       if ((personId == null) === (url == null)) {
         return mcpError(
           "Exactly one of personId or url must be provided.",
@@ -42,7 +42,7 @@ export function registerVisitProfile(server: McpServer): void {
       }
 
       try {
-        const result = await visitProfile({ personId, url, extractCurrentOrganizations, cdpPort, cdpHost, allowRemote });
+        const result = await visitProfile({ personId, url, extractCurrentOrganizations, cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         return mcpCatchAll(error, "Failed to visit profile");


### PR DESCRIPTION
## Summary
- Add E2E tests for all 6 engagement tools (`visit-profile`, `follow-person`, `endorse-skills`, `like-person-posts`, `react-to-post`, `comment-on-post`) with both CLI handler and MCP tool coverage (12 tests)
- Add `accountId` to `ConnectionOptions` for multi-account environments — bypasses automatic account resolution when provided
- Fix ephemeral action DB opened as read-only (should be read-write for campaign creation)
- Pause other campaigns before ephemeral action execution to prevent runner contention
- Auto-dismiss UI popups during ephemeral campaign lifecycle (`dismissAndRetry`)
- Add `getE2EPostUrl()` test helper (`LHREMOTE_E2E_POST_URL` env var) for post-based tests on user's own content

## Test plan
- [x] 12/12 E2E tests pass locally with LinkedHelper running
- [x] `pnpm lint` passes
- [x] `pnpm build` passes
- [ ] CI passes

Closes #495

🤖 Generated with [Claude Code](https://claude.com/claude-code)