### PR TITLE
Add --dry-run mode to comment-on-post operation

### DIFF
--- a/packages/cli/src/handlers/comment-on-post.test.ts
+++ b/packages/cli/src/handlers/comment-on-post.test.ts
@@ -22,6 +22,7 @@ const MOCK_RESULT: CommentOnPostOutput = {
     "https://www.linkedin.com/feed/update/urn:li:activity:123/",
   commentText: "Great post!",
   parentCommentUrn: null,
+  dryRun: false,
 };
 
 describe("handleCommentOnPost", () => {
@@ -159,12 +160,90 @@ describe("handleCommentOnPost", () => {
     expect(commentOnPost).not.toHaveBeenCalled();
   });
 
+  it("prints [dry-run] prefix for top-level comment", async () => {
+    vi.mocked(commentOnPost).mockResolvedValue({
+      ...MOCK_RESULT,
+      dryRun: true,
+    });
+
+    await handleCommentOnPost({
+      url: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+      text: "Great post!",
+      dryRun: true,
+    });
+
+    expect(process.exitCode).toBeUndefined();
+    const stdout = getStdout(stdoutSpy);
+    expect(stdout).toContain("[dry-run]");
+    expect(stdout).toContain("Would post comment on");
+    expect(stdout).toContain("Great post!");
+  });
+
+  it("prints [dry-run] prefix for reply", async () => {
+    vi.mocked(commentOnPost).mockResolvedValue({
+      ...MOCK_RESULT,
+      commentText: "Nice reply!",
+      parentCommentUrn: "urn:li:comment:(activity:123,456)",
+      dryRun: true,
+    });
+
+    await handleCommentOnPost({
+      url: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+      text: "Nice reply!",
+      parentCommentUrn: "urn:li:comment:(activity:123,456)",
+      dryRun: true,
+    });
+
+    expect(process.exitCode).toBeUndefined();
+    const stdout = getStdout(stdoutSpy);
+    expect(stdout).toContain("[dry-run]");
+    expect(stdout).toContain("Would post reply on");
+    expect(stdout).toContain("In reply to: urn:li:comment:(activity:123,456)");
+  });
+
+  it("outputs JSON with dryRun field when --json --dry-run", async () => {
+    vi.mocked(commentOnPost).mockResolvedValue({
+      ...MOCK_RESULT,
+      dryRun: true,
+    });
+
+    await handleCommentOnPost({
+      url: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+      text: "Great post!",
+      dryRun: true,
+      json: true,
+    });
+
+    expect(process.exitCode).toBeUndefined();
+    const output = JSON.parse(getStdout(stdoutSpy));
+    expect(output.dryRun).toBe(true);
+    expect(output.success).toBe(true);
+  });
+
+  it("passes dryRun to commentOnPost", async () => {
+    vi.mocked(commentOnPost).mockResolvedValue({
+      ...MOCK_RESULT,
+      dryRun: true,
+    });
+
+    await handleCommentOnPost({
+      url: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+      text: "Great post!",
+      dryRun: true,
+    });
+
+    expect(commentOnPost).toHaveBeenCalledWith(
+      expect.objectContaining({ dryRun: true }),
+    );
+  });
+
   it("prints reply-specific output when parentCommentUrn is set", async () => {
     const replyResult: CommentOnPostOutput = {
       success: true,
       postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
       commentText: "Nice reply!",
       parentCommentUrn: "urn:li:comment:(activity:123,456)",
+      dryRun: false,
     };
     vi.mocked(commentOnPost).mockResolvedValue(replyResult);
 

--- a/packages/cli/src/handlers/comment-on-post.ts
+++ b/packages/cli/src/handlers/comment-on-post.ts
@@ -19,6 +19,7 @@ export async function handleCommentOnPost(options: {
   cdpHost?: string;
   allowRemote?: boolean;
   accountId?: number;
+  dryRun?: boolean;
   json?: boolean;
 }): Promise<void> {
   process.stderr.write(
@@ -68,6 +69,7 @@ export async function handleCommentOnPost(options: {
       cdpHost: options.cdpHost,
       allowRemote: options.allowRemote,
       accountId: options.accountId,
+      dryRun: options.dryRun,
     });
   } catch (error) {
     if (error instanceof BudgetExceededError) {
@@ -84,6 +86,19 @@ export async function handleCommentOnPost(options: {
 
   if (options.json) {
     process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+  } else if (result.dryRun) {
+    if (result.parentCommentUrn) {
+      process.stdout.write(
+        `[dry-run] Would post reply on ${result.postUrl}\n` +
+          `In reply to: ${result.parentCommentUrn}\n` +
+          `Text: ${result.commentText}\n`,
+      );
+    } else {
+      process.stdout.write(
+        `[dry-run] Would post comment on ${result.postUrl}\n` +
+          `Text: ${result.commentText}\n`,
+      );
+    }
   } else {
     if (result.parentCommentUrn) {
       process.stdout.write(`Reply posted on ${result.postUrl}\n`);

--- a/packages/cli/src/handlers/comment-on-post.ts
+++ b/packages/cli/src/handlers/comment-on-post.ts
@@ -22,8 +22,11 @@ export async function handleCommentOnPost(options: {
   dryRun?: boolean;
   json?: boolean;
 }): Promise<void> {
+  const dryTag = options.dryRun ? "[dry-run] " : "";
   process.stderr.write(
-    options.parentCommentUrn ? "Posting reply...\n" : "Posting comment...\n",
+    options.parentCommentUrn
+      ? `${dryTag}Posting reply...\n`
+      : `${dryTag}Posting comment...\n`,
   );
 
   let parsedMentions: MentionEntry[] | undefined;

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -705,7 +705,7 @@ export function createProgram(): Command {
     .option("--cdp-port <port>", "CDP debugging port (auto-discovered when omitted)", parsePositiveInt)
     .option("--cdp-host <host>", "CDP host (default: 127.0.0.1)")
     .option("--allow-remote", "SECURITY: allow non-loopback CDP connections (enables remote code execution on target)")
-    .option("--dry-run", "Prepare the comment but do not click submit")
+    .option("--dry-run", "Validate the comment flow but skip typing and submitting")
     .option("--json", "Output as JSON")
     .action(handleCommentOnPost);
 

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -705,6 +705,7 @@ export function createProgram(): Command {
     .option("--cdp-port <port>", "CDP debugging port (auto-discovered when omitted)", parsePositiveInt)
     .option("--cdp-host <host>", "CDP host (default: 127.0.0.1)")
     .option("--allow-remote", "SECURITY: allow non-loopback CDP connections (enables remote code execution on target)")
+    .option("--dry-run", "Prepare the comment but do not click submit")
     .option("--json", "Output as JSON")
     .action(handleCommentOnPost);
 

--- a/packages/core/src/operations/comment-on-post.ts
+++ b/packages/core/src/operations/comment-on-post.ts
@@ -49,6 +49,8 @@ export interface CommentOnPostInput extends ConnectionOptions {
   readonly mentions?: readonly MentionEntry[] | undefined;
   /** Optional humanized mouse for natural cursor movement and clicks. */
   readonly mouse?: HumanizedMouse | null | undefined;
+  /** When true, prepare the comment but do not click submit. */
+  readonly dryRun?: boolean | undefined;
 }
 
 /**
@@ -60,6 +62,7 @@ export interface CommentOnPostOutput {
   readonly commentText: string;
   /** The parent comment URN when this was posted as a reply, or `null` for top-level comments. */
   readonly parentCommentUrn: string | null;
+  readonly dryRun: boolean;
 }
 
 /**
@@ -160,6 +163,7 @@ export async function commentOnPost(
     const mouse = input.mouse;
     const parentUrn = input.parentCommentUrn;
     const mentions = input.mentions ?? [];
+    const dryRun = input.dryRun ?? false;
 
     if (parentUrn) {
       // --- Reply to a specific comment ---
@@ -180,10 +184,12 @@ export async function commentOnPost(
       await waitForElement(client, `${COMMENT_INPUT}:focus`, undefined, mouse);
       await gaussianDelay(350, 50, 250, 500);
 
-      if (mentions.length > 0) {
-        await typeTextWithMentions(client, `${COMMENT_INPUT}:focus`, input.text, mentions);
-      } else {
-        await typeText(client, `${COMMENT_INPUT}:focus`, input.text);
+      if (!dryRun) {
+        if (mentions.length > 0) {
+          await typeTextWithMentions(client, `${COMMENT_INPUT}:focus`, input.text, mentions);
+        } else {
+          await typeText(client, `${COMMENT_INPUT}:focus`, input.text);
+        }
       }
     } else {
       // --- Top-level comment ---
@@ -192,19 +198,23 @@ export async function commentOnPost(
       await humanizedClick(client, COMMENT_INPUT, mouse);
       await gaussianDelay(550, 75, 400, 700);
 
-      if (mentions.length > 0) {
-        await typeTextWithMentions(client, COMMENT_INPUT, input.text, mentions);
-      } else {
-        await typeText(client, COMMENT_INPUT, input.text);
+      if (!dryRun) {
+        if (mentions.length > 0) {
+          await typeTextWithMentions(client, COMMENT_INPUT, input.text, mentions);
+        } else {
+          await typeText(client, COMMENT_INPUT, input.text);
+        }
       }
     }
 
-    // Wait for submit button and click
-    await waitForElement(client, COMMENT_SUBMIT_BUTTON, undefined, mouse);
-    await humanizedClick(client, COMMENT_SUBMIT_BUTTON, mouse);
+    if (!dryRun) {
+      // Wait for submit button and click
+      await waitForElement(client, COMMENT_SUBMIT_BUTTON, undefined, mouse);
+      await humanizedClick(client, COMMENT_SUBMIT_BUTTON, mouse);
 
-    // Brief wait for the comment to post
-    await gaussianDelay(2_000, 250, 1_500, 2_500);
+      // Brief wait for the comment to post
+      await gaussianDelay(2_000, 250, 1_500, 2_500);
+    }
 
     await gaussianDelay(1_500, 500, 700, 3_500); // Post-action dwell
     return {
@@ -212,6 +222,7 @@ export async function commentOnPost(
       postUrl: input.postUrl,
       commentText: input.text,
       parentCommentUrn: parentUrn ?? null,
+      dryRun,
     };
   } finally {
     client.disconnect();

--- a/packages/core/src/operations/comment-on-post.ts
+++ b/packages/core/src/operations/comment-on-post.ts
@@ -72,6 +72,10 @@ export interface CommentOnPostOutput {
  * input via selectors, types the comment text character-by-character
  * for human-like behaviour, and clicks submit.
  *
+ * When {@link CommentOnPostInput.dryRun | dryRun} is `true`, the
+ * operation validates that the comment input and submit button are
+ * present but skips typing and clicking submit.
+ *
  * Checks the action budget before attempting the comment and fails
  * with a {@link BudgetExceededError} if the PostComment limit has
  * been reached.
@@ -207,9 +211,10 @@ export async function commentOnPost(
       }
     }
 
+    // Wait for submit button to validate the submit flow would work
+    await waitForElement(client, COMMENT_SUBMIT_BUTTON, undefined, mouse);
+
     if (!dryRun) {
-      // Wait for submit button and click
-      await waitForElement(client, COMMENT_SUBMIT_BUTTON, undefined, mouse);
       await humanizedClick(client, COMMENT_SUBMIT_BUTTON, mouse);
 
       // Brief wait for the comment to post

--- a/packages/core/src/operations/comment-on-post.ts
+++ b/packages/core/src/operations/comment-on-post.ts
@@ -49,7 +49,7 @@ export interface CommentOnPostInput extends ConnectionOptions {
   readonly mentions?: readonly MentionEntry[] | undefined;
   /** Optional humanized mouse for natural cursor movement and clicks. */
   readonly mouse?: HumanizedMouse | null | undefined;
-  /** When true, prepare the comment but do not click submit. */
+  /** When true, validate the comment flow but skip typing and clicking submit. */
   readonly dryRun?: boolean | undefined;
 }
 

--- a/packages/e2e/src/engagement.e2e.test.ts
+++ b/packages/e2e/src/engagement.e2e.test.ts
@@ -564,6 +564,93 @@ describeE2E("engagement operations", () => {
       }, 120_000);
     });
 
+    describe("dry-run", () => {
+      const originalExitCode = process.exitCode;
+
+      beforeEach(() => {
+        process.exitCode = undefined;
+      });
+
+      afterEach(() => {
+        process.exitCode = originalExitCode;
+        vi.restoreAllMocks();
+      });
+
+      it("comment-on-post --json --dry-run reports dry-run result", async () => {
+        const stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+        const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+
+        await handleCommentOnPost({
+          url: postUrl,
+          text: "E2E dry-run comment",
+          cdpPort,
+          accountId,
+          dryRun: true,
+          json: true,
+        });
+
+        const stderr = stderrSpy.mock.calls.map((c) => String(c[0])).join("");
+        expect(process.exitCode, `CLI handler error: ${stderr}`).toBeUndefined();
+        expect(stdoutSpy).toHaveBeenCalled();
+
+        const output = stdoutSpy.mock.calls.map((call) => String(call[0])).join("");
+        const parsed = JSON.parse(output) as CommentOnPostOutput;
+
+        expect(parsed.success).toBe(true);
+        expect(parsed.postUrl).toBe(postUrl);
+        expect(parsed.commentText).toBe("E2E dry-run comment");
+        expect(parsed.dryRun).toBe(true);
+      }, 120_000);
+
+      it("comment-on-post --dry-run (human-friendly) includes [dry-run] prefix", async () => {
+        const stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+        const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+
+        await handleCommentOnPost({
+          url: postUrl,
+          text: "E2E dry-run comment",
+          cdpPort,
+          accountId,
+          dryRun: true,
+        });
+
+        const stderr = stderrSpy.mock.calls.map((c) => String(c[0])).join("");
+        expect(process.exitCode, `CLI handler error: ${stderr}`).toBeUndefined();
+
+        const output = stdoutSpy.mock.calls.map((call) => String(call[0])).join("");
+        expect(output).toContain("[dry-run]");
+      }, 120_000);
+
+      it("comment-on-post MCP tool returns valid dry-run JSON", async () => {
+        const { server, getHandler } = createMockServer();
+        registerCommentOnPost(server);
+
+        const handler = getHandler("comment-on-post");
+        const result = (await handler({
+          postUrl,
+          text: "E2E dry-run comment via MCP",
+          cdpPort,
+          accountId,
+          dryRun: true,
+        })) as {
+          isError?: boolean;
+          content: { type: string; text: string }[];
+        };
+
+        expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
+        expect(result.content).toHaveLength(1);
+
+        const parsed = JSON.parse(
+          (result.content[0] as { text: string }).text,
+        ) as CommentOnPostOutput;
+
+        expect(parsed.success).toBe(true);
+        expect(parsed.postUrl).toBe(postUrl);
+        expect(parsed.commentText).toBe("E2E dry-run comment via MCP");
+        expect(parsed.dryRun).toBe(true);
+      }, 120_000);
+    });
+
     describe("reply to comment", () => {
       it("replies to a specific comment via parentCommentUrn (CLI)", async () => {
         const stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);

--- a/packages/mcp/src/tools/comment-on-post.test.ts
+++ b/packages/mcp/src/tools/comment-on-post.test.ts
@@ -19,6 +19,7 @@ const MOCK_RESULT = {
     "https://www.linkedin.com/feed/update/urn:li:activity:123/",
   commentText: "Great post!",
   parentCommentUrn: null as string | null,
+  dryRun: false,
 };
 
 describe("registerCommentOnPost", () => {
@@ -77,6 +78,24 @@ describe("registerCommentOnPost", () => {
 
     expect(commentOnPost).toHaveBeenCalledWith(
       expect.objectContaining({ parentCommentUrn: "urn:li:comment:(activity:123,456)" }),
+    );
+  });
+
+  it("passes dryRun to core operation", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCommentOnPost(server);
+    vi.mocked(commentOnPost).mockResolvedValue({ ...MOCK_RESULT, dryRun: true });
+
+    const handler = getHandler("comment-on-post");
+    await handler({
+      postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+      text: "Great post!",
+      dryRun: true,
+      cdpPort: 9222,
+    });
+
+    expect(commentOnPost).toHaveBeenCalledWith(
+      expect.objectContaining({ dryRun: true }),
     );
   });
 

--- a/packages/mcp/src/tools/comment-on-post.ts
+++ b/packages/mcp/src/tools/comment-on-post.ts
@@ -46,7 +46,7 @@ export function registerCommentOnPost(server: McpServer): void {
         .boolean()
         .optional()
         .default(false)
-        .describe("When true, prepare the comment but do not click submit"),
+        .describe("When true, validate the comment input and submit button are present, but skip typing and submitting"),
       ...cdpConnectionSchema,
     },
     async ({ postUrl, text, parentCommentUrn, mentions, dryRun, cdpPort, cdpHost, allowRemote, accountId }) => {

--- a/packages/mcp/src/tools/comment-on-post.ts
+++ b/packages/mcp/src/tools/comment-on-post.ts
@@ -10,7 +10,7 @@ import { cdpConnectionSchema, mcpCatchAll, mcpSuccess } from "../helpers.js";
 export function registerCommentOnPost(server: McpServer): void {
   server.tool(
     "comment-on-post",
-    "Post a comment on a LinkedIn post. Navigate to the post, type the comment text character-by-character for human-like behaviour, and submit. Checks action budget before attempting — fails if PostComment limit is reached.",
+    "Post a comment on a LinkedIn post. Navigate to the post, type the comment text character-by-character for human-like behaviour, and submit. When dryRun is true, validates comment input and submit button are present but skips typing and submitting. Checks action budget before attempting — fails if PostComment limit is reached.",
     {
       postUrl: z
         .string()

--- a/packages/mcp/src/tools/comment-on-post.ts
+++ b/packages/mcp/src/tools/comment-on-post.ts
@@ -42,11 +42,16 @@ export function registerCommentOnPost(server: McpServer): void {
             'literal @Name in the text (e.g. text "@John Doe hello" with mentions [{name: "John Doe"}]). ' +
             "During typing, each @Name triggers LinkedIn's mention autocomplete.",
         ),
+      dryRun: z
+        .boolean()
+        .optional()
+        .default(false)
+        .describe("When true, prepare the comment but do not click submit"),
       ...cdpConnectionSchema,
     },
-    async ({ postUrl, text, parentCommentUrn, mentions, cdpPort, cdpHost, allowRemote, accountId }) => {
+    async ({ postUrl, text, parentCommentUrn, mentions, dryRun, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await commentOnPost({ postUrl, text, parentCommentUrn, mentions, cdpPort, cdpHost, allowRemote, accountId });
+        const result = await commentOnPost({ postUrl, text, parentCommentUrn, mentions, dryRun, cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         return mcpCatchAll(error, "Failed to comment on post");


### PR DESCRIPTION
## Summary

- Add `dryRun` option to `CommentOnPostInput`/`CommentOnPostOutput` in the core operation — skips typing and submit while still validating navigation and comment input presence
- Wire `--dry-run` flag through CLI handler (`[dry-run]` human-friendly prefix) and program definition
- Add `dryRun` to MCP tool Zod schema with `optional().default(false)`
- Add unit tests for dry-run in both CLI handler and MCP tool
- Add E2E dry-run tests (CLI JSON, CLI human-friendly, MCP) to `engagement.e2e.test.ts`

Follows the pattern established by dismiss-feed-post, hide-feed-author, and unfollow-from-feed.

Closes #724

## Test plan

- [x] `pnpm build` passes
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (1958 tests across all packages)
- [ ] CI passes on all platforms
- [ ] E2E dry-run tests pass locally (`pnpm test:e2e`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)