### PR TITLE
Add --dry-run mode to react-to-post operation

### DIFF
--- a/packages/cli/src/handlers/react-to-post.test.ts
+++ b/packages/cli/src/handlers/react-to-post.test.ts
@@ -18,6 +18,8 @@ const MOCK_RESULT: ReactToPostOutput = {
     "https://www.linkedin.com/feed/update/urn:li:activity:123/",
   reactionType: "like",
   alreadyReacted: false,
+  currentReaction: null,
+  dryRun: false,
 };
 
 describe("handleReactToPost", () => {
@@ -84,6 +86,42 @@ describe("handleReactToPost", () => {
     const output = getStdout(stdoutSpy);
     expect(output).toContain('Already reacted to post with "like"');
     expect(output).toContain("no change");
+  });
+
+  it("prints [dry-run] prefix in human-readable mode", async () => {
+    vi.mocked(reactToPost).mockResolvedValue({
+      ...MOCK_RESULT,
+      dryRun: true,
+    });
+
+    await handleReactToPost(
+      "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+      { dryRun: true },
+    );
+
+    expect(process.exitCode).toBeUndefined();
+    const output = getStdout(stdoutSpy);
+    expect(output).toContain("[dry-run]");
+    expect(output).toContain('Would react to post with "like"');
+  });
+
+  it("prints [dry-run] already-reacted output", async () => {
+    vi.mocked(reactToPost).mockResolvedValue({
+      ...MOCK_RESULT,
+      alreadyReacted: true,
+      currentReaction: "like",
+      dryRun: true,
+    });
+
+    await handleReactToPost(
+      "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+      { dryRun: true },
+    );
+
+    expect(process.exitCode).toBeUndefined();
+    const output = getStdout(stdoutSpy);
+    expect(output).toContain("[dry-run]");
+    expect(output).toContain('Already reacted to post with "like"');
   });
 
   it("sets exitCode on error", async () => {

--- a/packages/cli/src/handlers/react-to-post.ts
+++ b/packages/cli/src/handlers/react-to-post.ts
@@ -16,6 +16,7 @@ export async function handleReactToPost(
     cdpPort?: number;
     cdpHost?: string;
     allowRemote?: boolean;
+    dryRun?: boolean;
     json?: boolean;
   },
 ): Promise<void> {
@@ -27,6 +28,7 @@ export async function handleReactToPost(
       cdpPort: options.cdpPort,
       cdpHost: options.cdpHost,
       allowRemote: options.allowRemote,
+      dryRun: options.dryRun,
     });
   } catch (error) {
     const message = errorMessage(error);
@@ -37,6 +39,18 @@ export async function handleReactToPost(
 
   if (options.json) {
     process.stdout.write(JSON.stringify(result, null, 2) + "\n");
+  } else if (result.dryRun) {
+    if (result.alreadyReacted) {
+      process.stdout.write(
+        `[dry-run] Already reacted to post with "${result.reactionType}" (no change)\n` +
+          `  Post: ${result.postUrl}\n`,
+      );
+    } else {
+      process.stdout.write(
+        `[dry-run] Would react to post with "${result.reactionType}"\n` +
+          `  Post: ${result.postUrl}\n`,
+      );
+    }
   } else if (result.alreadyReacted) {
     process.stdout.write(
       `Already reacted to post with "${result.reactionType}" (no change)\n` +

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -764,6 +764,7 @@ export function createProgram(): Command {
     .option("--cdp-port <port>", "CDP debugging port (auto-discovered when omitted)", parsePositiveInt)
     .option("--cdp-host <host>", "CDP host (default: 127.0.0.1)")
     .option("--allow-remote", "SECURITY: allow non-loopback CDP connections (enables remote code execution on target)")
+    .option("--dry-run", "Detect current reaction state without clicking")
     .option("--json", "Output as JSON")
     .action(handleReactToPost);
 

--- a/packages/core/src/operations/react-to-post.test.ts
+++ b/packages/core/src/operations/react-to-post.test.ts
@@ -189,7 +189,7 @@ describe("reactToPost", () => {
     expect(humanizedHover).toHaveBeenCalled();
   });
 
-  it("returns dryRun: true without clicking when dryRun is set", async () => {
+  it("returns dryRun: true and hovers popup but skips click", async () => {
     setupMocks();
 
     const result = await reactToPost({
@@ -203,8 +203,8 @@ describe("reactToPost", () => {
     expect(result.dryRun).toBe(true);
     expect(result.alreadyReacted).toBe(false);
     expect(result.currentReaction).toBeNull();
-    // Should NOT hover or click reaction buttons
-    expect(humanizedHover).not.toHaveBeenCalled();
+    // Should hover to validate popup opens, but NOT click
+    expect(humanizedHover).toHaveBeenCalled();
     expect(humanizedClick).not.toHaveBeenCalled();
   });
 
@@ -223,8 +223,9 @@ describe("reactToPost", () => {
     expect(result.dryRun).toBe(true);
     expect(result.alreadyReacted).toBe(false);
     expect(result.currentReaction).toBe("celebrate");
-    // Should NOT click to unreact or click the new reaction
+    // Should NOT click to unreact, but should hover to validate popup
     expect(humanizedClick).not.toHaveBeenCalled();
+    expect(humanizedHover).toHaveBeenCalled();
   });
 
   it("returns alreadyReacted with dryRun when same reaction is active", async () => {

--- a/packages/core/src/operations/react-to-post.test.ts
+++ b/packages/core/src/operations/react-to-post.test.ts
@@ -131,6 +131,8 @@ describe("reactToPost", () => {
       postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
       reactionType: "celebrate",
       alreadyReacted: false,
+      currentReaction: null,
+      dryRun: false,
     });
   });
 
@@ -185,6 +187,61 @@ describe("reactToPost", () => {
     // Should click trigger to unreact, then hover to open popup
     expect(humanizedClick).toHaveBeenCalledTimes(2);
     expect(humanizedHover).toHaveBeenCalled();
+  });
+
+  it("returns dryRun: true without clicking when dryRun is set", async () => {
+    setupMocks();
+
+    const result = await reactToPost({
+      postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+      reactionType: "like",
+      cdpPort: 9222,
+      dryRun: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.dryRun).toBe(true);
+    expect(result.alreadyReacted).toBe(false);
+    expect(result.currentReaction).toBeNull();
+    // Should NOT hover or click reaction buttons
+    expect(humanizedHover).not.toHaveBeenCalled();
+    expect(humanizedClick).not.toHaveBeenCalled();
+  });
+
+  it("returns dryRun with currentReaction when a different reaction is active", async () => {
+    setupMocks();
+    mockClient.evaluate.mockResolvedValueOnce("Unreact Celebrate");
+
+    const result = await reactToPost({
+      postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+      reactionType: "like",
+      cdpPort: 9222,
+      dryRun: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.dryRun).toBe(true);
+    expect(result.alreadyReacted).toBe(false);
+    expect(result.currentReaction).toBe("celebrate");
+    // Should NOT click to unreact or click the new reaction
+    expect(humanizedClick).not.toHaveBeenCalled();
+  });
+
+  it("returns alreadyReacted with dryRun when same reaction is active", async () => {
+    setupMocks();
+    mockClient.evaluate.mockResolvedValueOnce("Unreact Like");
+
+    const result = await reactToPost({
+      postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+      reactionType: "like",
+      cdpPort: 9222,
+      dryRun: true,
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.dryRun).toBe(true);
+    expect(result.alreadyReacted).toBe(true);
+    expect(result.currentReaction).toBe("like");
   });
 
   it("navigates to the post URL", async () => {

--- a/packages/core/src/operations/react-to-post.ts
+++ b/packages/core/src/operations/react-to-post.ts
@@ -137,6 +137,10 @@ export interface ReactToPostOutput {
  * - **Already reacted with a different type**: clicks the trigger to
  *   remove the existing reaction, then applies the requested one.
  *
+ * When `dryRun` is `true`, the operation navigates to the post, detects
+ * the current reaction state, and validates that the reaction popup opens,
+ * but skips the final reaction click.
+ *
  * @param input - Post URL, reaction type, and CDP connection parameters.
  * @returns Confirmation of the reaction applied, including whether the
  *   post was already reacted with the requested type.

--- a/packages/core/src/operations/react-to-post.ts
+++ b/packages/core/src/operations/react-to-post.ts
@@ -109,6 +109,8 @@ export interface ReactToPostInput extends ConnectionOptions {
   readonly reactionType?: ReactionType | undefined;
   /** Optional humanized mouse for natural cursor movement and clicks. */
   readonly mouse?: HumanizedMouse | null | undefined;
+  /** When true, detect the reaction state but do not click. */
+  readonly dryRun?: boolean | undefined;
 }
 
 export interface ReactToPostOutput {
@@ -117,6 +119,9 @@ export interface ReactToPostOutput {
   readonly reactionType: ReactionType;
   /** Whether the post was already reacted with the requested type (no-op). */
   readonly alreadyReacted: boolean;
+  /** The reaction currently applied to the post (null if none). */
+  readonly currentReaction: ReactionType | null;
+  readonly dryRun: boolean;
 }
 
 /**
@@ -143,6 +148,7 @@ export async function reactToPost(
   const cdpHost = input.cdpHost ?? "127.0.0.1";
   const allowRemote = input.allowRemote ?? false;
   const reactionType = input.reactionType ?? "like";
+  const dryRun = input.dryRun ?? false;
 
   if (!REACTION_TYPES.includes(reactionType)) {
     throw new Error(
@@ -194,6 +200,21 @@ export async function reactToPost(
         postUrl: input.postUrl,
         reactionType,
         alreadyReacted: true,
+        currentReaction,
+        dryRun,
+      };
+    }
+
+    if (dryRun) {
+      // Dry-run: detected state without mutating — return early
+      await gaussianDelay(1_500, 500, 700, 3_500); // Post-action dwell
+      return {
+        success: true as const,
+        postUrl: input.postUrl,
+        reactionType,
+        alreadyReacted: false,
+        currentReaction,
+        dryRun,
       };
     }
 
@@ -232,6 +253,8 @@ export async function reactToPost(
       postUrl: input.postUrl,
       reactionType,
       alreadyReacted: false,
+      currentReaction,
+      dryRun,
     };
   } finally {
     client.disconnect();

--- a/packages/core/src/operations/react-to-post.ts
+++ b/packages/core/src/operations/react-to-post.ts
@@ -119,7 +119,7 @@ export interface ReactToPostOutput {
   readonly reactionType: ReactionType;
   /** Whether the post was already reacted with the requested type (no-op). */
   readonly alreadyReacted: boolean;
-  /** The reaction currently applied to the post (null if none). */
+  /** The reaction detected on the post before acting (null if none). */
   readonly currentReaction: ReactionType | null;
   readonly dryRun: boolean;
 }
@@ -205,20 +205,7 @@ export async function reactToPost(
       };
     }
 
-    if (dryRun) {
-      // Dry-run: detected state without mutating — return early
-      await gaussianDelay(1_500, 500, 700, 3_500); // Post-action dwell
-      return {
-        success: true as const,
-        postUrl: input.postUrl,
-        reactionType,
-        alreadyReacted: false,
-        currentReaction,
-        dryRun,
-      };
-    }
-
-    if (currentReaction !== null) {
+    if (!dryRun && currentReaction !== null) {
       // Reacted with a different type — click trigger to unreact first
       await humanizedClick(client, REACTION_TRIGGER, mouse);
       // Wait for DOM to settle after unreacting — the trigger element
@@ -242,10 +229,13 @@ export async function reactToPost(
       await gaussianDelay(2_000, 300, 1_500, 3_000);
       await waitForElement(client, reactionSelector, { timeout: 10_000 });
     }, 3);
-    await humanizedClick(client, reactionSelector, mouse);
 
-    // Let the UI settle
-    await gaussianDelay(550, 75, 400, 700);
+    if (!dryRun) {
+      await humanizedClick(client, reactionSelector, mouse);
+
+      // Let the UI settle
+      await gaussianDelay(550, 75, 400, 700);
+    }
 
     await gaussianDelay(1_500, 500, 700, 3_500); // Post-action dwell
     return {

--- a/packages/e2e/src/engagement.e2e.test.ts
+++ b/packages/e2e/src/engagement.e2e.test.ts
@@ -405,6 +405,38 @@ describeE2E("engagement operations", () => {
         expect(typeof parsed.alreadyReacted).toBe("boolean");
       }, 120_000);
 
+      it("react-to-post --json --dry-run reports dry-run result", async () => {
+        const stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+        const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+
+        await handleReactToPost(postUrl, { cdpPort, json: true, dryRun: true });
+
+        const stderr = stderrSpy.mock.calls.map((c) => String(c[0])).join("");
+        expect(process.exitCode, `CLI handler error: ${stderr}`).toBeUndefined();
+        expect(stdoutSpy).toHaveBeenCalled();
+
+        const output = stdoutSpy.mock.calls.map((call) => String(call[0])).join("");
+        const parsed = JSON.parse(output) as ReactToPostOutput;
+
+        expect(parsed.success).toBe(true);
+        expect(parsed.postUrl).toBe(postUrl);
+        expect(parsed.reactionType).toBe("like");
+        expect(parsed.dryRun).toBe(true);
+      }, 120_000);
+
+      it("react-to-post --dry-run (human-friendly) includes [dry-run] prefix", async () => {
+        const stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+        const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+
+        await handleReactToPost(postUrl, { cdpPort, dryRun: true });
+
+        const stderr = stderrSpy.mock.calls.map((c) => String(c[0])).join("");
+        expect(process.exitCode, `CLI handler error: ${stderr}`).toBeUndefined();
+
+        const output = stdoutSpy.mock.calls.map((call) => String(call[0])).join("");
+        expect(output).toContain("[dry-run]");
+      }, 120_000);
+
       it("react-to-post --json with insightful reaction uses popup", async () => {
         // Ensure post is in "like" state so the insightful reaction
         // exercises the unreact-then-react popup path regardless of
@@ -459,6 +491,34 @@ describeE2E("engagement operations", () => {
         expect(parsed.success).toBe(true);
         expect(parsed.postUrl).toBe(postUrl);
         expect(parsed.reactionType).toBe("like");
+      }, 120_000);
+
+      it("react-to-post tool returns valid dry-run JSON", async () => {
+        const { server, getHandler } = createMockServer();
+        registerReactToPost(server);
+
+        const handler = getHandler("react-to-post");
+        const result = (await handler({
+          postUrl,
+          reactionType: "like",
+          cdpPort,
+          dryRun: true,
+        })) as {
+          isError?: boolean;
+          content: { type: string; text: string }[];
+        };
+
+        expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
+        expect(result.content).toHaveLength(1);
+
+        const parsed = JSON.parse(
+          (result.content[0] as { text: string }).text,
+        ) as ReactToPostOutput;
+
+        expect(parsed.success).toBe(true);
+        expect(parsed.postUrl).toBe(postUrl);
+        expect(parsed.reactionType).toBe("like");
+        expect(parsed.dryRun).toBe(true);
       }, 120_000);
 
       it("react-to-post tool with insightful reaction uses popup", async () => {

--- a/packages/mcp/src/tools/react-to-post.test.ts
+++ b/packages/mcp/src/tools/react-to-post.test.ts
@@ -19,6 +19,8 @@ const MOCK_RESULT = {
     "https://www.linkedin.com/feed/update/urn:li:activity:123/",
   reactionType: "like" as const,
   alreadyReacted: false as const,
+  currentReaction: null,
+  dryRun: false as const,
 };
 
 describe("registerReactToPost", () => {

--- a/packages/mcp/src/tools/react-to-post.ts
+++ b/packages/mcp/src/tools/react-to-post.ts
@@ -10,7 +10,7 @@ import { cdpConnectionSchema, mcpCatchAll, mcpSuccess } from "../helpers.js";
 export function registerReactToPost(server: McpServer): void {
   server.tool(
     "react-to-post",
-    "React to a LinkedIn post with a specific reaction type (like, celebrate, support, love, insightful, funny). Navigates to the post and clicks the reaction button.",
+    "React to a LinkedIn post with a specific reaction type (like, celebrate, support, love, insightful, funny). Navigates to the post and clicks the reaction button. With dryRun, validates the popup opens but skips the click.",
     {
       postUrl: z
         .string()

--- a/packages/mcp/src/tools/react-to-post.ts
+++ b/packages/mcp/src/tools/react-to-post.ts
@@ -24,9 +24,10 @@ export function registerReactToPost(server: McpServer): void {
         .describe(
           "Reaction type to apply (default: like). Options: like, celebrate, support, love, insightful, funny",
         ),
+      dryRun: z.boolean().optional().default(false).describe("When true, detect current reaction state without clicking"),
       ...cdpConnectionSchema,
     },
-    async ({ postUrl, reactionType, cdpPort, cdpHost, allowRemote }) => {
+    async ({ postUrl, reactionType, dryRun, cdpPort, cdpHost, allowRemote }) => {
       try {
         const result = await reactToPost({
           postUrl,
@@ -34,6 +35,7 @@ export function registerReactToPost(server: McpServer): void {
           cdpPort,
           cdpHost,
           allowRemote,
+          dryRun,
         });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {


### PR DESCRIPTION
## Summary

- Add `dryRun` option to `reactToPost()` core operation — navigates to the post, detects current reaction state, but skips the final reaction click
- Add `--dry-run` CLI flag with `[dry-run]` prefixed human-friendly output
- Add `dryRun` field to MCP tool schema with pass-through
- Add `currentReaction` field to `ReactToPostOutput` for dry-run visibility
- Unit tests for all three dry-run code paths (no reaction, different reaction, same reaction)
- E2E tests for CLI and MCP dry-run paths

Closes #725

## Test plan

- [x] `pnpm lint` passes
- [x] `pnpm test` passes (2,497 tests across core/cli/mcp)
- [ ] `pnpm test:e2e` covers CLI `--dry-run --json`, CLI `--dry-run` human-friendly, and MCP `dryRun: true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)