### PR TITLE
(fix) test: surface MCP tool error body in E2E assertions

### DIFF
--- a/packages/e2e/src/campaign-action-management.e2e.test.ts
+++ b/packages/e2e/src/campaign-action-management.e2e.test.ts
@@ -358,7 +358,7 @@ describeE2E("Campaign action management", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(
@@ -391,7 +391,7 @@ describeE2E("Campaign action management", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(
@@ -431,7 +431,7 @@ describeE2E("Campaign action management", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(
@@ -469,7 +469,7 @@ describeE2E("Campaign action management", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(
@@ -508,7 +508,7 @@ describeE2E("Campaign action management", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(
@@ -539,7 +539,7 @@ describeE2E("Campaign action management", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(

--- a/packages/e2e/src/campaign-advanced.e2e.test.ts
+++ b/packages/e2e/src/campaign-advanced.e2e.test.ts
@@ -299,7 +299,7 @@ describeE2E("Campaign advanced operations", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(
@@ -332,7 +332,7 @@ describeE2E("Campaign advanced operations", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(
@@ -369,7 +369,7 @@ describeE2E("Campaign advanced operations", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(
@@ -404,7 +404,7 @@ describeE2E("Campaign advanced operations", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(
@@ -437,7 +437,7 @@ describeE2E("Campaign advanced operations", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(

--- a/packages/e2e/src/campaign-exclude.e2e.test.ts
+++ b/packages/e2e/src/campaign-exclude.e2e.test.ts
@@ -519,7 +519,7 @@ describeE2E("Campaign exclude list", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(
@@ -552,7 +552,7 @@ describeE2E("Campaign exclude list", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(
@@ -588,7 +588,7 @@ describeE2E("Campaign exclude list", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(
@@ -622,7 +622,7 @@ describeE2E("Campaign exclude list", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(
@@ -656,7 +656,7 @@ describeE2E("Campaign exclude list", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(
@@ -690,7 +690,7 @@ describeE2E("Campaign exclude list", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(
@@ -727,7 +727,7 @@ describeE2E("Campaign exclude list", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(
@@ -765,7 +765,7 @@ describeE2E("Campaign exclude list", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(
@@ -803,7 +803,7 @@ describeE2E("Campaign exclude list", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(
@@ -841,7 +841,7 @@ describeE2E("Campaign exclude list", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(
@@ -877,7 +877,7 @@ describeE2E("Campaign exclude list", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(

--- a/packages/e2e/src/campaign-execution.e2e.test.ts
+++ b/packages/e2e/src/campaign-execution.e2e.test.ts
@@ -437,7 +437,7 @@ describeE2E("Campaign execution and monitoring", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(
@@ -470,7 +470,7 @@ describeE2E("Campaign execution and monitoring", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(
@@ -504,7 +504,7 @@ describeE2E("Campaign execution and monitoring", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(
@@ -535,7 +535,7 @@ describeE2E("Campaign execution and monitoring", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(
@@ -570,7 +570,7 @@ describeE2E("Campaign execution and monitoring", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(
@@ -602,7 +602,7 @@ describeE2E("Campaign execution and monitoring", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(
@@ -633,7 +633,7 @@ describeE2E("Campaign execution and monitoring", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(
@@ -667,7 +667,7 @@ describeE2E("Campaign execution and monitoring", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(
@@ -702,7 +702,7 @@ describeE2E("Campaign execution and monitoring", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(

--- a/packages/e2e/src/campaign-lifecycle.e2e.test.ts
+++ b/packages/e2e/src/campaign-lifecycle.e2e.test.ts
@@ -372,7 +372,7 @@ describeE2E("Campaign CRUD lifecycle", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(
@@ -411,7 +411,7 @@ describeE2E("Campaign CRUD lifecycle", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(
@@ -443,7 +443,7 @@ describeE2E("Campaign CRUD lifecycle", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(
@@ -475,7 +475,7 @@ describeE2E("Campaign CRUD lifecycle", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(
@@ -502,7 +502,7 @@ describeE2E("Campaign CRUD lifecycle", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const wrapper = JSON.parse(
@@ -544,7 +544,7 @@ describeE2E("Campaign CRUD lifecycle", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const wrapper = JSON.parse(
@@ -585,7 +585,7 @@ describeE2E("Campaign CRUD lifecycle", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(
@@ -614,7 +614,7 @@ describeE2E("Campaign CRUD lifecycle", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(

--- a/packages/e2e/src/campaign-people.e2e.test.ts
+++ b/packages/e2e/src/campaign-people.e2e.test.ts
@@ -332,7 +332,7 @@ describeE2E("Campaign people management", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(
@@ -366,7 +366,7 @@ describeE2E("Campaign people management", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(
@@ -397,7 +397,7 @@ describeE2E("Campaign people management", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(
@@ -443,7 +443,7 @@ describeE2E("Campaign people management", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(
@@ -476,7 +476,7 @@ describeE2E("Campaign people management", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(

--- a/packages/e2e/src/check-replies.e2e.test.ts
+++ b/packages/e2e/src/check-replies.e2e.test.ts
@@ -128,7 +128,7 @@ describeE2E("check-replies", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(

--- a/packages/e2e/src/check-status.e2e.test.ts
+++ b/packages/e2e/src/check-status.e2e.test.ts
@@ -99,7 +99,7 @@ describeE2E("check-status", () => {
         isError?: boolean;
         content: { type: string; text: string }[];
       };
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
       const parsed = JSON.parse((result.content[0] as { text: string }).text) as StatusReport;
       expect(parsed.launcher.reachable).toBe(true);

--- a/packages/e2e/src/collect-people.e2e.test.ts
+++ b/packages/e2e/src/collect-people.e2e.test.ts
@@ -354,7 +354,7 @@ describeE2E("collect-people operation", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(
@@ -439,7 +439,7 @@ describeE2E("collect-people operation", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(
@@ -470,7 +470,7 @@ describeE2E("collect-people operation", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(

--- a/packages/e2e/src/collections.e2e.test.ts
+++ b/packages/e2e/src/collections.e2e.test.ts
@@ -401,7 +401,7 @@ describeE2E("Collections (create, list, delete, add/remove people, import)", () 
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(
@@ -433,7 +433,7 @@ describeE2E("Collections (create, list, delete, add/remove people, import)", () 
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(
@@ -465,7 +465,7 @@ describeE2E("Collections (create, list, delete, add/remove people, import)", () 
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(
@@ -522,7 +522,7 @@ describeE2E("Collections (create, list, delete, add/remove people, import)", () 
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(
@@ -563,7 +563,7 @@ describeE2E("Collections (create, list, delete, add/remove people, import)", () 
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(
@@ -594,7 +594,7 @@ describeE2E("Collections (create, list, delete, add/remove people, import)", () 
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(
@@ -625,7 +625,7 @@ describeE2E("Collections (create, list, delete, add/remove people, import)", () 
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(

--- a/packages/e2e/src/engagement.e2e.test.ts
+++ b/packages/e2e/src/engagement.e2e.test.ts
@@ -163,7 +163,7 @@ describeE2E("engagement operations", () => {
           content: { type: string; text: string }[];
         };
 
-        expect(result.isError).toBeUndefined();
+        expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
         expect(result.content).toHaveLength(1);
 
         const parsed = JSON.parse(
@@ -220,7 +220,7 @@ describeE2E("engagement operations", () => {
           content: { type: string; text: string }[];
         };
 
-        expect(result.isError).toBeUndefined();
+        expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
         expect(result.content).toHaveLength(1);
 
         const parsed = JSON.parse(
@@ -275,7 +275,7 @@ describeE2E("engagement operations", () => {
           content: { type: string; text: string }[];
         };
 
-        expect(result.isError).toBeUndefined();
+        expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
         expect(result.content).toHaveLength(1);
 
         const parsed = JSON.parse(
@@ -341,7 +341,7 @@ describeE2E("engagement operations", () => {
           content: { type: string; text: string }[];
         };
 
-        expect(result.isError).toBeUndefined();
+        expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
         expect(result.content).toHaveLength(1);
 
         const parsed = JSON.parse(
@@ -401,7 +401,7 @@ describeE2E("engagement operations", () => {
           content: { type: string; text: string }[];
         };
 
-        expect(result.isError).toBeUndefined();
+        expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
         expect(result.content).toHaveLength(1);
 
         const parsed = JSON.parse(
@@ -469,7 +469,7 @@ describeE2E("engagement operations", () => {
           content: { type: string; text: string }[];
         };
 
-        expect(result.isError).toBeUndefined();
+        expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
         expect(result.content).toHaveLength(1);
 
         const parsed = JSON.parse(

--- a/packages/e2e/src/error-and-lifecycle.e2e.test.ts
+++ b/packages/e2e/src/error-and-lifecycle.e2e.test.ts
@@ -71,7 +71,7 @@ describeE2E("Error handling and lifecycle", () => {
           content: { type: string; text: string }[];
         };
 
-        expect(result.isError).toBeUndefined();
+        expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
         expect(result.content).toHaveLength(1);
 
         const text = (result.content[0] as { text: string }).text;
@@ -151,7 +151,7 @@ describeE2E("Error handling and lifecycle", () => {
           content: { type: string; text: string }[];
         };
 
-        expect(result.isError).toBeUndefined();
+        expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
         expect(result.content).toHaveLength(1);
 
         const parsed = JSON.parse(

--- a/packages/e2e/src/find-app.e2e.test.ts
+++ b/packages/e2e/src/find-app.e2e.test.ts
@@ -96,7 +96,7 @@ describeE2E("find-app", () => {
         isError?: boolean;
         content: { type: string; text: string }[];
       };
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
       const parsed = JSON.parse((result.content[0] as { text: string }).text) as DiscoveredApp[];
       expect(parsed.length).toBeGreaterThan(0);

--- a/packages/e2e/src/get-errors.e2e.test.ts
+++ b/packages/e2e/src/get-errors.e2e.test.ts
@@ -111,7 +111,7 @@ describeE2E("get-errors operation", () => {
           content: { type: string; text: string }[];
         };
 
-        expect(result.isError).toBeUndefined();
+        expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
         expect(result.content).toHaveLength(1);
 
         const parsed = JSON.parse(
@@ -222,7 +222,7 @@ describeE2E("get-errors operation", () => {
           content: { type: string; text: string }[];
         };
 
-        expect(result.isError).toBeUndefined();
+        expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
         expect(result.content).toHaveLength(1);
 
         const parsed = JSON.parse(

--- a/packages/e2e/src/get-feed.e2e.test.ts
+++ b/packages/e2e/src/get-feed.e2e.test.ts
@@ -143,7 +143,7 @@ describeE2E("get-feed operation", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(

--- a/packages/e2e/src/get-post-engagers.e2e.test.ts
+++ b/packages/e2e/src/get-post-engagers.e2e.test.ts
@@ -102,7 +102,7 @@ describeE2E("get-post-engagers operation", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(

--- a/packages/e2e/src/get-post-stats.e2e.test.ts
+++ b/packages/e2e/src/get-post-stats.e2e.test.ts
@@ -168,7 +168,7 @@ describeE2E("get-post-stats operation", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(

--- a/packages/e2e/src/get-post.e2e.test.ts
+++ b/packages/e2e/src/get-post.e2e.test.ts
@@ -171,7 +171,7 @@ describeE2E("get-post operation", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(

--- a/packages/e2e/src/get-profile-activity.e2e.test.ts
+++ b/packages/e2e/src/get-profile-activity.e2e.test.ts
@@ -181,7 +181,7 @@ describeE2E("get-profile-activity operation", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(

--- a/packages/e2e/src/import-people-from-urls.e2e.test.ts
+++ b/packages/e2e/src/import-people-from-urls.e2e.test.ts
@@ -292,7 +292,7 @@ describeE2E("import-people-from-urls operation", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(
@@ -326,7 +326,7 @@ describeE2E("import-people-from-urls operation", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(
@@ -365,7 +365,7 @@ describeE2E("import-people-from-urls operation", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(
@@ -400,7 +400,7 @@ describeE2E("import-people-from-urls operation", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(

--- a/packages/e2e/src/instance-lifecycle.e2e.test.ts
+++ b/packages/e2e/src/instance-lifecycle.e2e.test.ts
@@ -204,7 +204,7 @@ describeE2E("Instance lifecycle", () => {
           content: { type: string; text: string }[];
         };
 
-        expect(result.isError).toBeUndefined();
+        expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
         expect(result.content).toHaveLength(1);
 
         const text = (result.content[0] as { text: string }).text;
@@ -227,7 +227,7 @@ describeE2E("Instance lifecycle", () => {
           content: { type: string; text: string }[];
         };
 
-        expect(result.isError).toBeUndefined();
+        expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
         expect(result.content).toHaveLength(1);
 
         const text = (result.content[0] as { text: string }).text;

--- a/packages/e2e/src/profile-and-utility.e2e.test.ts
+++ b/packages/e2e/src/profile-and-utility.e2e.test.ts
@@ -111,7 +111,7 @@ describeE2E("profile enrichment and utilities", () => {
           content: { type: string; text: string }[];
         };
 
-        expect(result.isError).toBeUndefined();
+        expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
         expect(result.content).toHaveLength(1);
 
         const parsed = JSON.parse((result.content[0] as { text: string }).text) as {
@@ -132,7 +132,7 @@ describeE2E("profile enrichment and utilities", () => {
           content: { type: string; text: string }[];
         };
 
-        expect(result.isError).toBeUndefined();
+        expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
         expect(result.content).toHaveLength(1);
 
         const parsed = JSON.parse((result.content[0] as { text: string }).text) as {
@@ -192,7 +192,7 @@ describeE2E("profile enrichment and utilities", () => {
           content: { type: string; text: string }[];
         };
 
-        expect(result.isError).toBeUndefined();
+        expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
         expect(result.content).toHaveLength(1);
 
         const parsed = JSON.parse((result.content[0] as { text: string }).text) as {
@@ -275,7 +275,7 @@ describeE2E("profile enrichment and utilities", () => {
           content: { type: string; text: string }[];
         };
 
-        expect(result.isError).toBeUndefined();
+        expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
         expect(result.content).toHaveLength(1);
 
         const parsed = JSON.parse((result.content[0] as { text: string }).text) as {
@@ -336,7 +336,7 @@ describeE2E("profile enrichment and utilities", () => {
           content: { type: string; text: string }[];
         };
 
-        expect(result.isError).toBeUndefined();
+        expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
         expect(result.content).toHaveLength(1);
 
         const parsed = JSON.parse((result.content[0] as { text: string }).text) as {
@@ -478,7 +478,7 @@ describeE2E("profile enrichment and utilities", () => {
             content: { type: string; text: string }[];
           };
 
-          expect(result.isError).toBeUndefined();
+          expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
           expect(result.content).toHaveLength(1);
 
           const parsed = JSON.parse((result.content[0] as { text: string }).text) as {
@@ -552,7 +552,7 @@ describeE2E("profile enrichment and utilities", () => {
             content: { type: string; text: string }[];
           };
 
-          expect(result.isError).toBeUndefined();
+          expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
           expect(result.content).toHaveLength(1);
 
           const parsed = JSON.parse((result.content[0] as { text: string }).text) as {
@@ -633,7 +633,7 @@ describeE2E("profile enrichment and utilities", () => {
             content: { type: string; text: string }[];
           };
 
-          expect(result.isError).toBeUndefined();
+          expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
           expect(result.content).toHaveLength(1);
 
           const parsed = JSON.parse((result.content[0] as { text: string }).text) as {
@@ -696,7 +696,7 @@ describeE2E("profile enrichment and utilities", () => {
             content: { type: string; text: string }[];
           };
 
-          expect(result.isError).toBeUndefined();
+          expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
           expect(result.content).toHaveLength(1);
 
           const parsed = JSON.parse((result.content[0] as { text: string }).text) as {

--- a/packages/e2e/src/query-profile.e2e.test.ts
+++ b/packages/e2e/src/query-profile.e2e.test.ts
@@ -78,7 +78,7 @@ describeE2E("query-profile", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse((result.content[0] as { text: string }).text) as Profile;

--- a/packages/e2e/src/query-profiles.e2e.test.ts
+++ b/packages/e2e/src/query-profiles.e2e.test.ts
@@ -129,7 +129,7 @@ describeE2E("query-profiles operation", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(
@@ -156,7 +156,7 @@ describeE2E("query-profiles operation", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(
@@ -179,7 +179,7 @@ describeE2E("query-profiles operation", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
 
       const parsed = JSON.parse(
         (result.content[0] as { text: string }).text,

--- a/packages/e2e/src/scrape-messaging-history.e2e.test.ts
+++ b/packages/e2e/src/scrape-messaging-history.e2e.test.ts
@@ -128,7 +128,7 @@ describeE2E("scrape-messaging-history", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(

--- a/packages/e2e/src/search-posts.e2e.test.ts
+++ b/packages/e2e/src/search-posts.e2e.test.ts
@@ -144,7 +144,7 @@ describeE2E("search-posts operation", () => {
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError).toBeUndefined();
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
 
       const parsed = JSON.parse(


### PR DESCRIPTION
## Summary

- Replace all 93 bare `expect(result.isError).toBeUndefined()` assertions with error-body-aware versions across 26 E2E test files
- When an MCP tool returns an error, vitest now shows the actual error text instead of just "expected true to be undefined"

## Test plan

- [x] No old pattern remains (`grep` confirms 0 occurrences of bare `expect(result.isError).toBeUndefined()`)
- [x] All 93 assertions updated to include `MCP tool error: ${result.content?.[0]?.text}` message
- [x] `pnpm lint` passes
- [ ] CI passes (build + lint + test)

Closes #674

🤖 Generated with [Claude Code](https://claude.com/claude-code)