### PR TITLE
(fix) types: RunnerState union is incomplete

### DIFF
--- a/packages/core/src/types/campaign.ts
+++ b/packages/core/src/types/campaign.ts
@@ -193,7 +193,13 @@ export interface CampaignActionConfig {
 /**
  * Runner state of the LinkedHelper main window.
  */
-export type RunnerState = "idle" | "campaigns" | "stopping-campaigns";
+export type RunnerState =
+  | "idle"
+  | "initializing"
+  | "campaigns"
+  | "stopping-campaigns"
+  | "preparing-collecting"
+  | "collecting";
 
 /**
  * People counts for a campaign action by processing state.


### PR DESCRIPTION
## Summary

- Add `initializing`, `preparing-collecting`, and `collecting` to the `RunnerState` union type
- These states were observed at runtime (documented in research and `CollectionService` JSDoc) but missing from the type definition
- No behavioral changes — purely a type correctness fix so TypeScript accurately reflects the full state space

Closes #682

## Test plan

- [x] Build passes
- [x] Lint passes
- [x] All unit and integration tests pass (468 tests)
- No new tests needed — this is a type-only change with no runtime behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)