### PR TITLE
(fix) feed-actions: use feedIndex, add --dry-run, fix feed-only menu items

### DIFF
--- a/packages/cli/src/handlers/dismiss-feed-post.ts
+++ b/packages/cli/src/handlers/dismiss-feed-post.ts
@@ -9,21 +9,23 @@ import {
 
 /** Handle the {@link https://github.com/alexey-pelykh/lhremote#dismiss-feed-post | dismiss-feed-post} CLI command. */
 export async function handleDismissFeedPost(
-  postUrl: string,
+  feedIndex: number,
   options: {
     cdpPort?: number;
     cdpHost?: string;
     allowRemote?: boolean;
+    dryRun?: boolean;
     json?: boolean;
   },
 ): Promise<void> {
   let result: DismissFeedPostOutput;
   try {
     result = await dismissFeedPost({
-      postUrl,
+      feedIndex,
       cdpPort: options.cdpPort,
       cdpHost: options.cdpHost,
       allowRemote: options.allowRemote,
+      dryRun: options.dryRun,
     });
   } catch (error) {
     const message = errorMessage(error);
@@ -34,9 +36,13 @@ export async function handleDismissFeedPost(
 
   if (options.json) {
     process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+  } else if (result.dryRun) {
+    process.stdout.write(
+      `[dry-run] Would dismiss post from feed\n  Feed index: ${result.feedIndex}\n`,
+    );
   } else {
     process.stdout.write(
-      `Dismissed post from feed\n  Post: ${result.postUrl}\n`,
+      `Dismissed post from feed\n  Feed index: ${result.feedIndex}\n`,
     );
   }
 }

--- a/packages/cli/src/handlers/hide-feed-author.ts
+++ b/packages/cli/src/handlers/hide-feed-author.ts
@@ -9,21 +9,23 @@ import {
 
 /** Handle the {@link https://github.com/alexey-pelykh/lhremote#hide-feed-author | hide-feed-author} CLI command. */
 export async function handleHideFeedAuthor(
-  postUrl: string,
+  feedIndex: number,
   options: {
     cdpPort?: number;
     cdpHost?: string;
     allowRemote?: boolean;
+    dryRun?: boolean;
     json?: boolean;
   },
 ): Promise<void> {
   let result: HideFeedAuthorOutput;
   try {
     result = await hideFeedAuthor({
-      postUrl,
+      feedIndex,
       cdpPort: options.cdpPort,
       cdpHost: options.cdpHost,
       allowRemote: options.allowRemote,
+      dryRun: options.dryRun,
     });
   } catch (error) {
     const message = errorMessage(error);
@@ -34,10 +36,15 @@ export async function handleHideFeedAuthor(
 
   if (options.json) {
     process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+  } else if (result.dryRun) {
+    process.stdout.write(
+      `[dry-run] Would hide posts by "${result.hiddenName}"\n` +
+        `  Feed index: ${result.feedIndex}\n`,
+    );
   } else {
     process.stdout.write(
       `Hidden posts by "${result.hiddenName}"\n` +
-        `  Post: ${result.postUrl}\n`,
+        `  Feed index: ${result.feedIndex}\n`,
     );
   }
 }

--- a/packages/cli/src/handlers/unfollow-from-feed.ts
+++ b/packages/cli/src/handlers/unfollow-from-feed.ts
@@ -9,21 +9,23 @@ import {
 
 /** Handle the {@link https://github.com/alexey-pelykh/lhremote#unfollow-from-feed | unfollow-from-feed} CLI command. */
 export async function handleUnfollowFromFeed(
-  postUrl: string,
+  feedIndex: number,
   options: {
     cdpPort?: number;
     cdpHost?: string;
     allowRemote?: boolean;
+    dryRun?: boolean;
     json?: boolean;
   },
 ): Promise<void> {
   let result: UnfollowFromFeedOutput;
   try {
     result = await unfollowFromFeed({
-      postUrl,
+      feedIndex,
       cdpPort: options.cdpPort,
       cdpHost: options.cdpHost,
       allowRemote: options.allowRemote,
+      dryRun: options.dryRun,
     });
   } catch (error) {
     const message = errorMessage(error);
@@ -34,10 +36,15 @@ export async function handleUnfollowFromFeed(
 
   if (options.json) {
     process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+  } else if (result.dryRun) {
+    process.stdout.write(
+      `[dry-run] Would unfollow "${result.unfollowedName}" from feed\n` +
+        `  Feed index: ${result.feedIndex}\n`,
+    );
   } else {
     process.stdout.write(
       `Unfollowed "${result.unfollowedName}" from feed\n` +
-        `  Post: ${result.postUrl}\n`,
+        `  Feed index: ${result.feedIndex}\n`,
     );
   }
 }

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -743,10 +743,11 @@ export function createProgram(): Command {
   program
     .command("dismiss-feed-post")
     .description('Dismiss a post from the LinkedIn feed by clicking "Not interested"')
-    .argument("<postUrl>", "LinkedIn post URL")
+    .argument("<feedIndex>", "Zero-based index of the post in the visible feed", parseNonNegativeInt)
     .option("--cdp-port <port>", "CDP debugging port (auto-discovered when omitted)", parsePositiveInt)
     .option("--cdp-host <host>", "CDP host (default: 127.0.0.1)")
     .option("--allow-remote", "SECURITY: allow non-loopback CDP connections (enables remote code execution on target)")
+    .option("--dry-run", "Locate the menu item without clicking it")
     .option("--json", "Output as JSON")
     .action(handleDismissFeedPost);
 
@@ -768,20 +769,22 @@ export function createProgram(): Command {
   program
     .command("unfollow-from-feed")
     .description("Unfollow the author of a post via its feed three-dot menu")
-    .argument("<postUrl>", "LinkedIn post URL")
+    .argument("<feedIndex>", "Zero-based index of the post in the visible feed", parseNonNegativeInt)
     .option("--cdp-port <port>", "CDP debugging port (auto-discovered when omitted)", parsePositiveInt)
     .option("--cdp-host <host>", "CDP host (default: 127.0.0.1)")
     .option("--allow-remote", "SECURITY: allow non-loopback CDP connections (enables remote code execution on target)")
+    .option("--dry-run", "Locate the menu item without clicking it")
     .option("--json", "Output as JSON")
     .action(handleUnfollowFromFeed);
 
   program
     .command("hide-feed-author")
     .description("Click 'Hide posts by {Name}' in a feed post's three-dot menu")
-    .argument("<postUrl>", "LinkedIn post URL")
+    .argument("<feedIndex>", "Zero-based index of the post in the visible feed", parseNonNegativeInt)
     .option("--cdp-port <port>", "CDP debugging port (auto-discovered when omitted)", parsePositiveInt)
     .option("--cdp-host <host>", "CDP host (default: 127.0.0.1)")
     .option("--allow-remote", "SECURITY: allow non-loopback CDP connections (enables remote code execution on target)")
+    .option("--dry-run", "Locate the menu item without clicking it")
     .option("--json", "Output as JSON")
     .action(handleHideFeedAuthor);
 

--- a/packages/core/src/operations/dismiss-feed-post.test.ts
+++ b/packages/core/src/operations/dismiss-feed-post.test.ts
@@ -35,8 +35,6 @@ import { CDPClient } from "../cdp/client.js";
 import { discoverTargets } from "../cdp/discovery.js";
 import { dismissFeedPost } from "./dismiss-feed-post.js";
 
-const TARGET_URL = "https://www.linkedin.com/feed/update/urn:li:activity:123/";
-
 const mockClient = {
   connect: vi.fn().mockResolvedValue(undefined),
   navigate: vi.fn().mockResolvedValue(undefined),
@@ -54,29 +52,14 @@ function setupMocks() {
 }
 
 /**
- * Configure mockClient.evaluate to simulate a feed with one post whose URL
- * matches `targetUrl`, and whose menu contains "Not interested".
+ * Configure mockClient.evaluate to simulate a feed with one post whose
+ * menu contains "Not interested".
  */
-function setupFeedWithPost(targetUrl: string) {
+function setupFeedWithNotInterested() {
   mockClient.evaluate.mockImplementation((script: string) => {
-    // Clipboard interceptor install
-    if (typeof script === "string" && script.includes("__capturedClipboard")) {
-      if (script.includes("writeText")) return Promise.resolve(undefined);
-      if (script.includes("= null")) return Promise.resolve(undefined);
-      // Read captured clipboard
-      return Promise.resolve(targetUrl);
-    }
-    // Post count query
-    if (typeof script === "string" && script.includes(".length")) {
-      return Promise.resolve(1);
-    }
     // Menu button click
     if (typeof script === "string" && script.includes("btn.click()")) {
       return Promise.resolve(true);
-    }
-    // "Copy link to post" click
-    if (typeof script === "string" && script.includes("Copy link to post")) {
-      return Promise.resolve(undefined);
     }
     // "Not interested" click
     if (typeof script === "string" && script.includes("Not interested")) {
@@ -102,7 +85,7 @@ describe("dismissFeedPost", () => {
   it("throws on non-loopback host without allowRemote", async () => {
     await expect(
       dismissFeedPost({
-        postUrl: TARGET_URL,
+        feedIndex: 0,
         cdpPort: 9222,
         cdpHost: "192.168.1.100",
       }),
@@ -111,10 +94,10 @@ describe("dismissFeedPost", () => {
 
   it("allows non-loopback host with allowRemote", async () => {
     setupMocks();
-    setupFeedWithPost(TARGET_URL);
+    setupFeedWithNotInterested();
 
     const result = await dismissFeedPost({
-      postUrl: TARGET_URL,
+      feedIndex: 0,
       cdpPort: 9222,
       cdpHost: "192.168.1.100",
       allowRemote: true,
@@ -130,7 +113,7 @@ describe("dismissFeedPost", () => {
 
     await expect(
       dismissFeedPost({
-        postUrl: TARGET_URL,
+        feedIndex: 0,
         cdpPort: 9222,
       }),
     ).rejects.toThrow("No LinkedIn page found");
@@ -138,28 +121,24 @@ describe("dismissFeedPost", () => {
 
   it("returns success when post is found and dismissed", async () => {
     setupMocks();
-    setupFeedWithPost(TARGET_URL);
+    setupFeedWithNotInterested();
 
     const result = await dismissFeedPost({
-      postUrl: TARGET_URL,
+      feedIndex: 0,
       cdpPort: 9222,
     });
 
     expect(result).toEqual({
       success: true,
-      postUrl: TARGET_URL,
+      feedIndex: 0,
+      dryRun: false,
     });
   });
 
   it("throws when Not interested is not in the menu", async () => {
     setupMocks();
     mockClient.evaluate.mockImplementation((script: string) => {
-      if (typeof script === "string" && script.includes("writeText")) return Promise.resolve(undefined);
-      if (typeof script === "string" && script.includes("= null")) return Promise.resolve(undefined);
-      if (typeof script === "string" && script.includes("__capturedClipboard") && !script.includes("=")) return Promise.resolve(TARGET_URL);
-      if (typeof script === "string" && script.includes(".length")) return Promise.resolve(1);
       if (typeof script === "string" && script.includes("btn.click()")) return Promise.resolve(true);
-      if (typeof script === "string" && script.includes("Copy link to post")) return Promise.resolve(undefined);
       if (typeof script === "string" && script.includes("Not interested")) return Promise.resolve(false);
       if (typeof script === "string" && script.includes("Escape")) return Promise.resolve(undefined);
       return Promise.resolve(null);
@@ -167,27 +146,10 @@ describe("dismissFeedPost", () => {
 
     await expect(
       dismissFeedPost({
-        postUrl: TARGET_URL,
+        feedIndex: 0,
         cdpPort: 9222,
       }),
     ).rejects.toThrow('does not contain "Not interested"');
-  });
-
-  it("throws when post is not found in the feed", async () => {
-    setupMocks();
-    // Simulate an empty feed (0 posts)
-    mockClient.evaluate.mockImplementation((script: string) => {
-      if (typeof script === "string" && script.includes("writeText")) return Promise.resolve(undefined);
-      if (typeof script === "string" && script.includes(".length")) return Promise.resolve(0);
-      return Promise.resolve(null);
-    });
-
-    await expect(
-      dismissFeedPost({
-        postUrl: TARGET_URL,
-        cdpPort: 9222,
-      }),
-    ).rejects.toThrow("Post not found in the feed");
   });
 
   it("disconnects the CDP client even when an error occurs", async () => {
@@ -196,7 +158,7 @@ describe("dismissFeedPost", () => {
 
     await expect(
       dismissFeedPost({
-        postUrl: TARGET_URL,
+        feedIndex: 0,
         cdpPort: 9222,
       }),
     ).rejects.toThrow("evaluation failed");

--- a/packages/core/src/operations/dismiss-feed-post.ts
+++ b/packages/core/src/operations/dismiss-feed-post.ts
@@ -4,91 +4,30 @@
 import { resolveInstancePort } from "../cdp/index.js";
 import { CDPClient } from "../cdp/client.js";
 import { discoverTargets } from "../cdp/discovery.js";
-import { humanizedScrollToByIndex, retryInteraction } from "../linkedin/dom-automation.js";
+import { humanizedScrollToByIndex } from "../linkedin/dom-automation.js";
 import type { HumanizedMouse } from "../linkedin/humanized-mouse.js";
 import { gaussianDelay, maybeHesitate } from "../utils/delay.js";
 import type { ConnectionOptions } from "./types.js";
 import { navigateAwayIf } from "./navigate-away.js";
-import { scrollFeed, waitForFeedLoad } from "./get-feed.js";
+import { waitForFeedLoad } from "./get-feed.js";
 
 /** CSS selector for feed post menu buttons. */
 const FEED_MENU_BUTTON_SELECTOR =
   '[data-testid="mainFeed"] div[role="listitem"] button[aria-label^="Open control menu for post"]';
 
 export interface DismissFeedPostInput extends ConnectionOptions {
-  /** LinkedIn post URL identifying a visible feed post. */
-  readonly postUrl: string;
+  /** Zero-based index of the post in the visible LinkedIn feed. */
+  readonly feedIndex: number;
   /** Optional humanized mouse for natural cursor movement and clicks. */
   readonly mouse?: HumanizedMouse | null | undefined;
+  /** When true, locate the menu item but do not click it. */
+  readonly dryRun?: boolean | undefined;
 }
 
 export interface DismissFeedPostOutput {
   readonly success: true;
-  readonly postUrl: string;
-}
-
-/**
- * Open the three-dot menu for a feed post at the given index, click
- * "Copy link to post", and return the captured URL (query params stripped).
- *
- * Returns `null` when the menu button doesn't exist or when clipboard
- * capture fails after up to 3 attempts.
- */
-async function capturePostUrl(
-  client: CDPClient,
-  postIndex: number,
-  mouse?: HumanizedMouse | null,
-): Promise<string | null> {
-  const MAX_ATTEMPTS = 3;
-
-  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
-    await maybeHesitate();
-
-    await client.evaluate(`window.__capturedClipboard = null;`);
-
-    await humanizedScrollToByIndex(client, FEED_MENU_BUTTON_SELECTOR, postIndex, mouse);
-
-    const clicked = await client.evaluate<boolean>(`(() => {
-      const btns = document.querySelectorAll(
-        ${JSON.stringify(FEED_MENU_BUTTON_SELECTOR)}
-      );
-      const btn = btns[${postIndex}];
-      if (!btn) return false;
-      btn.click();
-      return true;
-    })()`);
-
-    if (!clicked) return null;
-
-    await gaussianDelay(700, 100, 500, 900);
-
-    await client.evaluate(`(() => {
-      for (const el of document.querySelectorAll('[role="menuitem"]')) {
-        if (el.textContent.trim() === 'Copy link to post') {
-          el.click();
-          return;
-        }
-      }
-    })()`);
-
-    await gaussianDelay(550, 75, 400, 700);
-
-    const postUrl =
-      await client.evaluate<string | null>(`window.__capturedClipboard`);
-
-    if (postUrl) {
-      return postUrl.split("?")[0] ?? postUrl;
-    }
-
-    // Dismiss any open menu before retrying
-    await client.evaluate(`(() => {
-      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
-    })()`);
-
-    await gaussianDelay(700 * (attempt + 1), 200, 350 * (attempt + 1), 1_050 * (attempt + 1));
-  }
-
-  return null;
+  readonly feedIndex: number;
+  readonly dryRun: boolean;
 }
 
 /**
@@ -103,6 +42,7 @@ async function clickNotInterested(
   client: CDPClient,
   postIndex: number,
   mouse?: HumanizedMouse | null,
+  dryRun?: boolean,
 ): Promise<boolean> {
   await maybeHesitate();
 
@@ -127,9 +67,10 @@ async function clickNotInterested(
   await gaussianDelay(700, 100, 500, 900);
 
   const dismissed = await client.evaluate<boolean>(`(() => {
+    const dryRun = ${!!dryRun};
     for (const el of document.querySelectorAll('[role="menuitem"]')) {
       if (el.textContent.trim() === 'Not interested') {
-        el.click();
+        if (!dryRun) el.click();
         return true;
       }
     }
@@ -144,20 +85,26 @@ async function clickNotInterested(
     await gaussianDelay(300, 75, 200, 500);
   }
 
+  if (dismissed && dryRun) {
+    await client.evaluate(`(() => {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+    })()`);
+    await gaussianDelay(300, 75, 200, 500);
+  }
+
   return dismissed;
 }
 
 /**
  * Dismiss a post from the LinkedIn feed by clicking "Not interested".
  *
- * Navigates to the LinkedIn home feed, locates the post whose URL matches
- * the given `postUrl` (extracted via the three-dot menu → "Copy link to
- * post" clipboard trick), then reopens the menu and clicks "Not interested".
+ * Navigates to the LinkedIn home feed, opens the three-dot menu of the
+ * post at the given `feedIndex`, and clicks "Not interested".
  *
- * @param input - Post URL, CDP connection parameters, and optional mouse.
+ * @param input - Feed index, CDP connection parameters, and optional mouse.
  * @returns Confirmation that the post was dismissed.
- * @throws When the post is not found in the feed or "Not interested" is
- *   not available in its menu.
+ * @throws When the menu button is not found or "Not interested" is not
+ *   available in its menu.
  */
 export async function dismissFeedPost(
   input: DismissFeedPostInput,
@@ -191,71 +138,31 @@ export async function dismissFeedPost(
 
   try {
     const mouse = input.mouse;
-    const targetUrl = input.postUrl.split("?")[0];
+    const dryRun = input.dryRun ?? false;
+    const feedIndex = input.feedIndex;
 
     // Navigate to the feed (force fresh load if already there)
     await navigateAwayIf(client, "/feed");
     await client.navigate("https://www.linkedin.com/feed/");
     await waitForFeedLoad(client);
 
-    // Install clipboard interceptor (Electron's clipboard API is broken)
-    await client.evaluate(
-      `navigator.clipboard.writeText = function(text) {
-        window.__capturedClipboard = text;
-        return Promise.resolve();
-      };`,
-    );
+    // Click "Not interested" on the post at the given feed index
+    const dismissed = await clickNotInterested(client, feedIndex, mouse, dryRun);
 
-    const maxScrollAttempts = 5;
-    let checkedUpTo = 0;
-
-    for (let scroll = 0; scroll <= maxScrollAttempts; scroll++) {
-      const postCount = await client.evaluate<number>(
-        `document.querySelectorAll(${JSON.stringify(FEED_MENU_BUTTON_SELECTOR)}).length`,
+    if (!dismissed) {
+      throw new Error(
+        'The post\'s three-dot menu does not contain "Not interested". ' +
+          "This may happen for your own posts or sponsored content.",
       );
-
-      for (let i = checkedUpTo; i < postCount; i++) {
-        if (i > checkedUpTo) {
-          await gaussianDelay(550, 125, 300, 800);
-        }
-
-        const url = await retryInteraction(
-          () => capturePostUrl(client, i, mouse),
-        );
-
-        if (url && url === targetUrl) {
-          // Found the target post — click "Not interested"
-          const dismissed = await clickNotInterested(client, i, mouse);
-
-          if (!dismissed) {
-            throw new Error(
-              'The post\'s three-dot menu does not contain "Not interested". ' +
-                "This may happen for your own posts or sponsored content.",
-            );
-          }
-
-          await gaussianDelay(550, 75, 400, 700);
-          await gaussianDelay(1_500, 500, 700, 3_500); // Post-action dwell
-          return {
-            success: true as const,
-            postUrl: input.postUrl,
-          };
-        }
-      }
-
-      checkedUpTo = postCount;
-
-      // Scroll to load more posts
-      if (scroll < maxScrollAttempts) {
-        await scrollFeed(client, mouse);
-        await gaussianDelay(1_500, 300, 1_000, 2_500);
-      }
     }
 
-    throw new Error(
-      `Post not found in the feed: ${input.postUrl}. ` +
-        "Ensure the post is visible in the LinkedIn feed.",
-    );
+    await gaussianDelay(550, 75, 400, 700);
+    await gaussianDelay(1_500, 500, 700, 3_500); // Post-action dwell
+    return {
+      success: true as const,
+      feedIndex: input.feedIndex,
+      dryRun,
+    };
   } finally {
     client.disconnect();
   }

--- a/packages/core/src/operations/hide-feed-author.test.ts
+++ b/packages/core/src/operations/hide-feed-author.test.ts
@@ -12,7 +12,6 @@ vi.mock("../cdp/discovery.js", () => ({
 }));
 
 vi.mock("../linkedin/dom-automation.js", () => ({
-  waitForElement: vi.fn(),
   humanizedScrollToByIndex: vi.fn(),
   retryInteraction: vi.fn().mockImplementation((fn: () => Promise<unknown>) => fn()),
 }));
@@ -22,9 +21,17 @@ vi.mock("../utils/delay.js", () => ({
   gaussianDelay: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock("./navigate-away.js", () => ({
+  navigateAwayIf: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("./get-feed.js", () => ({
+  waitForFeedLoad: vi.fn().mockResolvedValue(undefined),
+}));
+
 import { CDPClient } from "../cdp/client.js";
 import { discoverTargets } from "../cdp/discovery.js";
-import { waitForElement, humanizedScrollToByIndex } from "../linkedin/dom-automation.js";
+import { humanizedScrollToByIndex } from "../linkedin/dom-automation.js";
 import { hideFeedAuthor } from "./hide-feed-author.js";
 
 const mockClient = {
@@ -41,7 +48,6 @@ function setupMocks(hiddenName: string | null = "John Doe") {
   vi.mocked(discoverTargets).mockResolvedValue([
     { id: "target-1", type: "page", title: "LinkedIn", url: "https://www.linkedin.com/feed/", description: "", devtoolsFrontendUrl: "" },
   ]);
-  vi.mocked(waitForElement).mockResolvedValue(undefined);
   vi.mocked(humanizedScrollToByIndex).mockResolvedValue(undefined);
 
   // First evaluate: click menu button by index → returns true
@@ -63,7 +69,7 @@ describe("hideFeedAuthor", () => {
   it("throws on non-loopback host without allowRemote", async () => {
     await expect(
       hideFeedAuthor({
-        postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+        feedIndex: 0,
         cdpPort: 9222,
         cdpHost: "192.168.1.100",
       }),
@@ -74,7 +80,7 @@ describe("hideFeedAuthor", () => {
     setupMocks();
 
     const result = await hideFeedAuthor({
-      postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+      feedIndex: 0,
       cdpPort: 9222,
       cdpHost: "192.168.1.100",
       allowRemote: true,
@@ -90,7 +96,7 @@ describe("hideFeedAuthor", () => {
 
     await expect(
       hideFeedAuthor({
-        postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+        feedIndex: 0,
         cdpPort: 9222,
       }),
     ).rejects.toThrow("No LinkedIn page found");
@@ -103,13 +109,12 @@ describe("hideFeedAuthor", () => {
     vi.mocked(discoverTargets).mockResolvedValue([
       { id: "target-1", type: "page", title: "LinkedIn", url: "https://www.linkedin.com/feed/", description: "", devtoolsFrontendUrl: "" },
     ]);
-    vi.mocked(waitForElement).mockResolvedValue(undefined);
     vi.mocked(humanizedScrollToByIndex).mockResolvedValue(undefined);
     mockClient.evaluate.mockResolvedValueOnce(false); // no menu button
 
     await expect(
       hideFeedAuthor({
-        postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+        feedIndex: 0,
         cdpPort: 9222,
       }),
     ).rejects.toThrow("No feed post menu button found");
@@ -123,7 +128,7 @@ describe("hideFeedAuthor", () => {
 
     await expect(
       hideFeedAuthor({
-        postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+        feedIndex: 0,
         cdpPort: 9222,
       }),
     ).rejects.toThrow('No "Hide posts by" menu item found');
@@ -133,27 +138,28 @@ describe("hideFeedAuthor", () => {
     setupMocks("Jane Smith");
 
     const result = await hideFeedAuthor({
-      postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+      feedIndex: 0,
       cdpPort: 9222,
     });
 
     expect(result).toEqual({
       success: true,
-      postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+      feedIndex: 0,
       hiddenName: "Jane Smith",
+      dryRun: false,
     });
   });
 
-  it("navigates to the post URL", async () => {
+  it("navigates to the feed", async () => {
     setupMocks();
 
     await hideFeedAuthor({
-      postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+      feedIndex: 0,
       cdpPort: 9222,
     });
 
     expect(mockClient.navigate).toHaveBeenCalledWith(
-      "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+      "https://www.linkedin.com/feed/",
     );
   });
 
@@ -161,7 +167,7 @@ describe("hideFeedAuthor", () => {
     setupMocks();
 
     await hideFeedAuthor({
-      postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+      feedIndex: 0,
       cdpPort: 9222,
     });
 
@@ -180,7 +186,7 @@ describe("hideFeedAuthor", () => {
     const { retryInteraction } = await import("../linkedin/dom-automation.js");
 
     await hideFeedAuthor({
-      postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+      feedIndex: 0,
       cdpPort: 9222,
     });
 
@@ -188,15 +194,21 @@ describe("hideFeedAuthor", () => {
   });
 
   it("disconnects the CDP client even when an error occurs", async () => {
-    setupMocks();
-    vi.mocked(waitForElement).mockRejectedValueOnce(new Error("timeout"));
+    vi.mocked(CDPClient).mockImplementation(function () {
+      return mockClient as unknown as CDPClient;
+    });
+    vi.mocked(discoverTargets).mockResolvedValue([
+      { id: "target-1", type: "page", title: "LinkedIn", url: "https://www.linkedin.com/feed/", description: "", devtoolsFrontendUrl: "" },
+    ]);
+    vi.mocked(humanizedScrollToByIndex).mockResolvedValue(undefined);
+    mockClient.evaluate.mockRejectedValue(new Error("evaluation failed"));
 
     await expect(
       hideFeedAuthor({
-        postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+        feedIndex: 0,
         cdpPort: 9222,
       }),
-    ).rejects.toThrow("timeout");
+    ).rejects.toThrow("evaluation failed");
 
     expect(mockClient.disconnect).toHaveBeenCalled();
   });

--- a/packages/core/src/operations/hide-feed-author.ts
+++ b/packages/core/src/operations/hide-feed-author.ts
@@ -4,11 +4,12 @@
 import { resolveInstancePort } from "../cdp/index.js";
 import { CDPClient } from "../cdp/client.js";
 import { discoverTargets } from "../cdp/discovery.js";
-import { humanizedScrollToByIndex, retryInteraction, waitForElement } from "../linkedin/dom-automation.js";
+import { humanizedScrollToByIndex, retryInteraction } from "../linkedin/dom-automation.js";
 import type { HumanizedMouse } from "../linkedin/humanized-mouse.js";
-import { FEED_POST_CONTAINER } from "../linkedin/selectors.js";
 import { gaussianDelay } from "../utils/delay.js";
 import type { ConnectionOptions } from "./types.js";
+import { navigateAwayIf } from "./navigate-away.js";
+import { waitForFeedLoad } from "./get-feed.js";
 
 /** CSS selector for feed post menu buttons. */
 const FEED_MENU_BUTTON_SELECTOR =
@@ -18,30 +19,33 @@ const FEED_MENU_BUTTON_SELECTOR =
 const HIDE_POSTS_PREFIX = "Hide posts by ";
 
 export interface HideFeedAuthorInput extends ConnectionOptions {
-  /** LinkedIn post URL identifying the feed post whose author to hide. */
-  readonly postUrl: string;
+  /** Zero-based index of the post in the visible LinkedIn feed. */
+  readonly feedIndex: number;
   /** Optional humanized mouse for natural cursor movement and clicks. */
   readonly mouse?: HumanizedMouse | null | undefined;
+  /** When true, locate the menu item but do not click it. */
+  readonly dryRun?: boolean | undefined;
 }
 
 export interface HideFeedAuthorOutput {
   readonly success: true;
-  readonly postUrl: string;
+  readonly feedIndex: number;
   /** Name extracted from the "Hide posts by {Name}" menu item. */
   readonly hiddenName: string;
+  readonly dryRun: boolean;
 }
 
 /**
  * Hide posts by a person via the three-dot menu on a feed post.
  *
- * Navigates to the post URL in the LinkedIn WebView — LinkedIn
- * renders it as the first feed item — then opens the three-dot
- * menu and clicks the "Hide posts by {Name}" menu item.
+ * Navigates to the LinkedIn home feed, opens the three-dot menu of
+ * the post at the given `feedIndex`, and clicks the "Hide posts by
+ * {Name}" menu item.
  *
  * **Note:** The name in the menu may differ from the post's
  * original author (e.g. when the post is a repost).
  *
- * @param input - Post URL and CDP connection parameters.
+ * @param input - Feed index and CDP connection parameters.
  * @returns Confirmation including the name extracted from the menu item.
  */
 export async function hideFeedAuthor(
@@ -76,18 +80,13 @@ export async function hideFeedAuthor(
 
   try {
     const mouse = input.mouse;
+    const dryRun = input.dryRun ?? false;
+    const feedIndex = input.feedIndex;
 
-    // Navigate to the post URL — LinkedIn redirects post URLs to the
-    // feed page with the target post scrolled into view.
-    await client.navigate(input.postUrl);
-
-    // Wait for the feed to render
-    await waitForElement(client, FEED_POST_CONTAINER, undefined, mouse);
-
-    // After navigation, the target post is the first feed item.
-    // Locate its menu button index to ensure we interact with the
-    // correct post (same navigation pattern as react-to-post).
-    const postIndex = 0;
+    // Navigate to the feed (force fresh load if already there)
+    await navigateAwayIf(client, "/feed");
+    await client.navigate("https://www.linkedin.com/feed/");
+    await waitForFeedLoad(client);
 
     // Open the three-dot menu with retry logic
     const hiddenName = await retryInteraction(async () => {
@@ -95,7 +94,7 @@ export async function hideFeedAuthor(
       await humanizedScrollToByIndex(
         client,
         FEED_MENU_BUTTON_SELECTOR,
-        postIndex,
+        feedIndex,
         mouse,
       );
 
@@ -104,7 +103,7 @@ export async function hideFeedAuthor(
         const btns = document.querySelectorAll(
           ${JSON.stringify(FEED_MENU_BUTTON_SELECTOR)}
         );
-        const btn = btns[${postIndex}];
+        const btn = btns[${feedIndex}];
         if (!btn) return false;
         btn.click();
         return true;
@@ -113,7 +112,7 @@ export async function hideFeedAuthor(
       if (!clicked) {
         throw new Error(
           "No feed post menu button found. " +
-            "Ensure the post URL points to a visible feed post.",
+            "Ensure the feed index points to a visible feed post.",
         );
       }
 
@@ -121,12 +120,13 @@ export async function hideFeedAuthor(
 
       // Find and click "Hide posts by {Name}" menu item
       const name = await client.evaluate<string | null>(`(() => {
+        const dryRun = ${dryRun};
         for (const el of document.querySelectorAll('[role="menuitem"]')) {
           const text = el.textContent.trim();
           if (text.startsWith(${JSON.stringify(HIDE_POSTS_PREFIX)})) {
             const name = text.slice(${HIDE_POSTS_PREFIX.length}).trim();
             if (!name) return null;
-            el.click();
+            if (!dryRun) el.click();
             return name;
           }
         }
@@ -148,6 +148,13 @@ export async function hideFeedAuthor(
       return name;
     }, 3);
 
+    if (dryRun) {
+      await client.evaluate(`(() => {
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+      })()`);
+      await gaussianDelay(300, 75, 200, 500);
+    }
+
     // Let the UI settle after clicking
     await gaussianDelay(550, 75, 400, 700);
 
@@ -155,8 +162,9 @@ export async function hideFeedAuthor(
 
     return {
       success: true as const,
-      postUrl: input.postUrl,
+      feedIndex: input.feedIndex,
       hiddenName,
+      dryRun,
     };
   } finally {
     client.disconnect();

--- a/packages/core/src/operations/unfollow-from-feed.test.ts
+++ b/packages/core/src/operations/unfollow-from-feed.test.ts
@@ -12,9 +12,7 @@ vi.mock("../cdp/discovery.js", () => ({
 }));
 
 vi.mock("../linkedin/dom-automation.js", () => ({
-  waitForElement: vi.fn(),
-  humanizedClick: vi.fn(),
-  humanizedScrollTo: vi.fn(),
+  humanizedScrollToByIndex: vi.fn().mockResolvedValue(undefined),
   retryInteraction: vi.fn().mockImplementation((fn: () => Promise<unknown>) => fn()),
 }));
 
@@ -24,9 +22,17 @@ vi.mock("../utils/delay.js", () => ({
   maybeHesitate: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock("./navigate-away.js", () => ({
+  navigateAwayIf: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("./get-feed.js", () => ({
+  waitForFeedLoad: vi.fn().mockResolvedValue(undefined),
+}));
+
 import { CDPClient } from "../cdp/client.js";
 import { discoverTargets } from "../cdp/discovery.js";
-import { waitForElement, humanizedClick, humanizedScrollTo, retryInteraction } from "../linkedin/dom-automation.js";
+import { humanizedScrollToByIndex, retryInteraction } from "../linkedin/dom-automation.js";
 import { unfollowFromFeed } from "./unfollow-from-feed.js";
 
 const mockClient = {
@@ -43,12 +49,13 @@ function setupMocks(unfollowName: string | null = "John Doe") {
   vi.mocked(discoverTargets).mockResolvedValue([
     { id: "target-1", type: "page", title: "LinkedIn", url: "https://www.linkedin.com/feed/", description: "", devtoolsFrontendUrl: "" },
   ]);
-  vi.mocked(waitForElement).mockResolvedValue(undefined);
-  vi.mocked(humanizedClick).mockResolvedValue(undefined);
-  vi.mocked(humanizedScrollTo).mockResolvedValue(undefined);
+  vi.mocked(humanizedScrollToByIndex).mockResolvedValue(undefined);
 
-  // The evaluate call inside retryInteraction finds the menu item
-  mockClient.evaluate.mockResolvedValue(unfollowName);
+  // First evaluate: click menu button by index → returns true
+  // Second evaluate: click "Unfollow {Name}" menu item → returns name
+  mockClient.evaluate
+    .mockResolvedValueOnce(true) // menu button clicked
+    .mockResolvedValueOnce(unfollowName); // unfollow name from menu item
 }
 
 describe("unfollowFromFeed", () => {
@@ -63,7 +70,7 @@ describe("unfollowFromFeed", () => {
   it("throws on non-loopback host without allowRemote", async () => {
     await expect(
       unfollowFromFeed({
-        postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+        feedIndex: 0,
         cdpPort: 9222,
         cdpHost: "192.168.1.100",
       }),
@@ -74,7 +81,7 @@ describe("unfollowFromFeed", () => {
     setupMocks();
 
     const result = await unfollowFromFeed({
-      postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+      feedIndex: 0,
       cdpPort: 9222,
       cdpHost: "192.168.1.100",
       allowRemote: true,
@@ -90,22 +97,22 @@ describe("unfollowFromFeed", () => {
 
     await expect(
       unfollowFromFeed({
-        postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+        feedIndex: 0,
         cdpPort: 9222,
       }),
     ).rejects.toThrow("No LinkedIn page found");
   });
 
-  it("navigates to the post URL", async () => {
+  it("navigates to the feed", async () => {
     setupMocks();
 
     await unfollowFromFeed({
-      postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+      feedIndex: 0,
       cdpPort: 9222,
     });
 
     expect(mockClient.navigate).toHaveBeenCalledWith(
-      "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+      "https://www.linkedin.com/feed/",
     );
   });
 
@@ -113,23 +120,27 @@ describe("unfollowFromFeed", () => {
     setupMocks("Jane Smith");
 
     const result = await unfollowFromFeed({
-      postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+      feedIndex: 0,
       cdpPort: 9222,
     });
 
     expect(result).toEqual({
       success: true,
-      postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+      feedIndex: 0,
       unfollowedName: "Jane Smith",
+      dryRun: false,
     });
   });
 
   it("throws when no Unfollow menu item is found", async () => {
     setupMocks(null);
 
+    // Third evaluate is the Escape dismiss
+    mockClient.evaluate.mockResolvedValueOnce(undefined);
+
     await expect(
       unfollowFromFeed({
-        postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+        feedIndex: 0,
         cdpPort: 9222,
       }),
     ).rejects.toThrow('No "Unfollow" item found');
@@ -139,50 +150,42 @@ describe("unfollowFromFeed", () => {
     setupMocks();
 
     await unfollowFromFeed({
-      postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+      feedIndex: 0,
       cdpPort: 9222,
     });
 
     expect(retryInteraction).toHaveBeenCalledWith(expect.any(Function), 3);
   });
 
-  it("scrolls to and clicks the menu button", async () => {
+  it("scrolls menu button into view and clicks by index", async () => {
     setupMocks();
 
     await unfollowFromFeed({
-      postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+      feedIndex: 0,
       cdpPort: 9222,
     });
 
-    const selector = 'button[aria-label^="Open control menu for post"]';
-    expect(humanizedScrollTo).toHaveBeenCalledWith(mockClient, selector, undefined);
-    expect(humanizedClick).toHaveBeenCalledWith(mockClient, selector, undefined);
+    expect(humanizedScrollToByIndex).toHaveBeenCalledWith(
+      mockClient,
+      '[data-testid="mainFeed"] div[role="listitem"] button[aria-label^="Open control menu for post"]',
+      0,
+      undefined,
+    );
+    // Menu button is clicked via evaluate (by index), not humanizedClick
+    expect(mockClient.evaluate).toHaveBeenCalled();
   });
 
   it("disconnects the client even on error", async () => {
     setupMocks(null);
 
+    // Third evaluate is the Escape dismiss
+    mockClient.evaluate.mockResolvedValueOnce(undefined);
+
     await unfollowFromFeed({
-      postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+      feedIndex: 0,
       cdpPort: 9222,
     }).catch(() => {});
 
     expect(mockClient.disconnect).toHaveBeenCalled();
-  });
-
-  it("waits for the menu button before interacting", async () => {
-    setupMocks();
-
-    await unfollowFromFeed({
-      postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
-      cdpPort: 9222,
-    });
-
-    expect(waitForElement).toHaveBeenCalledWith(
-      mockClient,
-      'button[aria-label^="Open control menu for post"]',
-      undefined,
-      undefined,
-    );
   });
 });

--- a/packages/core/src/operations/unfollow-from-feed.ts
+++ b/packages/core/src/operations/unfollow-from-feed.ts
@@ -4,37 +4,42 @@
 import { resolveInstancePort } from "../cdp/index.js";
 import { CDPClient } from "../cdp/client.js";
 import { discoverTargets } from "../cdp/discovery.js";
-import { humanizedClick, humanizedScrollTo, retryInteraction, waitForElement } from "../linkedin/dom-automation.js";
+import { humanizedScrollToByIndex, retryInteraction } from "../linkedin/dom-automation.js";
 import type { HumanizedMouse } from "../linkedin/humanized-mouse.js";
 import { gaussianDelay, maybeHesitate } from "../utils/delay.js";
 import type { ConnectionOptions } from "./types.js";
+import { navigateAwayIf } from "./navigate-away.js";
+import { waitForFeedLoad } from "./get-feed.js";
 
-/** CSS selector for the post's three-dot control menu button. */
-const POST_MENU_BUTTON_SELECTOR =
-  'button[aria-label^="Open control menu for post"]';
+/** CSS selector for feed post menu buttons. */
+const FEED_MENU_BUTTON_SELECTOR =
+  '[data-testid="mainFeed"] div[role="listitem"] button[aria-label^="Open control menu for post"]';
 
 export interface UnfollowFromFeedInput extends ConnectionOptions {
-  /** LinkedIn post URL identifying a visible feed post. */
-  readonly postUrl: string;
+  /** Zero-based index of the post in the visible LinkedIn feed. */
+  readonly feedIndex: number;
   /** Optional humanized mouse for natural cursor movement and clicks. */
   readonly mouse?: HumanizedMouse | null | undefined;
+  /** When true, locate the menu item but do not click it. */
+  readonly dryRun?: boolean | undefined;
 }
 
 export interface UnfollowFromFeedOutput {
   readonly success: true;
-  readonly postUrl: string;
+  readonly feedIndex: number;
   /** The name extracted from the "Unfollow {Name}" menu item. */
   readonly unfollowedName: string;
+  readonly dryRun: boolean;
 }
 
 /**
  * Unfollow the author of a LinkedIn post via its feed three-dot menu.
  *
- * Navigates to the post URL, opens the three-dot control menu, and
- * clicks the "Unfollow {Name}" menu item.  The unfollowed person's
- * name is extracted from the menu item text.
+ * Navigates to the LinkedIn home feed, opens the three-dot menu of the
+ * post at the given `feedIndex`, and clicks the "Unfollow {Name}" menu
+ * item.  The unfollowed person's name is extracted from the menu item text.
  *
- * @param input - Post URL and CDP connection parameters.
+ * @param input - Feed index and CDP connection parameters.
  * @returns Confirmation including the unfollowed person's name.
  * @throws If the three-dot menu does not contain an "Unfollow" item.
  */
@@ -69,31 +74,49 @@ export async function unfollowFromFeed(
   await client.connect(linkedInTarget.id);
 
   try {
-    // Navigate to the post URL
-    await client.navigate(input.postUrl);
-
     const mouse = input.mouse;
+    const dryRun = input.dryRun ?? false;
+    const feedIndex = input.feedIndex;
 
-    // Wait for the three-dot menu button to appear
-    await waitForElement(client, POST_MENU_BUTTON_SELECTOR, undefined, mouse);
+    // Navigate to the feed (force fresh load if already there)
+    await navigateAwayIf(client, "/feed");
+    await client.navigate("https://www.linkedin.com/feed/");
+    await waitForFeedLoad(client);
 
     await maybeHesitate();
 
-    // Scroll the menu button into view and click it, retrying if the
-    // menu does not open on the first attempt.
+    // Scroll the menu button into view by index and click it, retrying if
+    // the menu does not open on the first attempt.
     const unfollowedName = await retryInteraction(async () => {
-      await humanizedScrollTo(client, POST_MENU_BUTTON_SELECTOR, mouse);
-      await humanizedClick(client, POST_MENU_BUTTON_SELECTOR, mouse);
+      await humanizedScrollToByIndex(client, FEED_MENU_BUTTON_SELECTOR, feedIndex, mouse);
+
+      const clicked = await client.evaluate<boolean>(`(() => {
+        const btns = document.querySelectorAll(
+          ${JSON.stringify(FEED_MENU_BUTTON_SELECTOR)}
+        );
+        const btn = btns[${feedIndex}];
+        if (!btn) return false;
+        btn.click();
+        return true;
+      })()`);
+
+      if (!clicked) {
+        throw new Error(
+          "No feed post menu button found. " +
+            "Ensure the feed index points to a visible feed post.",
+        );
+      }
 
       await gaussianDelay(700, 100, 500, 900);
 
       // Find and click the "Unfollow {Name}" menu item, extracting
       // the name from the text.
       const name = await client.evaluate<string | null>(`(() => {
+        const dryRun = ${dryRun};
         for (const el of document.querySelectorAll('[role="menuitem"]')) {
           const text = el.textContent?.trim() ?? '';
           if (text.startsWith('Unfollow ')) {
-            el.click();
+            if (!dryRun) el.click();
             return text.slice('Unfollow '.length);
           }
         }
@@ -119,14 +142,22 @@ export async function unfollowFromFeed(
       return name;
     }, 3);
 
+    if (dryRun) {
+      await client.evaluate(`(() => {
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }));
+      })()`);
+      await gaussianDelay(300, 75, 200, 500);
+    }
+
     // Let the UI settle after clicking Unfollow
     await gaussianDelay(550, 75, 400, 700);
 
     await gaussianDelay(1_500, 500, 700, 3_500); // Post-action dwell
     return {
       success: true as const,
-      postUrl: input.postUrl,
+      feedIndex: input.feedIndex,
       unfollowedName,
+      dryRun,
     };
   } finally {
     client.disconnect();

--- a/packages/e2e/src/feed-dismissal.e2e.test.ts
+++ b/packages/e2e/src/feed-dismissal.e2e.test.ts
@@ -5,7 +5,6 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } 
 import {
   describeE2E,
   forceStopInstance,
-  getE2EPostUrl,
   installErrorDetection,
   launchApp,
   quitApp,
@@ -34,11 +33,8 @@ describeE2E("feed dismissal operations", () => {
   let port: number;
   let accountId: number;
   let cdpPort: number;
-  let postUrl: string;
 
   beforeAll(async () => {
-    postUrl = getE2EPostUrl();
-
     const launched = await launchApp();
     app = launched.app;
     port = launched.port;
@@ -114,11 +110,11 @@ describeE2E("feed dismissal operations", () => {
         vi.restoreAllMocks();
       });
 
-      it("dismiss-feed-post --json dismisses post from feed", async () => {
+      it("dismiss-feed-post --json --dry-run reports dry-run result", async () => {
         const stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
         const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
 
-        await handleDismissFeedPost(postUrl, { cdpPort, json: true });
+        await handleDismissFeedPost(0, { cdpPort, json: true, dryRun: true });
 
         const stderr = stderrSpy.mock.calls.map((c) => String(c[0])).join("");
         expect(process.exitCode, `CLI handler error: ${stderr}`).toBeUndefined();
@@ -128,19 +124,34 @@ describeE2E("feed dismissal operations", () => {
         const parsed = JSON.parse(output) as DismissFeedPostOutput;
 
         expect(parsed.success).toBe(true);
-        expect(parsed.postUrl).toBe(postUrl);
+        expect(parsed.feedIndex).toBe(0);
+        expect(parsed.dryRun).toBe(true);
+      }, 120_000);
+
+      it("dismiss-feed-post --dry-run (human-friendly) includes [dry-run] prefix", async () => {
+        const stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+        const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+
+        await handleDismissFeedPost(0, { cdpPort, dryRun: true });
+
+        const stderr = stderrSpy.mock.calls.map((c) => String(c[0])).join("");
+        expect(process.exitCode, `CLI handler error: ${stderr}`).toBeUndefined();
+
+        const output = stdoutSpy.mock.calls.map((call) => String(call[0])).join("");
+        expect(output).toContain("[dry-run]");
       }, 120_000);
     });
 
     describe("MCP tools", () => {
-      it("dismiss-feed-post tool returns valid JSON", async () => {
+      it("dismiss-feed-post tool returns valid dry-run JSON", async () => {
         const { server, getHandler } = createMockServer();
         registerDismissFeedPost(server);
 
         const handler = getHandler("dismiss-feed-post");
         const result = (await handler({
-          postUrl,
+          feedIndex: 0,
           cdpPort,
+          dryRun: true,
         })) as {
           isError?: boolean;
           content: { type: string; text: string }[];
@@ -154,7 +165,8 @@ describeE2E("feed dismissal operations", () => {
         ) as DismissFeedPostOutput;
 
         expect(parsed.success).toBe(true);
-        expect(parsed.postUrl).toBe(postUrl);
+        expect(parsed.feedIndex).toBe(0);
+        expect(parsed.dryRun).toBe(true);
       }, 120_000);
     });
   });

--- a/packages/e2e/src/hide-feed-author.e2e.test.ts
+++ b/packages/e2e/src/hide-feed-author.e2e.test.ts
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, expect, it } from "vitest";
 import {
   describeE2E,
   forceStopInstance,
-  getE2EPostUrl,
   installErrorDetection,
   launchApp,
   quitApp,
@@ -16,14 +15,10 @@ import {
   type AppService,
   discoverInstancePort,
   discoverTargets,
-  dismissErrors,
+  type HideFeedAuthorOutput,
   LauncherService,
   startInstanceWithRecovery,
-  type HideFeedAuthorOutput,
 } from "@lhremote/core";
-
-// CLI handlers
-import { handleHideFeedAuthor } from "@lhremote/cli/handlers";
 
 // MCP tool registrations
 import { registerHideFeedAuthor } from "@lhremote/mcp/tools";
@@ -34,11 +29,8 @@ describeE2E("hide-feed-author", () => {
   let port: number;
   let accountId: number;
   let cdpPort: number;
-  let postUrl: string;
 
   beforeAll(async () => {
-    postUrl = getE2EPostUrl();
-
     const launched = await launchApp();
     app = launched.app;
     port = launched.port;
@@ -53,7 +45,6 @@ describeE2E("hide-feed-author", () => {
       launcher.disconnect();
     }
 
-    // Discover the instance's dynamic CDP port
     const instancePort = await retryAsync(
       async () => {
         const p = await discoverInstancePort(port);
@@ -64,7 +55,6 @@ describeE2E("hide-feed-author", () => {
     );
     cdpPort = instancePort;
 
-    // Wait for the LinkedIn WebView to become available
     await retryAsync(
       async () => {
         const targets = await discoverTargets(cdpPort);
@@ -78,11 +68,6 @@ describeE2E("hide-feed-author", () => {
       { retries: 30, delay: 2_000 },
     );
   }, 120_000);
-
-  // Dismiss any leftover error popups before each test to prevent cascade failures
-  beforeEach(async () => {
-    await dismissErrors({ cdpPort, accountId }).catch(() => {});
-  }, 30_000);
 
   installErrorDetection(() => port);
 
@@ -99,63 +84,44 @@ describeE2E("hide-feed-author", () => {
     await quitApp(app);
   }, 60_000);
 
-  describe("CLI handlers", () => {
-    const originalExitCode = process.exitCode;
+  it("hide-feed-author dryRun finds a non-own post and verifies menu item", async () => {
+    const { server, getHandler } = createMockServer();
+    registerHideFeedAuthor(server);
+    const handler = getHandler("hide-feed-author");
 
-    beforeEach(() => {
-      process.exitCode = undefined;
-    });
+    const MAX_INDEX = 5;
+    let found = false;
 
-    afterEach(() => {
-      process.exitCode = originalExitCode;
-      vi.restoreAllMocks();
-    });
-
-    it("hide-feed-author --json returns hidden name", async () => {
-      const stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
-      const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
-
-      await handleHideFeedAuthor(postUrl, { cdpPort, json: true });
-
-      const stderr = stderrSpy.mock.calls.map((c) => String(c[0])).join("");
-      expect(process.exitCode, `CLI handler error: ${stderr}`).toBeUndefined();
-      expect(stdoutSpy).toHaveBeenCalled();
-
-      const output = stdoutSpy.mock.calls.map((call) => String(call[0])).join("");
-      const parsed = JSON.parse(output) as HideFeedAuthorOutput;
-
-      expect(parsed.success).toBe(true);
-      expect(parsed.postUrl).toBe(postUrl);
-      expect(typeof parsed.hiddenName).toBe("string");
-      expect(parsed.hiddenName.length).toBeGreaterThan(0);
-    }, 120_000);
-  });
-
-  describe("MCP tools", () => {
-    it("hide-feed-author tool returns valid JSON", async () => {
-      const { server, getHandler } = createMockServer();
-      registerHideFeedAuthor(server);
-
-      const handler = getHandler("hide-feed-author");
+    for (let i = 0; i < MAX_INDEX; i++) {
       const result = (await handler({
-        postUrl,
+        feedIndex: i,
         cdpPort,
+        dryRun: true,
       })) as {
         isError?: boolean;
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
+      const text = (result.content[0] as { text: string }).text;
 
-      const parsed = JSON.parse(
-        (result.content[0] as { text: string }).text,
-      ) as HideFeedAuthorOutput;
+      if (result.isError) {
+        // This post doesn't have "Hide posts by" (own post, etc.) — try next
+        console.log(`[info] Feed index ${i}: no Hide posts by — ${text.slice(0, 120)}`);
+        continue;
+      }
 
+      const parsed = JSON.parse(text) as HideFeedAuthorOutput;
       expect(parsed.success).toBe(true);
-      expect(parsed.postUrl).toBe(postUrl);
+      expect(parsed.feedIndex).toBe(i);
+      expect(parsed.dryRun).toBe(true);
       expect(typeof parsed.hiddenName).toBe("string");
       expect(parsed.hiddenName.length).toBeGreaterThan(0);
-    }, 120_000);
-  });
+      console.log(`[info] Feed index ${i}: Hide posts by "${parsed.hiddenName}" available`);
+      found = true;
+      break;
+    }
+
+    expect(found, `No feed post in indices 0–${MAX_INDEX - 1} has a "Hide posts by" menu item`).toBe(true);
+  }, 180_000);
 });

--- a/packages/e2e/src/unfollow-from-feed.e2e.test.ts
+++ b/packages/e2e/src/unfollow-from-feed.e2e.test.ts
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterAll, beforeAll, expect, it } from "vitest";
 import {
   describeE2E,
   forceStopInstance,
-  getE2EPostUrl,
   installErrorDetection,
   launchApp,
   quitApp,
@@ -16,14 +15,10 @@ import {
   type AppService,
   discoverInstancePort,
   discoverTargets,
-  dismissErrors,
   LauncherService,
   startInstanceWithRecovery,
 } from "@lhremote/core";
 import type { UnfollowFromFeedOutput } from "@lhremote/core";
-
-// CLI handlers
-import { handleUnfollowFromFeed } from "@lhremote/cli/handlers";
 
 // MCP tool registrations
 import { registerUnfollowFromFeed } from "@lhremote/mcp/tools";
@@ -34,11 +29,8 @@ describeE2E("unfollow-from-feed operation", () => {
   let port: number;
   let accountId: number;
   let cdpPort: number;
-  let postUrl: string;
 
   beforeAll(async () => {
-    postUrl = getE2EPostUrl();
-
     const launched = await launchApp();
     app = launched.app;
     port = launched.port;
@@ -53,7 +45,6 @@ describeE2E("unfollow-from-feed operation", () => {
       launcher.disconnect();
     }
 
-    // Discover the instance's dynamic CDP port
     const instancePort = await retryAsync(
       async () => {
         const p = await discoverInstancePort(port);
@@ -64,7 +55,6 @@ describeE2E("unfollow-from-feed operation", () => {
     );
     cdpPort = instancePort;
 
-    // Wait for the LinkedIn WebView to become available
     await retryAsync(
       async () => {
         const targets = await discoverTargets(cdpPort);
@@ -78,11 +68,6 @@ describeE2E("unfollow-from-feed operation", () => {
       { retries: 30, delay: 2_000 },
     );
   }, 120_000);
-
-  // Dismiss any leftover error popups before each test to prevent cascade failures
-  beforeEach(async () => {
-    await dismissErrors({ cdpPort, accountId }).catch(() => {});
-  }, 30_000);
 
   installErrorDetection(() => port);
 
@@ -99,67 +84,44 @@ describeE2E("unfollow-from-feed operation", () => {
     await quitApp(app);
   }, 60_000);
 
-  // ── CLI handlers ──────────────────────────────────────────────────
+  it("unfollow-from-feed dryRun finds a non-own post and verifies menu item", async () => {
+    const { server, getHandler } = createMockServer();
+    registerUnfollowFromFeed(server);
+    const handler = getHandler("unfollow-from-feed");
 
-  describe("CLI handlers", () => {
-    const originalExitCode = process.exitCode;
+    const MAX_INDEX = 5;
+    let found = false;
 
-    beforeEach(() => {
-      process.exitCode = undefined;
-    });
-
-    afterEach(() => {
-      process.exitCode = originalExitCode;
-      vi.restoreAllMocks();
-    });
-
-    it("unfollow-from-feed --json returns valid result", async () => {
-      const stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
-      const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
-
-      await handleUnfollowFromFeed(postUrl, { cdpPort, json: true });
-
-      const stderr = stderrSpy.mock.calls.map((c) => String(c[0])).join("");
-      expect(process.exitCode, `CLI handler error: ${stderr}`).toBeUndefined();
-      expect(stdoutSpy).toHaveBeenCalled();
-
-      const output = stdoutSpy.mock.calls.map((call) => String(call[0])).join("");
-      const parsed = JSON.parse(output) as UnfollowFromFeedOutput;
-
-      expect(parsed.success).toBe(true);
-      expect(parsed.postUrl).toBe(postUrl);
-      expect(typeof parsed.unfollowedName).toBe("string");
-      expect(parsed.unfollowedName.length).toBeGreaterThan(0);
-    }, 120_000);
-  });
-
-  // ── MCP tools ─────────────────────────────────────────────────────
-
-  describe("MCP tools", () => {
-    it("unfollow-from-feed tool returns valid JSON", async () => {
-      const { server, getHandler } = createMockServer();
-      registerUnfollowFromFeed(server);
-
-      const handler = getHandler("unfollow-from-feed");
+    for (let i = 0; i < MAX_INDEX; i++) {
       const result = (await handler({
-        postUrl,
+        feedIndex: i,
         cdpPort,
+        dryRun: true,
       })) as {
         isError?: boolean;
         content: { type: string; text: string }[];
       };
 
-      expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
       expect(result.content).toHaveLength(1);
+      const text = (result.content[0] as { text: string }).text;
 
-      const parsed = JSON.parse(
-        (result.content[0] as { text: string }).text,
-      ) as UnfollowFromFeedOutput;
+      if (result.isError) {
+        // This post doesn't have "Unfollow" (own post, etc.) — try next
+        console.log(`[info] Feed index ${i}: no Unfollow — ${text.slice(0, 120)}`);
+        continue;
+      }
 
+      const parsed = JSON.parse(text) as UnfollowFromFeedOutput;
       expect(parsed.success).toBe(true);
-      expect(parsed.postUrl).toBe(postUrl);
+      expect(parsed.feedIndex).toBe(i);
+      expect(parsed.dryRun).toBe(true);
       expect(typeof parsed.unfollowedName).toBe("string");
       expect(parsed.unfollowedName.length).toBeGreaterThan(0);
-    }, 120_000);
-  });
+      console.log(`[info] Feed index ${i}: Unfollow available for "${parsed.unfollowedName}"`);
+      found = true;
+      break;
+    }
+
+    expect(found, `No feed post in indices 0–${MAX_INDEX - 1} has an "Unfollow" menu item`).toBe(true);
+  }, 180_000);
 });

--- a/packages/mcp/src/tools/dismiss-feed-post.ts
+++ b/packages/mcp/src/tools/dismiss-feed-post.ts
@@ -10,22 +10,20 @@ import { cdpConnectionSchema, mcpCatchAll, mcpSuccess } from "../helpers.js";
 export function registerDismissFeedPost(server: McpServer): void {
   server.tool(
     "dismiss-feed-post",
-    'Dismiss a post from the LinkedIn feed by clicking "Not interested" in its three-dot menu. The post must be visible in the home feed.',
+    'Dismiss a post from the LinkedIn feed by clicking "Not interested" in its three-dot menu. Operates on the home feed by position index (pair with get-feed to identify posts).',
     {
-      postUrl: z
-        .string()
-        .describe(
-          "LinkedIn post URL (e.g. https://www.linkedin.com/feed/update/urn:li:activity:1234567890/)",
-        ),
+      feedIndex: z.number().int().min(0).describe("Zero-based index of the post in the visible LinkedIn feed (pair with get-feed to identify posts)"),
+      dryRun: z.boolean().optional().default(false).describe("When true, locate the menu item but do not click it"),
       ...cdpConnectionSchema,
     },
-    async ({ postUrl, cdpPort, cdpHost, allowRemote }) => {
+    async ({ feedIndex, dryRun, cdpPort, cdpHost, allowRemote }) => {
       try {
         const result = await dismissFeedPost({
-          postUrl,
+          feedIndex,
           cdpPort,
           cdpHost,
           allowRemote,
+          dryRun,
         });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {

--- a/packages/mcp/src/tools/hide-feed-author.test.ts
+++ b/packages/mcp/src/tools/hide-feed-author.test.ts
@@ -15,9 +15,9 @@ import { createMockServer } from "./testing/mock-server.js";
 
 const MOCK_RESULT = {
   success: true as const,
-  postUrl:
-    "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+  feedIndex: 0,
   hiddenName: "John Doe",
+  dryRun: false,
 };
 
 describe("registerHideFeedAuthor", () => {
@@ -49,8 +49,7 @@ describe("registerHideFeedAuthor", () => {
 
     const handler = getHandler("hide-feed-author");
     const result = await handler({
-      postUrl:
-        "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+      feedIndex: 0,
       cdpPort: 9222,
     });
 
@@ -68,8 +67,7 @@ describe("registerHideFeedAuthor", () => {
 
     const handler = getHandler("hide-feed-author");
     const result = (await handler({
-      postUrl:
-        "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+      feedIndex: 0,
       cdpPort: 9222,
     })) as { isError?: boolean; content: { text: string }[] };
 
@@ -82,8 +80,7 @@ describe("registerHideFeedAuthor", () => {
     registerHideFeedAuthor,
     "hide-feed-author",
     () => ({
-      postUrl:
-        "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+      feedIndex: 0,
       cdpPort: 9222,
     }),
     (error) => vi.mocked(hideFeedAuthor).mockRejectedValue(error),

--- a/packages/mcp/src/tools/hide-feed-author.ts
+++ b/packages/mcp/src/tools/hide-feed-author.ts
@@ -10,22 +10,20 @@ import { cdpConnectionSchema, mcpCatchAll, mcpSuccess } from "../helpers.js";
 export function registerHideFeedAuthor(server: McpServer): void {
   server.tool(
     "hide-feed-author",
-    "Click 'Hide posts by {Name}' in a feed post's three-dot menu. The hidden person may differ from the original author (e.g. reposter).",
+    "Click 'Hide posts by {Name}' in a feed post's three-dot menu. Operates on the home feed by position index (pair with get-feed to identify posts). The hidden person may differ from the original author (e.g. reposter).",
     {
-      postUrl: z
-        .string()
-        .describe(
-          "LinkedIn post URL identifying the feed post whose 'Hide posts by' action to invoke",
-        ),
+      feedIndex: z.number().int().min(0).describe("Zero-based index of the post in the visible LinkedIn feed (pair with get-feed to identify posts)"),
+      dryRun: z.boolean().optional().default(false).describe("When true, locate the menu item but do not click it"),
       ...cdpConnectionSchema,
     },
-    async ({ postUrl, cdpPort, cdpHost, allowRemote }) => {
+    async ({ feedIndex, dryRun, cdpPort, cdpHost, allowRemote }) => {
       try {
         const result = await hideFeedAuthor({
-          postUrl,
+          feedIndex,
           cdpPort,
           cdpHost,
           allowRemote,
+          dryRun,
         });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {

--- a/packages/mcp/src/tools/unfollow-from-feed.ts
+++ b/packages/mcp/src/tools/unfollow-from-feed.ts
@@ -10,22 +10,20 @@ import { cdpConnectionSchema, mcpCatchAll, mcpSuccess } from "../helpers.js";
 export function registerUnfollowFromFeed(server: McpServer): void {
   server.tool(
     "unfollow-from-feed",
-    "Unfollow the author of a LinkedIn post via its feed three-dot menu. Navigates to the post and clicks the 'Unfollow {Name}' menu item.",
+    "Unfollow the author of a LinkedIn feed post via its three-dot menu. Operates on the home feed by position index (pair with get-feed to identify posts).",
     {
-      postUrl: z
-        .string()
-        .describe(
-          "LinkedIn post URL (e.g. https://www.linkedin.com/feed/update/urn:li:activity:1234567890/)",
-        ),
+      feedIndex: z.number().int().min(0).describe("Zero-based index of the post in the visible LinkedIn feed (pair with get-feed to identify posts)"),
+      dryRun: z.boolean().optional().default(false).describe("When true, locate the menu item but do not click it"),
       ...cdpConnectionSchema,
     },
-    async ({ postUrl, cdpPort, cdpHost, allowRemote }) => {
+    async ({ feedIndex, dryRun, cdpPort, cdpHost, allowRemote }) => {
       try {
         const result = await unfollowFromFeed({
-          postUrl,
+          feedIndex,
           cdpPort,
           cdpHost,
           allowRemote,
+          dryRun,
         });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {


### PR DESCRIPTION
## Summary

Fixes all 3 feed menu operations (`dismiss-feed-post`, `unfollow-from-feed`, `hide-feed-author`) which were broken as shipped:

- **Bug**: `unfollow-from-feed` and `hide-feed-author` navigated to individual post pages where "Unfollow" and "Hide posts by" menu items **don't exist** (confirmed by spike — these are feed-page-only actions)
- **Bug**: `dismiss-feed-post` used an O(n) clipboard-based URL matching loop to find posts in the feed — slow and fragile

### Changes

1. **Refactored to `feedIndex`**: All 3 operations now take `feedIndex: number` (0-based position in the visible feed) instead of `postUrl: string`. They navigate to `/feed/`, scroll to the target post by index, and interact with its three-dot menu directly.

2. **Added `--dry-run` mode**: When `dryRun: true`, the operation opens the three-dot menu, locates the target menu item, confirms it exists, then dismisses the menu **without clicking** the destructive action. Output includes `dryRun: true`.

3. **Fixed E2E tests**: Tests now use `dryRun: true` with `feedIndex: 0` (first visible feed post) — no hardcoded post URLs, no destructive side effects.

### Spike evidence

- `feed-dismiss-spike.e2e.test.ts`: Confirmed feed page has all 3 menu items
- `post-page-menu-spike.e2e.test.ts`: Confirmed post page has **none** of the 3 items
- Research: `research/linkedin/feed-post-menu-items-20260409.md`

Closes #716, Closes #717, Closes #718

## Test plan

- [x] Unit tests pass (all 3 operations + MCP tool tests)
- [x] Lint passes
- [ ] E2E tests with `dryRun: true` against live LinkedHelper

🤖 Generated with [Claude Code](https://claude.com/claude-code)