### PR TITLE
dismiss-feed-post: add "Not interested" operation

### DIFF
--- a/packages/cli/src/handlers/dismiss-feed-post.ts
+++ b/packages/cli/src/handlers/dismiss-feed-post.ts
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import {
+  errorMessage,
+  dismissFeedPost,
+  type DismissFeedPostOutput,
+} from "@lhremote/core";
+
+/** Handle the {@link https://github.com/alexey-pelykh/lhremote#dismiss-feed-post | dismiss-feed-post} CLI command. */
+export async function handleDismissFeedPost(
+  postUrl: string,
+  options: {
+    cdpPort?: number;
+    cdpHost?: string;
+    allowRemote?: boolean;
+    json?: boolean;
+  },
+): Promise<void> {
+  let result: DismissFeedPostOutput;
+  try {
+    result = await dismissFeedPost({
+      postUrl,
+      cdpPort: options.cdpPort,
+      cdpHost: options.cdpHost,
+      allowRemote: options.allowRemote,
+    });
+  } catch (error) {
+    const message = errorMessage(error);
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+    return;
+  }
+
+  if (options.json) {
+    process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+  } else {
+    process.stdout.write(
+      `Dismissed post from feed\n  Post: ${result.postUrl}\n`,
+    );
+  }
+}

--- a/packages/cli/src/handlers/index.ts
+++ b/packages/cli/src/handlers/index.ts
@@ -27,6 +27,7 @@ export { handleCampaignUpdate } from "./campaign-update.js";
 export { handleCampaignUpdateAction } from "./campaign-update-action.js";
 export { handleCreateCollection } from "./create-collection.js";
 export { handleDeleteCollection } from "./delete-collection.js";
+export { handleDismissFeedPost } from "./dismiss-feed-post.js";
 export { handleDismissErrors } from "./dismiss-errors.js";
 export { handleCheckReplies } from "./check-replies.js";
 export { handleCommentOnPost } from "./comment-on-post.js";

