### PR TITLE
feat: add unfollow-from-feed operation

### DIFF
--- a/packages/cli/src/handlers/index.ts
+++ b/packages/cli/src/handlers/index.ts
@@ -68,4 +68,5 @@ export { handleStopInstance } from "./stop-instance.js";
 export { handleVisitProfile } from "./visit-profile.js";
 export { handleBuildUrl } from "./build-url.js";
 export { handleResolveEntity } from "./resolve-entity.js";
+export { handleUnfollowFromFeed } from "./unfollow-from-feed.js";
 export { handleListReferenceData } from "./list-reference-data.js";

--- a/packages/cli/src/handlers/unfollow-from-feed.ts
+++ b/packages/cli/src/handlers/unfollow-from-feed.ts
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import {
+  errorMessage,
+  unfollowFromFeed,
+  type UnfollowFromFeedOutput,
+} from "@lhremote/core";
+
+/** Handle the {@link https://github.com/alexey-pelykh/lhremote#unfollow-from-feed | unfollow-from-feed} CLI command. */
+export async function handleUnfollowFromFeed(
+  postUrl: string,
+  options: {
+    cdpPort?: number;
+    cdpHost?: string;
+    allowRemote?: boolean;
+    json?: boolean;
+  },
+): Promise<void> {
+  let result: UnfollowFromFeedOutput;
+  try {
+    result = await unfollowFromFeed({
+      postUrl,
+      cdpPort: options.cdpPort,
+      cdpHost: options.cdpHost,
+      allowRemote: options.allowRemote,
+    });
+  } catch (error) {
+    const message = errorMessage(error);
+    process.stderr.write(`${message}\n`);
+    process.exitCode = 1;
+    return;
+  }
+
+  if (options.json) {
+    process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+  } else {
+    process.stdout.write(
+      `Unfollowed "${result.unfollowedName}" from feed\n` +
+        `  Post: ${result.postUrl}\n`,
+    );
+  }
+}

