### PR TITLE
(fix) campaign: skip redundant stop on idle/stopping runner

### DIFF
--- a/packages/core/src/services/campaign.test.ts
+++ b/packages/core/src/services/campaign.test.ts
@@ -386,6 +386,39 @@ describe("CampaignService", () => {
       expect(stopExpr).toContain("campaignController.stop()");
     });
 
+    it("force-restarts runner stuck in stopping-campaigns before re-stopping", async () => {
+      mockEvaluateUI
+        .mockResolvedValueOnce("stopping-campaigns") // getRunnerState (initial check)
+        .mockResolvedValueOnce(undefined)            // startRunner (force restart)
+        .mockResolvedValueOnce("campaigns")          // getRunnerState (re-check after restart)
+        .mockResolvedValueOnce(undefined)            // stopRunner (clean stop)
+        .mockResolvedValueOnce("idle")               // getRunnerState (waitForIdle poll 1)
+        .mockResolvedValueOnce(undefined)            // unpause
+        .mockResolvedValueOnce(true);                // start
+
+      const promise = service.start(1, [42]);
+      await vi.advanceTimersByTimeAsync(3000);
+      await promise;
+
+      expect(mockEvaluateUI.mock.calls.length).toBeGreaterThanOrEqual(7);
+
+      // Call 1: getRunnerState → stopping-campaigns
+      const stateExpr = mockEvaluateUI.mock.calls[0]?.[0] as string;
+      expect(stateExpr).toContain("state");
+
+      // Call 2: startRunner (force restart to break stuck state)
+      const startExpr = mockEvaluateUI.mock.calls[1]?.[0] as string;
+      expect(startExpr).toContain("campaignController.start()");
+
+      // Call 3: getRunnerState re-check after restart
+      const recheckExpr = mockEvaluateUI.mock.calls[2]?.[0] as string;
+      expect(recheckExpr).toContain("state");
+
+      // Call 4: stopRunner (clean stop)
+      const stopExpr = mockEvaluateUI.mock.calls[3]?.[0] as string;
+      expect(stopExpr).toContain("campaignController.stop()");
+    });
+
     it("throws CampaignTimeoutError with state and campaign context when runner does not reach idle", async () => {
       mockEvaluateUI.mockResolvedValue("campaigns"); // always busy
 
@@ -427,20 +460,26 @@ describe("CampaignService", () => {
   });
 
   describe("stop", () => {
-    it("pauses campaign and stops runner", async () => {
+    it("pauses campaign and conditionally stops runner", async () => {
       mockGetCampaign.mockReturnValue(MOCK_CAMPAIGN);
       mockEvaluateUI
         .mockResolvedValueOnce(undefined) // pause
-        .mockResolvedValueOnce(undefined); // stop
+        .mockResolvedValueOnce(undefined); // atomic state-check + stop
 
       await service.stop(1);
 
       expect(mockEvaluateUI).toHaveBeenCalledTimes(2);
+
+      // First call: pause the campaign
       const pauseExpr = mockEvaluateUI.mock.calls[0]?.[0] as string;
       expect(pauseExpr).toContain("setCampaignPaused");
       expect(pauseExpr).toContain("true");
 
+      // Second call: atomic state-check + conditional stop
       const stopExpr = mockEvaluateUI.mock.calls[1]?.[0] as string;
+      expect(stopExpr).toContain("state");
+      expect(stopExpr).toContain("idle");
+      expect(stopExpr).toContain("stopping-campaigns");
       expect(stopExpr).toContain("campaignController.stop()");
     });
 

--- a/packages/core/src/services/campaign.ts
+++ b/packages/core/src/services/campaign.ts
@@ -453,16 +453,28 @@ export class CampaignService {
    * runner's own SQLite writes.
    */
   async stopRunnerAndWaitForIdle(campaignId?: number): Promise<void> {
-    const state = await this.getRunnerState();
+    let state = await this.getRunnerState();
     if (state === "idle") return;
-    try {
-      await this.stopRunner();
-    } catch (error) {
-      if (campaignId !== undefined && error instanceof CampaignExecutionError && error.campaignId === undefined) {
-        throw new CampaignExecutionError(error.message, campaignId, { cause: error.cause });
-      }
-      throw error;
+    if (state === "stopping-campaigns") {
+      // Runner is in stopping-campaigns and may be stuck — force a restart
+      // cycle to break out of that state, then re-stop cleanly.
+      try { await this.startRunner(); } catch { /* best-effort */ }
+      state = await this.getRunnerState();
+      if (state === "idle") return;
     }
+    if (state !== "stopping-campaigns") {
+      try {
+        await this.stopRunner();
+      } catch (error) {
+        if (campaignId !== undefined && error instanceof CampaignExecutionError && error.campaignId === undefined) {
+          throw new CampaignExecutionError(error.message, campaignId, { cause: error.cause });
+        }
+        throw error;
+      }
+    }
+    // If still in stopping-campaigns after recovery attempt, waitForIdle is
+    // the fallback — re-issuing stopRunner() on a stopping runner is known
+    // to not help and may worsen the stuck state.
     await this.waitForIdle(campaignId);
   }
 
@@ -633,10 +645,14 @@ export class CampaignService {
         })()`,
       );
 
-      // Stop the global runner
+      // Stop the global runner. Skip if already idle or stopping — calling
+      // stop on an idle/stopping runner can leave it stuck.
       await this.instance.evaluateUI(
         `(function() {
-          window.mainWindowService.mainWindow.campaignController.stop();
+          const s = window.mainWindowService.mainWindow.state;
+          if (s !== "idle" && s !== "stopping-campaigns") {
+            window.mainWindowService.mainWindow.campaignController.stop();
+          }
         })()`,
         false,
       );


### PR DESCRIPTION
## Summary

The LH runner gets permanently stuck in `stopping-campaigns` after `campaignController.stop()` is called — it never transitions back to idle. This caused the MCP `campaign-start` E2E test to time out after 60s.

**Root cause**: Calling `campaignController.stop()` on an idle or already-stopping runner leaves it in a `stopping-campaigns` state that never resolves. The CLI `campaign-stop` test leaves the runner in this state, and the MCP `campaign-start` test finds it stuck.

**Fixes in `CampaignService`:**
- `stop()`: atomic state check inside `evaluateUI` skips `campaignController.stop()` when runner is already idle or stopping — prevents creating new stuck states
- `stopRunnerAndWaitForIdle()`: when runner is stuck in `stopping-campaigns`, force a restart cycle (`startRunner()` → `stopRunner()`) to break out and trigger a clean stop transition

## Test plan

- [x] Unit test: `stop()` atomically checks state before stopping
- [x] Unit test: `start()` force-restarts runner stuck in `stopping-campaigns`
- [x] All 1409 unit/integration tests pass, lint clean
- [x] E2E: `campaign-execution` — all 18 tests pass (MCP `campaign-start` now completes in ~1s vs 60s timeout)

Closes #675

🤖 Generated with [Claude Code](https://claude.com/claude-code)