--- a/packages/cli/src/program.test.ts
+++ b/packages/cli/src/program.test.ts
@@ -102,7 +102,8 @@ describe("createProgram", () => {
     expect(commandNames).toContain("remove-connection");
     expect(commandNames).toContain("enrich-profile");
     expect(commandNames).toContain("campaign-erase");
-    expect(commandNames).toHaveLength(67);
+    expect(commandNames).toContain("dismiss-feed-post");
+    expect(commandNames).toHaveLength(68);
   });
 
   describe("launch-app", () => {

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -32,6 +32,7 @@ import {
   handleCampaignUpdateAction,
   handleCreateCollection,
   handleDeleteCollection,
+  handleDismissFeedPost,
   handleDismissErrors,
   handleImportPeopleFromCollection,
   handleImportPeopleFromUrls,
@@ -736,6 +737,16 @@ export function createProgram(): Command {
     .option("--allow-remote", "SECURITY: allow non-loopback CDP connections (enables remote code execution on target)")
     .option("--json", "Output as JSON")
     .action(handleGetFeed);
+
+  program
+    .command("dismiss-feed-post")
+    .description('Dismiss a post from the LinkedIn feed by clicking "Not interested"')
+    .argument("<postUrl>", "LinkedIn post URL")
+    .option("--cdp-port <port>", "CDP debugging port (auto-discovered when omitted)", parsePositiveInt)
+    .option("--cdp-host <host>", "CDP host (default: 127.0.0.1)")
+    .option("--allow-remote", "SECURITY: allow non-loopback CDP connections (enables remote code execution on target)")
+    .option("--json", "Output as JSON")
+    .action(handleDismissFeedPost);
 
   program
     .command("react-to-post")

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -303,6 +303,9 @@ export {
   commentOnPost,
   type CommentOnPostInput,
   type CommentOnPostOutput,
+  dismissFeedPost,
+  type DismissFeedPostInput,
+  type DismissFeedPostOutput,
   // Feed
   getFeed,
   type GetFeedInput,

--- a/packages/core/src/operations/dismiss-feed-post.test.ts
+++ b/packages/core/src/operations/dismiss-feed-post.test.ts
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../cdp/client.js", () => ({
+  CDPClient: vi.fn(),
+}));
+
+vi.mock("../cdp/discovery.js", () => ({
+  discoverTargets: vi.fn(),
+}));
+
+vi.mock("../linkedin/dom-automation.js", () => ({
+  humanizedScrollToByIndex: vi.fn().mockResolvedValue(undefined),
+  retryInteraction: vi.fn().mockImplementation((fn: () => Promise<unknown>) => fn()),
+}));
+
+vi.mock("../utils/delay.js", () => ({
+  delay: vi.fn().mockResolvedValue(undefined),
+  gaussianDelay: vi.fn().mockResolvedValue(undefined),
+  maybeHesitate: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("./navigate-away.js", () => ({
+  navigateAwayIf: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("./get-feed.js", () => ({
+  waitForFeedLoad: vi.fn().mockResolvedValue(undefined),
+  scrollFeed: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { CDPClient } from "../cdp/client.js";
+import { discoverTargets } from "../cdp/discovery.js";
+import { dismissFeedPost } from "./dismiss-feed-post.js";
+
+const TARGET_URL = "https://www.linkedin.com/feed/update/urn:li:activity:123/";
+
+const mockClient = {
+  connect: vi.fn().mockResolvedValue(undefined),
+  navigate: vi.fn().mockResolvedValue(undefined),
+  evaluate: vi.fn().mockResolvedValue(null),
+  disconnect: vi.fn(),
+};
+
+function setupMocks() {
+  vi.mocked(CDPClient).mockImplementation(function () {
+    return mockClient as unknown as CDPClient;
+  });
+  vi.mocked(discoverTargets).mockResolvedValue([
+    { id: "target-1", type: "page", title: "LinkedIn", url: "https://www.linkedin.com/feed/", description: "", devtoolsFrontendUrl: "" },
+  ]);
+}
+
+/**
+ * Configure mockClient.evaluate to simulate a feed with one post whose URL
+ * matches `targetUrl`, and whose menu contains "Not interested".
+ */
+function setupFeedWithPost(targetUrl: string) {
+  mockClient.evaluate.mockImplementation((script: string) => {
+    // Clipboard interceptor install
+    if (typeof script === "string" && script.includes("__capturedClipboard")) {
+      if (script.includes("writeText")) return Promise.resolve(undefined);
+      if (script.includes("= null")) return Promise.resolve(undefined);
+      // Read captured clipboard
+      return Promise.resolve(targetUrl);
+    }
+    // Post count query
+    if (typeof script === "string" && script.includes(".length")) {
+      return Promise.resolve(1);
+    }
+    // Menu button click
+    if (typeof script === "string" && script.includes("btn.click()")) {
+      return Promise.resolve(true);
+    }
+    // "Copy link to post" click
+    if (typeof script === "string" && script.includes("Copy link to post")) {
+      return Promise.resolve(undefined);
+    }
+    // "Not interested" click
+    if (typeof script === "string" && script.includes("Not interested")) {
+      return Promise.resolve(true);
+    }
+    // Escape key
+    if (typeof script === "string" && script.includes("Escape")) {
+      return Promise.resolve(undefined);
+    }
+    return Promise.resolve(null);
+  });
+}
+
+describe("dismissFeedPost", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("throws on non-loopback host without allowRemote", async () => {
+    await expect(
+      dismissFeedPost({
+        postUrl: TARGET_URL,
+        cdpPort: 9222,
+        cdpHost: "192.168.1.100",
+      }),
+    ).rejects.toThrow("requires --allow-remote");
+  });
+
+  it("allows non-loopback host with allowRemote", async () => {
+    setupMocks();
+    setupFeedWithPost(TARGET_URL);
+
+    const result = await dismissFeedPost({
+      postUrl: TARGET_URL,
+      cdpPort: 9222,
+      cdpHost: "192.168.1.100",
+      allowRemote: true,
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("throws when no LinkedIn page is found", async () => {
+    vi.mocked(discoverTargets).mockResolvedValue([
+      { id: "target-1", type: "page", title: "Example", url: "https://example.com", description: "", devtoolsFrontendUrl: "" },
+    ]);
+
+    await expect(
+      dismissFeedPost({
+        postUrl: TARGET_URL,
+        cdpPort: 9222,
+      }),
+    ).rejects.toThrow("No LinkedIn page found");
+  });
+
+  it("returns success when post is found and dismissed", async () => {
+    setupMocks();
+    setupFeedWithPost(TARGET_URL);
+
+    const result = await dismissFeedPost({
+      postUrl: TARGET_URL,
+      cdpPort: 9222,
+    });
+
+    expect(result).toEqual({
+      success: true,
+      postUrl: TARGET_URL,
+    });
+  });
+
+  it("throws when Not interested is not in the menu", async () => {
+    setupMocks();
+    mockClient.evaluate.mockImplementation((script: string) => {
+      if (typeof script === "string" && script.includes("writeText")) return Promise.resolve(undefined);
+      if (typeof script === "string" && script.includes("= null")) return Promise.resolve(undefined);
+      if (typeof script === "string" && script.includes("__capturedClipboard") && !script.includes("=")) return Promise.resolve(TARGET_URL);
+      if (typeof script === "string" && script.includes(".length")) return Promise.resolve(1);
+      if (typeof script === "string" && script.includes("btn.click()")) return Promise.resolve(true);
+      if (typeof script === "string" && script.includes("Copy link to post")) return Promise.resolve(undefined);
+      if (typeof script === "string" && script.includes("Not interested")) return Promise.resolve(false);
+      if (typeof script === "string" && script.includes("Escape")) return Promise.resolve(undefined);
+      return Promise.resolve(null);
+    });
+
+    await expect(
+      dismissFeedPost({
+        postUrl: TARGET_URL,
+        cdpPort: 9222,
+      }),
+    ).rejects.toThrow('does not contain "Not interested"');
+  });
+
+  it("throws when post is not found in the feed", async () => {
+    setupMocks();
+    // Simulate an empty feed (0 posts)
+    mockClient.evaluate.mockImplementation((script: string) => {
+      if (typeof script === "string" && script.includes("writeText")) return Promise.resolve(undefined);
+      if (typeof script === "string" && script.includes(".length")) return Promise.resolve(0);
+      return Promise.resolve(null);
+    });
+
+    await expect(
+      dismissFeedPost({
+        postUrl: TARGET_URL,
+        cdpPort: 9222,
+      }),
+    ).rejects.toThrow("Post not found in the feed");
+  });
+
+  it("disconnects the CDP client even when an error occurs", async () => {
+    setupMocks();
+    mockClient.evaluate.mockRejectedValue(new Error("evaluation failed"));
+
+    await expect(
+      dismissFeedPost({
+        postUrl: TARGET_URL,
+        cdpPort: 9222,
+      }),
+    ).rejects.toThrow("evaluation failed");
+
+    expect(mockClient.disconnect).toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/operations/dismiss-feed-post.ts
+++ b/packages/core/src/operations/dismiss-feed-post.ts
@@ -31,9 +31,8 @@ export interface DismissFeedPostOutput {
  * Open the three-dot menu for a feed post at the given index, click
  * "Copy link to post", and return the captured URL (query params stripped).
  *
- * Returns `null` when the menu button doesn't exist or the clipboard
- * capture fails after up to 3 attempts (matching the retry behaviour of
- * the identical helper in `get-feed.ts`).
+ * Returns `null` when the menu button doesn't exist or when clipboard
+ * capture fails after up to 3 attempts.
  */
 async function capturePostUrl(
   client: CDPClient,
@@ -136,6 +135,14 @@ async function clickNotInterested(
     }
     return false;
   })()`);
+
+  if (!dismissed) {
+    // Dismiss the open menu to avoid leaving the UI in a modal state
+    await client.evaluate(`(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    })()`);
+    await gaussianDelay(300, 75, 200, 500);
+  }
 
   return dismissed;
 }

--- a/packages/core/src/operations/dismiss-feed-post.ts
+++ b/packages/core/src/operations/dismiss-feed-post.ts
@@ -1,0 +1,255 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { resolveInstancePort } from "../cdp/index.js";
+import { CDPClient } from "../cdp/client.js";
+import { discoverTargets } from "../cdp/discovery.js";
+import { humanizedScrollToByIndex, retryInteraction } from "../linkedin/dom-automation.js";
+import type { HumanizedMouse } from "../linkedin/humanized-mouse.js";
+import { gaussianDelay, maybeHesitate } from "../utils/delay.js";
+import type { ConnectionOptions } from "./types.js";
+import { navigateAwayIf } from "./navigate-away.js";
+import { scrollFeed, waitForFeedLoad } from "./get-feed.js";
+
+/** CSS selector for feed post menu buttons. */
+const FEED_MENU_BUTTON_SELECTOR =
+  '[data-testid="mainFeed"] div[role="listitem"] button[aria-label^="Open control menu for post"]';
+
+export interface DismissFeedPostInput extends ConnectionOptions {
+  /** LinkedIn post URL identifying a visible feed post. */
+  readonly postUrl: string;
+  /** Optional humanized mouse for natural cursor movement and clicks. */
+  readonly mouse?: HumanizedMouse | null | undefined;
+}
+
+export interface DismissFeedPostOutput {
+  readonly success: true;
+  readonly postUrl: string;
+}
+
+/**
+ * Open the three-dot menu for a feed post at the given index, click
+ * "Copy link to post", and return the captured URL (query params stripped).
+ *
+ * Returns `null` when the menu button doesn't exist or the clipboard
+ * capture fails after up to 3 attempts (matching the retry behaviour of
+ * the identical helper in `get-feed.ts`).
+ */
+async function capturePostUrl(
+  client: CDPClient,
+  postIndex: number,
+  mouse?: HumanizedMouse | null,
+): Promise<string | null> {
+  const MAX_ATTEMPTS = 3;
+
+  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+    await maybeHesitate();
+
+    await client.evaluate(`window.__capturedClipboard = null;`);
+
+    await humanizedScrollToByIndex(client, FEED_MENU_BUTTON_SELECTOR, postIndex, mouse);
+
+    const clicked = await client.evaluate<boolean>(`(() => {
+      const btns = document.querySelectorAll(
+        ${JSON.stringify(FEED_MENU_BUTTON_SELECTOR)}
+      );
+      const btn = btns[${postIndex}];
+      if (!btn) return false;
+      btn.click();
+      return true;
+    })()`);
+
+    if (!clicked) return null;
+
+    await gaussianDelay(700, 100, 500, 900);
+
+    await client.evaluate(`(() => {
+      for (const el of document.querySelectorAll('[role="menuitem"]')) {
+        if (el.textContent.trim() === 'Copy link to post') {
+          el.click();
+          return;
+        }
+      }
+    })()`);
+
+    await gaussianDelay(550, 75, 400, 700);
+
+    const postUrl =
+      await client.evaluate<string | null>(`window.__capturedClipboard`);
+
+    if (postUrl) {
+      return postUrl.split("?")[0] ?? postUrl;
+    }
+
+    // Dismiss any open menu before retrying
+    await client.evaluate(`(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    })()`);
+
+    await gaussianDelay(700 * (attempt + 1), 200, 350 * (attempt + 1), 1_050 * (attempt + 1));
+  }
+
+  return null;
+}
+
+/**
+ * Open the three-dot menu for a feed post at the given index and click
+ * the "Not interested" menu item.
+ *
+ * @returns `true` if "Not interested" was clicked, `false` if the menu
+ *   item was not found.
+ * @throws If the menu button could not be clicked.
+ */
+async function clickNotInterested(
+  client: CDPClient,
+  postIndex: number,
+  mouse?: HumanizedMouse | null,
+): Promise<boolean> {
+  await maybeHesitate();
+
+  await humanizedScrollToByIndex(client, FEED_MENU_BUTTON_SELECTOR, postIndex, mouse);
+
+  const clicked = await client.evaluate<boolean>(`(() => {
+    const btns = document.querySelectorAll(
+      ${JSON.stringify(FEED_MENU_BUTTON_SELECTOR)}
+    );
+    const btn = btns[${postIndex}];
+    if (!btn) return false;
+    btn.click();
+    return true;
+  })()`);
+
+  if (!clicked) {
+    throw new Error(
+      "Failed to open the three-dot menu for the target post.",
+    );
+  }
+
+  await gaussianDelay(700, 100, 500, 900);
+
+  const dismissed = await client.evaluate<boolean>(`(() => {
+    for (const el of document.querySelectorAll('[role="menuitem"]')) {
+      if (el.textContent.trim() === 'Not interested') {
+        el.click();
+        return true;
+      }
+    }
+    return false;
+  })()`);
+
+  return dismissed;
+}
+
+/**
+ * Dismiss a post from the LinkedIn feed by clicking "Not interested".
+ *
+ * Navigates to the LinkedIn home feed, locates the post whose URL matches
+ * the given `postUrl` (extracted via the three-dot menu → "Copy link to
+ * post" clipboard trick), then reopens the menu and clicks "Not interested".
+ *
+ * @param input - Post URL, CDP connection parameters, and optional mouse.
+ * @returns Confirmation that the post was dismissed.
+ * @throws When the post is not found in the feed or "Not interested" is
+ *   not available in its menu.
+ */
+export async function dismissFeedPost(
+  input: DismissFeedPostInput,
+): Promise<DismissFeedPostOutput> {
+  const cdpPort = await resolveInstancePort(input.cdpPort, input.cdpHost);
+  const cdpHost = input.cdpHost ?? "127.0.0.1";
+  const allowRemote = input.allowRemote ?? false;
+
+  // Enforce loopback guard
+  if (!allowRemote && cdpHost !== "127.0.0.1" && cdpHost !== "localhost") {
+    throw new Error(
+      `Non-loopback CDP host "${cdpHost}" requires --allow-remote. ` +
+        "This is a security measure to prevent remote code execution.",
+    );
+  }
+
+  const targets = await discoverTargets(cdpPort, cdpHost);
+  const linkedInTarget = targets.find(
+    (t) => t.type === "page" && t.url?.includes("linkedin.com"),
+  );
+
+  if (!linkedInTarget) {
+    throw new Error(
+      "No LinkedIn page found in LinkedHelper. " +
+        "Ensure LinkedHelper is running with an active LinkedIn session.",
+    );
+  }
+
+  const client = new CDPClient(cdpPort, { host: cdpHost, allowRemote });
+  await client.connect(linkedInTarget.id);
+
+  try {
+    const mouse = input.mouse;
+    const targetUrl = input.postUrl.split("?")[0];
+
+    // Navigate to the feed (force fresh load if already there)
+    await navigateAwayIf(client, "/feed");
+    await client.navigate("https://www.linkedin.com/feed/");
+    await waitForFeedLoad(client);
+
+    // Install clipboard interceptor (Electron's clipboard API is broken)
+    await client.evaluate(
+      `navigator.clipboard.writeText = function(text) {
+        window.__capturedClipboard = text;
+        return Promise.resolve();
+      };`,
+    );
+
+    const maxScrollAttempts = 5;
+    let checkedUpTo = 0;
+
+    for (let scroll = 0; scroll <= maxScrollAttempts; scroll++) {
+      const postCount = await client.evaluate<number>(
+        `document.querySelectorAll(${JSON.stringify(FEED_MENU_BUTTON_SELECTOR)}).length`,
+      );
+
+      for (let i = checkedUpTo; i < postCount; i++) {
+        if (i > checkedUpTo) {
+          await gaussianDelay(550, 125, 300, 800);
+        }
+
+        const url = await retryInteraction(
+          () => capturePostUrl(client, i, mouse),
+        );
+
+        if (url && url === targetUrl) {
+          // Found the target post — click "Not interested"
+          const dismissed = await clickNotInterested(client, i, mouse);
+
+          if (!dismissed) {
+            throw new Error(
+              'The post\'s three-dot menu does not contain "Not interested". ' +
+                "This may happen for your own posts or sponsored content.",
+            );
+          }
+
+          await gaussianDelay(550, 75, 400, 700);
+          await gaussianDelay(1_500, 500, 700, 3_500); // Post-action dwell
+          return {
+            success: true as const,
+            postUrl: input.postUrl,
+          };
+        }
+      }
+
+      checkedUpTo = postCount;
+
+      // Scroll to load more posts
+      if (scroll < maxScrollAttempts) {
+        await scrollFeed(client, mouse);
+        await gaussianDelay(1_500, 300, 1_000, 2_500);
+      }
+    }
+
+    throw new Error(
+      `Post not found in the feed: ${input.postUrl}. ` +
+        "Ensure the post is visible in the LinkedIn feed.",
+    );
+  } finally {
+    client.disconnect();
+  }
+}

--- a/packages/core/src/operations/index.ts
+++ b/packages/core/src/operations/index.ts
@@ -203,6 +203,11 @@ export {
   type CommentOnPostInput,
   type CommentOnPostOutput,
 } from "./comment-on-post.js";
+export {
+  dismissFeedPost,
+  type DismissFeedPostInput,
+  type DismissFeedPostOutput,
+} from "./dismiss-feed-post.js";
 
 // Post detail
 export {

--- a/packages/e2e/src/feed-dismissal.e2e.test.ts
+++ b/packages/e2e/src/feed-dismissal.e2e.test.ts
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  describeE2E,
+  forceStopInstance,
+  getE2EPostUrl,
+  installErrorDetection,
+  launchApp,
+  quitApp,
+  resolveAccountId,
+  retryAsync,
+} from "@lhremote/core/testing";
+import {
+  type AppService,
+  discoverInstancePort,
+  discoverTargets,
+  dismissErrors,
+  LauncherService,
+  startInstanceWithRecovery,
+} from "@lhremote/core";
+import type { DismissFeedPostOutput } from "@lhremote/core";
+
+// CLI handlers
+import { handleDismissFeedPost } from "@lhremote/cli/handlers";
+
+// MCP tool registrations
+import { registerDismissFeedPost } from "@lhremote/mcp/tools";
+import { createMockServer } from "@lhremote/mcp/testing";
+
+describeE2E("feed dismissal operations", () => {
+  let app: AppService;
+  let port: number;
+  let accountId: number;
+  let cdpPort: number;
+  let postUrl: string;
+
+  beforeAll(async () => {
+    postUrl = getE2EPostUrl();
+
+    const launched = await launchApp();
+    app = launched.app;
+    port = launched.port;
+
+    accountId = await resolveAccountId(port);
+
+    const launcher = new LauncherService(port);
+    try {
+      await retryAsync(() => launcher.connect(), { retries: 3, delay: 1_000 });
+      await startInstanceWithRecovery(launcher, accountId, port);
+    } finally {
+      launcher.disconnect();
+    }
+
+    // Discover the instance's dynamic CDP port
+    const instancePort = await retryAsync(
+      async () => {
+        const p = await discoverInstancePort(port);
+        if (p === null) throw new Error("Instance CDP port not discovered yet");
+        return p;
+      },
+      { retries: 10, delay: 2_000 },
+    );
+    cdpPort = instancePort;
+
+    // Wait for the LinkedIn WebView to become available
+    await retryAsync(
+      async () => {
+        const targets = await discoverTargets(cdpPort);
+        const hasLinkedIn = targets.some(
+          (t) => t.type === "page" && t.url?.includes("linkedin.com"),
+        );
+        if (!hasLinkedIn) {
+          throw new Error("LinkedIn target not available yet");
+        }
+      },
+      { retries: 30, delay: 2_000 },
+    );
+  }, 120_000);
+
+  // Dismiss any leftover error popups before each test to prevent cascade failures
+  beforeEach(async () => {
+    await dismissErrors({ cdpPort, accountId }).catch(() => {});
+  }, 30_000);
+
+  installErrorDetection(() => port);
+
+  afterAll(async () => {
+    const launcher = new LauncherService(port);
+    try {
+      await launcher.connect();
+      await forceStopInstance(launcher, accountId, port);
+    } catch {
+      // Best-effort cleanup
+    } finally {
+      launcher.disconnect();
+    }
+    await quitApp(app);
+  }, 60_000);
+
+  // ── dismiss-feed-post ───────────────────────────────────────────────
+
+  describe("dismiss-feed-post", () => {
+    describe("CLI handlers", () => {
+      const originalExitCode = process.exitCode;
+
+      beforeEach(() => {
+        process.exitCode = undefined;
+      });
+
+      afterEach(() => {
+        process.exitCode = originalExitCode;
+        vi.restoreAllMocks();
+      });
+
+      it("dismiss-feed-post --json dismisses post from feed", async () => {
+        const stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+        const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+
+        await handleDismissFeedPost(postUrl, { cdpPort, json: true });
+
+        const stderr = stderrSpy.mock.calls.map((c) => String(c[0])).join("");
+        expect(process.exitCode, `CLI handler error: ${stderr}`).toBeUndefined();
+        expect(stdoutSpy).toHaveBeenCalled();
+
+        const output = stdoutSpy.mock.calls.map((call) => String(call[0])).join("");
+        const parsed = JSON.parse(output) as DismissFeedPostOutput;
+
+        expect(parsed.success).toBe(true);
+        expect(parsed.postUrl).toBe(postUrl);
+      }, 120_000);
+    });
+
+    describe("MCP tools", () => {
+      it("dismiss-feed-post tool returns valid JSON", async () => {
+        const { server, getHandler } = createMockServer();
+        registerDismissFeedPost(server);
+
+        const handler = getHandler("dismiss-feed-post");
+        const result = (await handler({
+          postUrl,
+          cdpPort,
+        })) as {
+          isError?: boolean;
+          content: { type: string; text: string }[];
+        };
+
+        expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
+        expect(result.content).toHaveLength(1);
+
+        const parsed = JSON.parse(
+          (result.content[0] as { text: string }).text,
+        ) as DismissFeedPostOutput;
+
+        expect(parsed.success).toBe(true);
+        expect(parsed.postUrl).toBe(postUrl);
+      }, 120_000);
+    });
+  });
+});

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -142,6 +142,7 @@ describe("createServer", () => {
     expect(names).toContain("send-invite");
     expect(names).toContain("get-profile-activity");
     expect(names).toContain("campaign-erase");
-    expect(names).toHaveLength(68);
+    expect(names).toContain("dismiss-feed-post");
+    expect(names).toHaveLength(69);
   });
 });

--- a/packages/mcp/src/tools/dismiss-feed-post.ts
+++ b/packages/mcp/src/tools/dismiss-feed-post.ts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { dismissFeedPost } from "@lhremote/core";
+import { z } from "zod";
+import { cdpConnectionSchema, mcpCatchAll, mcpSuccess } from "../helpers.js";
+
+/** Register the {@link https://github.com/alexey-pelykh/lhremote#dismiss-feed-post | dismiss-feed-post} MCP tool. */
+export function registerDismissFeedPost(server: McpServer): void {
+  server.tool(
+    "dismiss-feed-post",
+    'Dismiss a post from the LinkedIn feed by clicking "Not interested" in its three-dot menu. The post must be visible in the home feed.',
+    {
+      postUrl: z
+        .string()
+        .describe(
+          "LinkedIn post URL (e.g. https://www.linkedin.com/feed/update/urn:li:activity:1234567890/)",
+        ),
+      ...cdpConnectionSchema,
+    },
+    async ({ postUrl, cdpPort, cdpHost, allowRemote }) => {
+      try {
+        const result = await dismissFeedPost({
+          postUrl,
+          cdpPort,
+          cdpHost,
+          allowRemote,
+        });
+        return mcpSuccess(JSON.stringify(result, null, 2));
+      } catch (error) {
+        return mcpCatchAll(error, "Failed to dismiss feed post");
+      }
+    },
+  );
+}

--- a/packages/mcp/src/tools/index.ts
+++ b/packages/mcp/src/tools/index.ts
@@ -44,6 +44,7 @@ import { registerCheckReplies } from "./check-replies.js";
 import { registerCheckStatus } from "./check-status.js";
 import { registerDismissErrors } from "./dismiss-errors.js";
 import { registerDescribeActions } from "./describe-actions.js";
+import { registerDismissFeedPost } from "./dismiss-feed-post.js";
 import { registerFindApp } from "./find-app.js";
 import { registerGetActionBudget } from "./get-action-budget.js";
 import { registerGetPost } from "./get-post.js";
@@ -109,6 +110,7 @@ export {
   registerCampaignUpdate,
   registerCreateCollection,
   registerDeleteCollection,
+  registerDismissFeedPost,
   registerDismissErrors,
   registerCheckReplies,
   registerCheckStatus,
@@ -191,6 +193,7 @@ export function registerAllTools(server: McpServer): void {
   registerSearchPosts(server);
   registerCreateCollection(server);
   registerDeleteCollection(server);
+  registerDismissFeedPost(server);
   registerDismissErrors(server);
   registerCheckReplies(server);
   registerCheckStatus(server);


### PR DESCRIPTION
## Summary

- Add `dismiss-feed-post` core operation that navigates to the LinkedIn home feed, locates a target post by URL (via the three-dot menu → "Copy link to post" clipboard trick), and clicks "Not interested" to dismiss it
- Register as MCP tool (`dismiss-feed-post`) and CLI command (`dismiss-feed-post <postUrl>`)
- Add E2E test scaffold in `packages/e2e/src/feed-dismissal.e2e.test.ts`

Closes #716

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (unit + integration)
- [ ] `pnpm test:e2e` — E2E test exercises CLI handler and MCP tool against live LinkedHelper (local only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)