--- a/packages/cli/src/program.test.ts
+++ b/packages/cli/src/program.test.ts
@@ -103,7 +103,8 @@ describe("createProgram", () => {
     expect(commandNames).toContain("enrich-profile");
     expect(commandNames).toContain("campaign-erase");
     expect(commandNames).toContain("dismiss-feed-post");
-    expect(commandNames).toHaveLength(68);
+    expect(commandNames).toContain("unfollow-from-feed");
+    expect(commandNames).toHaveLength(69);
   });
 
   describe("launch-app", () => {

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -74,6 +74,7 @@ import {
   handleReactToPost,
   handleStartInstance,
   handleStopInstance,
+  handleUnfollowFromFeed,
 } from "./handlers/index.js";
 
 const require = createRequire(import.meta.url);
@@ -762,6 +763,16 @@ export function createProgram(): Command {
     .option("--allow-remote", "SECURITY: allow non-loopback CDP connections (enables remote code execution on target)")
     .option("--json", "Output as JSON")
     .action(handleReactToPost);
+
+  program
+    .command("unfollow-from-feed")
+    .description("Unfollow the author of a post via its feed three-dot menu")
+    .argument("<postUrl>", "LinkedIn post URL")
+    .option("--cdp-port <port>", "CDP debugging port (auto-discovered when omitted)", parsePositiveInt)
+    .option("--cdp-host <host>", "CDP host (default: 127.0.0.1)")
+    .option("--allow-remote", "SECURITY: allow non-loopback CDP connections (enables remote code execution on target)")
+    .option("--json", "Output as JSON")
+    .action(handleUnfollowFromFeed);
 
   program
     .command("get-profile-activity")

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -391,6 +391,9 @@ export {
   type ReactToPostInput,
   type ReactToPostOutput,
   type ReactionType,
+  unfollowFromFeed,
+  type UnfollowFromFeedInput,
+  type UnfollowFromFeedOutput,
   // Individual actions (ephemeral campaign)
   type EphemeralActionInput,
   messagePerson,

--- a/packages/core/src/operations/index.ts
+++ b/packages/core/src/operations/index.ts
@@ -279,6 +279,11 @@ export {
   type ReactToPostOutput,
   type ReactionType,
 } from "./react-to-post.js";
+export {
+  unfollowFromFeed,
+  type UnfollowFromFeedInput,
+  type UnfollowFromFeedOutput,
+} from "./unfollow-from-feed.js";
 
 // Individual actions (ephemeral campaign)
 export {

--- a/packages/core/src/operations/unfollow-from-feed.test.ts
+++ b/packages/core/src/operations/unfollow-from-feed.test.ts
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../cdp/client.js", () => ({
+  CDPClient: vi.fn(),
+}));
+
+vi.mock("../cdp/discovery.js", () => ({
+  discoverTargets: vi.fn(),
+}));
+
+vi.mock("../linkedin/dom-automation.js", () => ({
+  waitForElement: vi.fn(),
+  humanizedClick: vi.fn(),
+  humanizedScrollTo: vi.fn(),
+  retryInteraction: vi.fn().mockImplementation((fn: () => Promise<unknown>) => fn()),
+}));
+
+vi.mock("../utils/delay.js", () => ({
+  delay: vi.fn().mockResolvedValue(undefined),
+  gaussianDelay: vi.fn().mockResolvedValue(undefined),
+  maybeHesitate: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { CDPClient } from "../cdp/client.js";
+import { discoverTargets } from "../cdp/discovery.js";
+import { waitForElement, humanizedClick, humanizedScrollTo, retryInteraction } from "../linkedin/dom-automation.js";
+import { unfollowFromFeed } from "./unfollow-from-feed.js";
+
+const mockClient = {
+  connect: vi.fn().mockResolvedValue(undefined),
+  navigate: vi.fn().mockResolvedValue(undefined),
+  evaluate: vi.fn().mockResolvedValue(null),
+  disconnect: vi.fn(),
+};
+
+function setupMocks(unfollowName: string | null = "John Doe") {
+  vi.mocked(CDPClient).mockImplementation(function () {
+    return mockClient as unknown as CDPClient;
+  });
+  vi.mocked(discoverTargets).mockResolvedValue([
+    { id: "target-1", type: "page", title: "LinkedIn", url: "https://www.linkedin.com/feed/", description: "", devtoolsFrontendUrl: "" },
+  ]);
+  vi.mocked(waitForElement).mockResolvedValue(undefined);
+  vi.mocked(humanizedClick).mockResolvedValue(undefined);
+  vi.mocked(humanizedScrollTo).mockResolvedValue(undefined);
+
+  // The evaluate call inside retryInteraction finds the menu item
+  mockClient.evaluate.mockResolvedValue(unfollowName);
+}
+
+describe("unfollowFromFeed", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("throws on non-loopback host without allowRemote", async () => {
+    await expect(
+      unfollowFromFeed({
+        postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+        cdpPort: 9222,
+        cdpHost: "192.168.1.100",
+      }),
+    ).rejects.toThrow("requires --allow-remote");
+  });
+
+  it("allows non-loopback host with allowRemote", async () => {
+    setupMocks();
+
+    const result = await unfollowFromFeed({
+      postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+      cdpPort: 9222,
+      cdpHost: "192.168.1.100",
+      allowRemote: true,
+    });
+
+    expect(result.success).toBe(true);
+  });
+
+  it("throws when no LinkedIn page is found", async () => {
+    vi.mocked(discoverTargets).mockResolvedValue([
+      { id: "target-1", type: "page", title: "Example", url: "https://example.com", description: "", devtoolsFrontendUrl: "" },
+    ]);
+
+    await expect(
+      unfollowFromFeed({
+        postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+        cdpPort: 9222,
+      }),
+    ).rejects.toThrow("No LinkedIn page found");
+  });
+
+  it("navigates to the post URL", async () => {
+    setupMocks();
+
+    await unfollowFromFeed({
+      postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+      cdpPort: 9222,
+    });
+
+    expect(mockClient.navigate).toHaveBeenCalledWith(
+      "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+    );
+  });
+
+  it("returns success with unfollowed name", async () => {
+    setupMocks("Jane Smith");
+
+    const result = await unfollowFromFeed({
+      postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+      cdpPort: 9222,
+    });
+
+    expect(result).toEqual({
+      success: true,
+      postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+      unfollowedName: "Jane Smith",
+    });
+  });
+
+  it("throws when no Unfollow menu item is found", async () => {
+    setupMocks(null);
+
+    await expect(
+      unfollowFromFeed({
+        postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+        cdpPort: 9222,
+      }),
+    ).rejects.toThrow('No "Unfollow" item found');
+  });
+
+  it("wraps menu interaction in retryInteraction", async () => {
+    setupMocks();
+
+    await unfollowFromFeed({
+      postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+      cdpPort: 9222,
+    });
+
+    expect(retryInteraction).toHaveBeenCalledWith(expect.any(Function), 3);
+  });
+
+  it("scrolls to and clicks the menu button", async () => {
+    setupMocks();
+
+    await unfollowFromFeed({
+      postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+      cdpPort: 9222,
+    });
+
+    const selector = 'button[aria-label^="Open control menu for post"]';
+    expect(humanizedScrollTo).toHaveBeenCalledWith(mockClient, selector, undefined);
+    expect(humanizedClick).toHaveBeenCalledWith(mockClient, selector, undefined);
+  });
+
+  it("disconnects the client even on error", async () => {
+    setupMocks(null);
+
+    await unfollowFromFeed({
+      postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+      cdpPort: 9222,
+    }).catch(() => {});
+
+    expect(mockClient.disconnect).toHaveBeenCalled();
+  });
+
+  it("waits for the menu button before interacting", async () => {
+    setupMocks();
+
+    await unfollowFromFeed({
+      postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+      cdpPort: 9222,
+    });
+
+    expect(waitForElement).toHaveBeenCalledWith(
+      mockClient,
+      'button[aria-label^="Open control menu for post"]',
+      undefined,
+      undefined,
+    );
+  });
+});

--- a/packages/core/src/operations/unfollow-from-feed.ts
+++ b/packages/core/src/operations/unfollow-from-feed.ts
@@ -6,13 +6,12 @@ import { CDPClient } from "../cdp/client.js";
 import { discoverTargets } from "../cdp/discovery.js";
 import { humanizedClick, humanizedScrollTo, retryInteraction, waitForElement } from "../linkedin/dom-automation.js";
 import type { HumanizedMouse } from "../linkedin/humanized-mouse.js";
-import { gaussianDelay } from "../utils/delay.js";
-import { maybeHesitate } from "../utils/delay.js";
+import { gaussianDelay, maybeHesitate } from "../utils/delay.js";
 import type { ConnectionOptions } from "./types.js";
 
 /** CSS selector for the post's three-dot control menu button. */
 const POST_MENU_BUTTON_SELECTOR =
-  'button[aria-label^="Open control menu"]';
+  'button[aria-label^="Open control menu for post"]';
 
 export interface UnfollowFromFeedInput extends ConnectionOptions {
   /** LinkedIn post URL identifying a visible feed post. */

--- a/packages/core/src/operations/unfollow-from-feed.ts
+++ b/packages/core/src/operations/unfollow-from-feed.ts
@@ -91,7 +91,7 @@ export async function unfollowFromFeed(
       // the name from the text.
       const name = await client.evaluate<string | null>(`(() => {
         for (const el of document.querySelectorAll('[role="menuitem"]')) {
-          const text = el.textContent.trim();
+          const text = el.textContent?.trim() ?? '';
           if (text.startsWith('Unfollow ')) {
             el.click();
             return text.slice('Unfollow '.length);

--- a/packages/core/src/operations/unfollow-from-feed.ts
+++ b/packages/core/src/operations/unfollow-from-feed.ts
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { resolveInstancePort } from "../cdp/index.js";
+import { CDPClient } from "../cdp/client.js";
+import { discoverTargets } from "../cdp/discovery.js";
+import { humanizedClick, humanizedScrollTo, retryInteraction, waitForElement } from "../linkedin/dom-automation.js";
+import type { HumanizedMouse } from "../linkedin/humanized-mouse.js";
+import { gaussianDelay } from "../utils/delay.js";
+import { maybeHesitate } from "../utils/delay.js";
+import type { ConnectionOptions } from "./types.js";
+
+/** CSS selector for the post's three-dot control menu button. */
+const POST_MENU_BUTTON_SELECTOR =
+  'button[aria-label^="Open control menu"]';
+
+export interface UnfollowFromFeedInput extends ConnectionOptions {
+  /** LinkedIn post URL identifying a visible feed post. */
+  readonly postUrl: string;
+  /** Optional humanized mouse for natural cursor movement and clicks. */
+  readonly mouse?: HumanizedMouse | null | undefined;
+}
+
+export interface UnfollowFromFeedOutput {
+  readonly success: true;
+  readonly postUrl: string;
+  /** The name extracted from the "Unfollow {Name}" menu item. */
+  readonly unfollowedName: string;
+}
+
+/**
+ * Unfollow the author of a LinkedIn post via its feed three-dot menu.
+ *
+ * Navigates to the post URL, opens the three-dot control menu, and
+ * clicks the "Unfollow {Name}" menu item.  The unfollowed person's
+ * name is extracted from the menu item text.
+ *
+ * @param input - Post URL and CDP connection parameters.
+ * @returns Confirmation including the unfollowed person's name.
+ * @throws If the three-dot menu does not contain an "Unfollow" item.
+ */
+export async function unfollowFromFeed(
+  input: UnfollowFromFeedInput,
+): Promise<UnfollowFromFeedOutput> {
+  const cdpPort = await resolveInstancePort(input.cdpPort, input.cdpHost);
+  const cdpHost = input.cdpHost ?? "127.0.0.1";
+  const allowRemote = input.allowRemote ?? false;
+
+  // Enforce loopback guard
+  if (!allowRemote && cdpHost !== "127.0.0.1" && cdpHost !== "localhost") {
+    throw new Error(
+      `Non-loopback CDP host "${cdpHost}" requires --allow-remote. ` +
+        "This is a security measure to prevent remote code execution.",
+    );
+  }
+
+  const targets = await discoverTargets(cdpPort, cdpHost);
+  const linkedInTarget = targets.find(
+    (t) => t.type === "page" && t.url?.includes("linkedin.com"),
+  );
+
+  if (!linkedInTarget) {
+    throw new Error(
+      "No LinkedIn page found in LinkedHelper. " +
+        "Ensure LinkedHelper is running with an active LinkedIn session.",
+    );
+  }
+
+  const client = new CDPClient(cdpPort, { host: cdpHost, allowRemote });
+  await client.connect(linkedInTarget.id);
+
+  try {
+    // Navigate to the post URL
+    await client.navigate(input.postUrl);
+
+    const mouse = input.mouse;
+
+    // Wait for the three-dot menu button to appear
+    await waitForElement(client, POST_MENU_BUTTON_SELECTOR, undefined, mouse);
+
+    await maybeHesitate();
+
+    // Scroll the menu button into view and click it, retrying if the
+    // menu does not open on the first attempt.
+    const unfollowedName = await retryInteraction(async () => {
+      await humanizedScrollTo(client, POST_MENU_BUTTON_SELECTOR, mouse);
+      await humanizedClick(client, POST_MENU_BUTTON_SELECTOR, mouse);
+
+      await gaussianDelay(700, 100, 500, 900);
+
+      // Find and click the "Unfollow {Name}" menu item, extracting
+      // the name from the text.
+      const name = await client.evaluate<string | null>(`(() => {
+        for (const el of document.querySelectorAll('[role="menuitem"]')) {
+          const text = el.textContent.trim();
+          if (text.startsWith('Unfollow ')) {
+            el.click();
+            return text.slice('Unfollow '.length);
+          }
+        }
+        return null;
+      })()`);
+
+      if (!name) {
+        // Dismiss any open menu before retrying
+        await client.evaluate(`(() => {
+          document.dispatchEvent(
+            new KeyboardEvent('keydown', { key: 'Escape', bubbles: true })
+          );
+        })()`);
+        await gaussianDelay(300, 75, 200, 500);
+
+        throw new Error(
+          'No "Unfollow" item found in the post control menu. ' +
+            "The post author may already be unfollowed, or the post " +
+            "may not support this action.",
+        );
+      }
+
+      return name;
+    }, 3);
+
+    // Let the UI settle after clicking Unfollow
+    await gaussianDelay(550, 75, 400, 700);
+
+    await gaussianDelay(1_500, 500, 700, 3_500); // Post-action dwell
+    return {
+      success: true as const,
+      postUrl: input.postUrl,
+      unfollowedName,
+    };
+  } finally {
+    client.disconnect();
+  }
+}

--- a/packages/e2e/src/unfollow-from-feed.e2e.test.ts
+++ b/packages/e2e/src/unfollow-from-feed.e2e.test.ts
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  describeE2E,
+  forceStopInstance,
+  getE2EPostUrl,
+  installErrorDetection,
+  launchApp,
+  quitApp,
+  resolveAccountId,
+  retryAsync,
+} from "@lhremote/core/testing";
+import {
+  type AppService,
+  discoverInstancePort,
+  discoverTargets,
+  dismissErrors,
+  LauncherService,
+  startInstanceWithRecovery,
+} from "@lhremote/core";
+import type { UnfollowFromFeedOutput } from "@lhremote/core";
+
+// CLI handlers
+import { handleUnfollowFromFeed } from "@lhremote/cli/handlers";
+
+// MCP tool registrations
+import { registerUnfollowFromFeed } from "@lhremote/mcp/tools";
+import { createMockServer } from "@lhremote/mcp/testing";
+
+describeE2E("unfollow-from-feed operation", () => {
+  let app: AppService;
+  let port: number;
+  let accountId: number;
+  let cdpPort: number;
+  let postUrl: string;
+
+  beforeAll(async () => {
+    postUrl = getE2EPostUrl();
+
+    const launched = await launchApp();
+    app = launched.app;
+    port = launched.port;
+
+    accountId = await resolveAccountId(port);
+
+    const launcher = new LauncherService(port);
+    try {
+      await retryAsync(() => launcher.connect(), { retries: 3, delay: 1_000 });
+      await startInstanceWithRecovery(launcher, accountId, port);
+    } finally {
+      launcher.disconnect();
+    }
+
+    // Discover the instance's dynamic CDP port
+    const instancePort = await retryAsync(
+      async () => {
+        const p = await discoverInstancePort(port);
+        if (p === null) throw new Error("Instance CDP port not discovered yet");
+        return p;
+      },
+      { retries: 10, delay: 2_000 },
+    );
+    cdpPort = instancePort;
+
+    // Wait for the LinkedIn WebView to become available
+    await retryAsync(
+      async () => {
+        const targets = await discoverTargets(cdpPort);
+        const hasLinkedIn = targets.some(
+          (t) => t.type === "page" && t.url?.includes("linkedin.com"),
+        );
+        if (!hasLinkedIn) {
+          throw new Error("LinkedIn target not available yet");
+        }
+      },
+      { retries: 30, delay: 2_000 },
+    );
+  }, 120_000);
+
+  // Dismiss any leftover error popups before each test to prevent cascade failures
+  beforeEach(async () => {
+    await dismissErrors({ cdpPort, accountId }).catch(() => {});
+  }, 30_000);
+
+  installErrorDetection(() => port);
+
+  afterAll(async () => {
+    const launcher = new LauncherService(port);
+    try {
+      await launcher.connect();
+      await forceStopInstance(launcher, accountId, port);
+    } catch {
+      // Best-effort cleanup
+    } finally {
+      launcher.disconnect();
+    }
+    await quitApp(app);
+  }, 60_000);
+
+  // ── CLI handlers ──────────────────────────────────────────────────
+
+  describe("CLI handlers", () => {
+    const originalExitCode = process.exitCode;
+
+    beforeEach(() => {
+      process.exitCode = undefined;
+    });
+
+    afterEach(() => {
+      process.exitCode = originalExitCode;
+      vi.restoreAllMocks();
+    });
+
+    it("unfollow-from-feed --json returns valid result", async () => {
+      const stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+      const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+
+      await handleUnfollowFromFeed(postUrl, { cdpPort, json: true });
+
+      const stderr = stderrSpy.mock.calls.map((c) => String(c[0])).join("");
+      expect(process.exitCode, `CLI handler error: ${stderr}`).toBeUndefined();
+      expect(stdoutSpy).toHaveBeenCalled();
+
+      const output = stdoutSpy.mock.calls.map((call) => String(call[0])).join("");
+      const parsed = JSON.parse(output) as UnfollowFromFeedOutput;
+
+      expect(parsed.success).toBe(true);
+      expect(parsed.postUrl).toBe(postUrl);
+      expect(typeof parsed.unfollowedName).toBe("string");
+      expect(parsed.unfollowedName.length).toBeGreaterThan(0);
+    }, 120_000);
+  });
+
+  // ── MCP tools ─────────────────────────────────────────────────────
+
+  describe("MCP tools", () => {
+    it("unfollow-from-feed tool returns valid JSON", async () => {
+      const { server, getHandler } = createMockServer();
+      registerUnfollowFromFeed(server);
+
+      const handler = getHandler("unfollow-from-feed");
+      const result = (await handler({
+        postUrl,
+        cdpPort,
+      })) as {
+        isError?: boolean;
+        content: { type: string; text: string }[];
+      };
+
+      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
+      expect(result.content).toHaveLength(1);
+
+      const parsed = JSON.parse(
+        (result.content[0] as { text: string }).text,
+      ) as UnfollowFromFeedOutput;
+
+      expect(parsed.success).toBe(true);
+      expect(parsed.postUrl).toBe(postUrl);
+      expect(typeof parsed.unfollowedName).toBe("string");
+      expect(parsed.unfollowedName.length).toBeGreaterThan(0);
+    }, 120_000);
+  });
+});

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -143,6 +143,7 @@ describe("createServer", () => {
     expect(names).toContain("get-profile-activity");
     expect(names).toContain("campaign-erase");
     expect(names).toContain("dismiss-feed-post");
-    expect(names).toHaveLength(69);
+    expect(names).toContain("unfollow-from-feed");
+    expect(names).toHaveLength(70);
   });
 });

--- a/packages/mcp/src/tools/index.ts
+++ b/packages/mcp/src/tools/index.ts
@@ -71,6 +71,7 @@ import { registerQueryProfiles } from "./query-profiles.js";
 import { registerQueryProfilesBulk } from "./query-profiles-bulk.js";
 import { registerScrapeMessagingHistory } from "./scrape-messaging-history.js";
 import { registerSearchPosts } from "./search-posts.js";
+import { registerUnfollowFromFeed } from "./unfollow-from-feed.js";
 import { registerVisitProfile } from "./visit-profile.js";
 
 export {
@@ -142,6 +143,7 @@ export {
   registerSearchPosts,
   registerStartInstance,
   registerStopInstance,
+  registerUnfollowFromFeed,
   registerVisitProfile,
 };
 
@@ -215,4 +217,5 @@ export function registerAllTools(server: McpServer): void {
   registerRemoveConnection(server);
   registerSendInmail(server);
   registerSendInvite(server);
+  registerUnfollowFromFeed(server);
 }

--- a/packages/mcp/src/tools/unfollow-from-feed.ts
+++ b/packages/mcp/src/tools/unfollow-from-feed.ts
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { unfollowFromFeed } from "@lhremote/core";
+import { z } from "zod";
+import { cdpConnectionSchema, mcpCatchAll, mcpSuccess } from "../helpers.js";
+
+/** Register the {@link https://github.com/alexey-pelykh/lhremote#unfollow-from-feed | unfollow-from-feed} MCP tool. */
+export function registerUnfollowFromFeed(server: McpServer): void {
+  server.tool(
+    "unfollow-from-feed",
+    "Unfollow the author of a LinkedIn post via its feed three-dot menu. Navigates to the post and clicks the 'Unfollow {Name}' menu item.",
+    {
+      postUrl: z
+        .string()
+        .describe(
+          "LinkedIn post URL (e.g. https://www.linkedin.com/feed/update/urn:li:activity:1234567890/)",
+        ),
+      ...cdpConnectionSchema,
+    },
+    async ({ postUrl, cdpPort, cdpHost, allowRemote }) => {
+      try {
+        const result = await unfollowFromFeed({
+          postUrl,
+          cdpPort,
+          cdpHost,
+          allowRemote,
+        });
+        return mcpSuccess(JSON.stringify(result, null, 2));
+      } catch (error) {
+        return mcpCatchAll(error, "Failed to unfollow from feed");
+      }
+    },
+  );
+}


### PR DESCRIPTION
## Summary

- Add `unfollow-from-feed` operation that opens a post's three-dot menu and clicks "Unfollow {Name}" to unfollow the post author from the feed
- Register MCP tool, CLI handler (`unfollow-from-feed <postUrl>`), and E2E test
- Extract the unfollowed person's name from the menu item text and return it in the output

Closes #717

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (unit + integration)
- [ ] `pnpm test:e2e` — E2E test exercises CLI handler and MCP tool against a live LinkedHelper instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)