### PR TITLE
(fix) get-feed: accumulate posts across scrolls, fix nextCursor null

### DIFF
--- a/packages/core/src/operations/get-feed.test.ts
+++ b/packages/core/src/operations/get-feed.test.ts
@@ -53,19 +53,33 @@ function rawPost(overrides: Partial<RawDomPost> = {}): RawDomPost {
 /**
  * Create a script-aware evaluate mock that handles the getFeed call sequence:
  * 1. waitForFeedLoad → truthy when posts exist
- * 2. SCRAPE_FEED_POSTS_SCRIPT → posts array (may repeat on scroll)
- * 3. Clipboard interceptor install → void
- * 4. Per-post URL capture: reset → void, scroll → void, menu click → true,
- *    copy-link click → void, clipboard read → url string
+ * 2. Clipboard interceptor install → void
+ * 3. SCRAPE_FEED_POSTS_SCRIPT → indexed posts array (may repeat on scroll)
+ * 4. Per-post URL capture (interleaved): reset → void, scroll → void,
+ *    menu click → true, copy-link click → void, clipboard read → url string
+ *
+ * The scrape mock adds an `_isNew` field to match the DOM-tagging
+ * accumulation strategy.  On the first call all posts are "new"; subsequent
+ * calls return the same posts as "already seen" so that the scroll loop
+ * exits after one iteration.
  */
 function createEvaluateMock(scrapedPosts: RawDomPost[]) {
   let urlIdx = 0;
+  let scrapeCallCount = 0;
   return vi.fn().mockImplementation((script: string) => {
     const s = String(script);
     // Order matters: check most specific patterns first
-    // Scrape script: long script with parseCount function
+    // Scrape script: long script with parseCount function.
+    // Returns posts with discovery-tagging field (_isNew).
     if (s.includes("parseCount")) {
-      return Promise.resolve(scrapedPosts);
+      const isFirstScrape = scrapeCallCount === 0;
+      scrapeCallCount++;
+      return Promise.resolve(
+        scrapedPosts.map((p) => ({
+          ...p,
+          _isNew: isFirstScrape,
+        })),
+      );
     }
     // Clipboard interceptor install
     if (s.includes("navigator.clipboard.writeText")) {
@@ -197,9 +211,14 @@ describe("getFeed", () => {
     ]);
 
     let clipboardReadCount = 0;
+    let retryScrapeCount = 0;
     const evaluate = vi.fn().mockImplementation((script: string) => {
       const s = String(script);
-      if (s.includes("parseCount")) return Promise.resolve([post]);
+      if (s.includes("parseCount")) {
+        const isFirst = retryScrapeCount === 0;
+        retryScrapeCount++;
+        return Promise.resolve([{ ...post, _isNew: isFirst }]);
+      }
       if (s.includes("navigator.clipboard.writeText")) return Promise.resolve(undefined);
       if (s.includes("__capturedClipboard = null")) return Promise.resolve(undefined);
       if (s.includes("Copy link to post")) return Promise.resolve(undefined);
@@ -269,6 +288,116 @@ describe("getFeed", () => {
     const result = await getFeed({ cdpPort: CDP_PORT, count: 2 });
 
     expect(result.nextCursor).toBe("https://www.linkedin.com/feed/update/urn:li:activity:2/");
+  });
+
+  it("returns nextCursor from nearest post with URL when last post URL is null", async () => {
+    // Custom mock: 3 posts where only the first has a successful URL extraction.
+    // The clipboard mock returns a URL for the first post only; all subsequent
+    // reads return null, causing capturePostUrl to genuinely fail for posts 2–3.
+    vi.mocked(discoverTargets).mockResolvedValue([{
+      id: "target-1", type: "page", title: "LinkedIn",
+      url: "https://www.linkedin.com/feed/",
+      description: "", devtoolsFrontendUrl: "",
+    }]);
+
+    const posts = [
+      { ...rawPost({ url: null }), _isNew: true },
+      { ...rawPost({ url: null }), _isNew: true },
+      { ...rawPost({ url: null }), _isNew: true },
+    ];
+    let clipIdx = 0;
+    const clipUrls = ["https://www.linkedin.com/feed/update/urn:li:activity:1/"];
+
+    const evaluate = vi.fn().mockImplementation((script: string) => {
+      const s = String(script);
+      if (s.includes("parseCount")) return Promise.resolve(posts);
+      if (s.includes("navigator.clipboard.writeText")) return Promise.resolve(undefined);
+      if (s.includes("__capturedClipboard = null")) return Promise.resolve(undefined);
+      if (s.includes("Copy link to post")) return Promise.resolve(undefined);
+      if (s === "window.__capturedClipboard") {
+        const url = clipUrls[clipIdx] ?? null;
+        clipIdx++;
+        return Promise.resolve(url);
+      }
+      if (s.includes("btn.click()")) return Promise.resolve(true);
+      if (s.includes("scrollIntoView")) return Promise.resolve(undefined);
+      if (s.includes("mainFeed")) return Promise.resolve(true);
+      return Promise.resolve(null);
+    });
+
+    vi.mocked(CDPClient).mockImplementation(function () {
+      return {
+        connect: vi.fn().mockResolvedValue(undefined),
+        disconnect: vi.fn(),
+        navigate: vi.fn().mockResolvedValue({ frameId: "F1" }),
+        evaluate,
+        send: vi.fn().mockResolvedValue(undefined),
+      } as unknown as CDPClient;
+    });
+
+    const result = await getFeed({ cdpPort: CDP_PORT, count: 2 });
+
+    // Window = [post0 (url:activity:1), post1 (url:null)], hasMore = true
+    // post1.url = null → scan backwards → post0.url
+    expect(result.posts).toHaveLength(2);
+    expect(result.nextCursor).toBe("https://www.linkedin.com/feed/update/urn:li:activity:1/");
+  });
+
+  it("stops extracting URLs once accumulationTarget is reached", async () => {
+    // 20 posts available, but count=3 → accumulationTarget = 4.
+    // Only 4 URL extractions should occur (not 20).
+    const posts = Array.from({ length: 20 }, (_, i) => ({
+      ...rawPost({
+        url: `https://www.linkedin.com/feed/update/urn:li:activity:${String(i + 1)}/`,
+      }),
+      _isNew: true,
+    }));
+
+    let copyLinkClicks = 0;
+    let clipIdx = 0;
+
+    vi.mocked(discoverTargets).mockResolvedValue([{
+      id: "target-1", type: "page", title: "LinkedIn",
+      url: "https://www.linkedin.com/feed/",
+      description: "", devtoolsFrontendUrl: "",
+    }]);
+
+    const evaluate = vi.fn().mockImplementation((script: string) => {
+      const s = String(script);
+      if (s.includes("parseCount")) return Promise.resolve(posts);
+      if (s.includes("navigator.clipboard.writeText")) return Promise.resolve(undefined);
+      if (s.includes("__capturedClipboard = null")) return Promise.resolve(undefined);
+      if (s.includes("Copy link to post")) {
+        copyLinkClicks++;
+        return Promise.resolve(undefined);
+      }
+      if (s === "window.__capturedClipboard") {
+        const url = posts[clipIdx]?.url ?? null;
+        clipIdx++;
+        return Promise.resolve(url);
+      }
+      if (s.includes("btn.click()")) return Promise.resolve(true);
+      if (s.includes("scrollIntoView")) return Promise.resolve(undefined);
+      if (s.includes("mainFeed")) return Promise.resolve(true);
+      return Promise.resolve(null);
+    });
+
+    vi.mocked(CDPClient).mockImplementation(function () {
+      return {
+        connect: vi.fn().mockResolvedValue(undefined),
+        disconnect: vi.fn(),
+        navigate: vi.fn().mockResolvedValue({ frameId: "F1" }),
+        evaluate,
+        send: vi.fn().mockResolvedValue(undefined),
+      } as unknown as CDPClient;
+    });
+
+    const result = await getFeed({ cdpPort: CDP_PORT, count: 3 });
+
+    expect(result.posts).toHaveLength(3);
+    // Target = count + 1 = 4.  Extraction stops as soon as seenUrls.size
+    // reaches 4, so "Copy link to post" is clicked exactly 4 times.
+    expect(copyLinkClicks).toBe(4);
   });
 
   it("returns null nextCursor when all posts are returned", async () => {
@@ -368,27 +497,34 @@ describe("getFeed", () => {
       rawPost({ url: "https://www.linkedin.com/feed/update/urn:li:activity:4/" }),
     ];
 
-    let urnIdx = 0;
+    let clipIdx = 0;
     evaluate.mockReset();
     evaluate.mockImplementation((script: string) => {
       const s = String(script);
       if (s.includes("parseCount")) {
         scrapeCall++;
-        return Promise.resolve(scrapeCall === 1 ? firstScrape : secondScrape);
+        // First scrape: 2 posts, all new.
+        // Second scrape: 4 posts — first 2 already tagged, last 2 new.
+        if (scrapeCall === 1) {
+          return Promise.resolve(firstScrape.map((p) => ({ ...p, _isNew: true })));
+        }
+        return Promise.resolve(secondScrape.map((p, i) => ({
+          ...p, _isNew: i >= firstScrape.length,
+        })));
       }
-      if (s.includes("embed-modal")) {
-        urnIdx++;
-        return Promise.resolve(`urn:li:activity:${String(urnIdx)}`);
+      if (s.includes("navigator.clipboard.writeText")) return Promise.resolve(undefined);
+      if (s.includes("__capturedClipboard = null")) return Promise.resolve(undefined);
+      if (s.includes("Copy link to post")) return Promise.resolve(undefined);
+      if (s === "window.__capturedClipboard") {
+        // Return URLs from the combined post list in discovery order
+        const allUrls = [...firstScrape, ...secondScrape.slice(firstScrape.length)];
+        const url = allUrls[clipIdx]?.url ?? null;
+        clipIdx++;
+        return Promise.resolve(url);
       }
-      if (s.includes("btn.click()")) {
-        return Promise.resolve(true);
-      }
-      if (s.includes("scrollIntoView")) {
-        return Promise.resolve(undefined);
-      }
-      if (s.includes("mainFeed")) {
-        return Promise.resolve(true);
-      }
+      if (s.includes("btn.click()")) return Promise.resolve(true);
+      if (s.includes("scrollIntoView")) return Promise.resolve(undefined);
+      if (s.includes("mainFeed")) return Promise.resolve(true);
       return Promise.resolve(null);
     });
 
@@ -412,27 +548,31 @@ describe("getFeed", () => {
       rawPost({ url: "https://www.linkedin.com/feed/update/urn:li:activity:1/" }),
       rawPost({ url: "https://www.linkedin.com/feed/update/urn:li:activity:2/" }),
     ];
-    let urnIdx = 0;
+    let staleScrapeCount = 0;
+    let staleClipIdx = 0;
 
     evaluate.mockReset();
     evaluate.mockImplementation((script: string) => {
       const s = String(script);
       if (s.includes("parseCount")) {
-        return Promise.resolve(fixedPosts);
+        // First call: posts are new.  Subsequent: same posts, not new.
+        const isFirst = staleScrapeCount === 0;
+        staleScrapeCount++;
+        return Promise.resolve(
+          fixedPosts.map((p) => ({ ...p, _isNew: isFirst })),
+        );
       }
-      if (s.includes("embed-modal")) {
-        urnIdx++;
-        return Promise.resolve(`urn:li:activity:${String(urnIdx)}`);
+      if (s.includes("navigator.clipboard.writeText")) return Promise.resolve(undefined);
+      if (s.includes("__capturedClipboard = null")) return Promise.resolve(undefined);
+      if (s.includes("Copy link to post")) return Promise.resolve(undefined);
+      if (s === "window.__capturedClipboard") {
+        const url = fixedPosts[staleClipIdx]?.url ?? null;
+        staleClipIdx++;
+        return Promise.resolve(url);
       }
-      if (s.includes("btn.click()")) {
-        return Promise.resolve(true);
-      }
-      if (s.includes("scrollIntoView")) {
-        return Promise.resolve(undefined);
-      }
-      if (s.includes("mainFeed")) {
-        return Promise.resolve(true);
-      }
+      if (s.includes("btn.click()")) return Promise.resolve(true);
+      if (s.includes("scrollIntoView")) return Promise.resolve(undefined);
+      if (s.includes("mainFeed")) return Promise.resolve(true);
       return Promise.resolve(null);
     });
 

--- a/packages/core/src/operations/get-feed.ts
+++ b/packages/core/src/operations/get-feed.ts
@@ -73,6 +73,7 @@ export interface RawDomPost {
  */
 const SCRAPE_FEED_POSTS_SCRIPT = `(() => {
   const posts = [];
+  if (window.__lhrNextIdx == null) window.__lhrNextIdx = 0;
 
   // --- Step 1: Find the feed list via data-testid ---
   const feedList = document.querySelector('[data-testid="mainFeed"]');
@@ -90,6 +91,19 @@ const SCRAPE_FEED_POSTS_SCRIPT = `(() => {
     // Detect real posts: must have a three-dot menu button
     const menuBtn = item.querySelector('button[aria-label^="Open control menu for post"]');
     if (!menuBtn) continue;
+
+    // --- Discovery tagging ---
+    // Tag each listitem with a unique index on first discovery so that
+    // posts can be accumulated across scroll iterations despite LinkedIn
+    // virtualising off-screen items out of the DOM.  The index value
+    // itself isn't consumed by the Node-side logic — it's only used as
+    // the DOM attribute payload so that already-seen items can be
+    // recognised on subsequent scrapes.
+    let _isNew = false;
+    if (!item.hasAttribute('data-lhr-idx')) {
+      item.setAttribute('data-lhr-idx', String(window.__lhrNextIdx++));
+      _isNew = true;
+    }
 
     // --- Author info ---
     let authorName = null;
@@ -176,6 +190,7 @@ const SCRAPE_FEED_POSTS_SCRIPT = `(() => {
     }
 
     posts.push({
+      _isNew: _isNew,
       url: null,
       authorName: authorName,
       authorHeadline: authorHeadline,
@@ -499,26 +514,94 @@ export async function getFeed(
     // Wait for the initial feed content to render
     await waitForFeedLoad(client);
 
-    // Collect posts — scroll to load more if needed
+    // Collect posts — scroll to load more if needed.
+    //
+    // LinkedIn's main feed virtualises off-screen posts out of the DOM,
+    // so each point-in-time scrape only sees ~8-13 items.  To accumulate
+    // beyond that cap we tag discovered listitems with `data-lhr-idx`
+    // and interleave URL extraction with scrolling so that each post's
+    // URL is captured while the element is still visible.
+    //
+    // The target is counted in URL-bearing posts only (`seenUrls.size`).
+    // Posts whose URL extraction failed are still accumulated for
+    // completeness but don't count toward the target — otherwise a run
+    // of transient failures could make the loop exit with a window of
+    // null-URL posts and no usable cursor.
+    //
+    // We need `count` posts plus one extra so the hasMore check has a
+    // post beyond the result window.  Cursor calls use `count * 2 + 1`:
+    // up to `count` posts may be consumed locating the cursor, then
+    // `count` more for the next page, plus one for hasMore.
     const maxScrollAttempts = 10;
-    let allPosts: RawDomPost[] = [];
-    let previousCount = 0;
+    const allPosts: RawDomPost[] = [];
+    const seenUrls = new Set<string>();
+    const accumulationTarget = cursor ? count * 2 + 1 : count + 1;
+    let previousUrlCount = 0;
+
+    type TaggedPost = RawDomPost & { _isNew: boolean };
 
     // If resuming with a cursor, we need to scroll past already-seen posts
     const cursorUrl = cursor;
 
+    // Install the clipboard interceptor before the scroll loop so that
+    // URL extraction can happen inside each iteration.
+    await installClipboardInterceptor(client);
+
     for (let scroll = 0; scroll <= maxScrollAttempts; scroll++) {
-      const countBeforeScroll = previousCount;
-      const scraped = await client.evaluate<RawDomPost[]>(SCRAPE_FEED_POSTS_SCRIPT);
-      allPosts = scraped ?? [];
+      const countBefore = allPosts.length;
 
-      // Determine which posts to return
-      const available = allPosts.length;
-      if (available >= count && !cursorUrl) break;
+      // Scrape visible posts — the script tags each listitem with a
+      // discovery index and reports which items are newly discovered.
+      const scraped = await client.evaluate<TaggedPost[]>(SCRAPE_FEED_POSTS_SCRIPT);
+      const batch = scraped ?? [];
 
-      // No new posts appeared after scroll — stop
-      if (allPosts.length === previousCount && scroll > 0) break;
-      previousCount = allPosts.length;
+      // Extract URLs for newly discovered posts while they are visible.
+      // `domIdx` is the position within the current batch which matches
+      // the DOM order of visible menu buttons.
+      //
+      // To avoid extracting URLs for far more posts than needed (each
+      // extraction opens the three-dot menu — ~1-2 s per post), we stop
+      // once we have enough URL-bearing posts.
+      let extractedInBatch = 0;
+      for (let domIdx = 0; domIdx < batch.length; domIdx++) {
+        const post = batch[domIdx];
+        if (!post?._isNew) continue;
+
+        // Stop extracting once we have enough URL-bearing posts
+        if (seenUrls.size >= accumulationTarget) break;
+
+        if (extractedInBatch > 0) await gaussianDelay(550, 125, 300, 800);
+        await maybeBreak();
+
+        const url = await retryInteraction(
+          () => capturePostUrl(client, domIdx, mouse),
+        );
+        if (url) {
+          post.url = url;
+        }
+        extractedInBatch++;
+
+        // Accumulate the post (dedup by URL when available)
+        if (post.url) {
+          if (!seenUrls.has(post.url)) {
+            seenUrls.add(post.url);
+            allPosts.push(post);
+          }
+        } else {
+          // URL extraction failed — include for completeness but don't
+          // count toward accumulationTarget (see comment above).
+          allPosts.push(post);
+        }
+      }
+
+      // Enough URL-bearing posts accumulated?
+      if (seenUrls.size >= accumulationTarget) break;
+
+      // No new URL-bearing posts after scroll — stop
+      if (seenUrls.size === previousUrlCount && scroll > 0) break;
+
+      const newPostCount = allPosts.length - countBefore;
+      previousUrlCount = seenUrls.size;
 
       // Scroll to load more
       if (scroll < maxScrollAttempts) {
@@ -527,7 +610,6 @@ export async function getFeed(
         // Progressive session fatigue: delays increase with each scroll
         const fatigueMultiplier = 1 + scroll * 0.1;
         // Scale delay by newly visible content volume
-        const newPostCount = allPosts.length - countBeforeScroll;
         const contentBonus = Math.min(
           newPostCount * gaussianBetween(350, 75, 200, 500),
           3_000,
@@ -549,25 +631,6 @@ export async function getFeed(
       }
     }
 
-    // --- URL extraction phase ---
-    // Open each post's three-dot menu, click "Copy link to post", and
-    // derive the URN from the captured URL.  This populates the urn/url
-    // fields that the scrape script left null.
-    await installClipboardInterceptor(client);
-
-    for (let i = 0; i < allPosts.length; i++) {
-      const post = allPosts[i];
-      if (!post) continue;
-      if (i > 0) await gaussianDelay(550, 125, 300, 800); // Inter-post delay
-      await maybeBreak();
-      const url = await retryInteraction(
-        () => capturePostUrl(client, i, mouse),
-      );
-      if (url) {
-        post.url = url;
-      }
-    }
-
     // Slice the result window
     let startIdx = 0;
     if (cursorUrl) {
@@ -580,10 +643,20 @@ export async function getFeed(
     const window = allPosts.slice(startIdx, startIdx + count);
     const posts = mapRawPosts(window);
 
-    // Determine next cursor
+    // Determine next cursor — scan backwards for the nearest post with a
+    // non-null URL so that a single failed URL extraction doesn't block
+    // pagination when more posts are available.
     const hasMore = startIdx + count < allPosts.length;
-    const lastPost = window[window.length - 1];
-    const nextCursor = hasMore && lastPost ? lastPost.url : null;
+    let nextCursor: string | null = null;
+    if (hasMore) {
+      for (let i = window.length - 1; i >= 0; i--) {
+        const postUrl = window[i]?.url;
+        if (postUrl) {
+          nextCursor = postUrl;
+          break;
+        }
+      }
+    }
 
     await gaussianDelay(800, 300, 300, 1_800); // Post-action dwell
     return { posts, nextCursor };


### PR DESCRIPTION
## Summary

- **DOM-tag accumulation**: The scrape script now stamps each feed listitem with `data-lhr-idx` on first discovery and reports `_isNew`. URL extraction is interleaved with scrolling so URLs are captured while posts are still visible in the DOM. Posts accumulate across scroll iterations via URL-based dedup, breaking the ~8-13 post virtualisation cap.
- **nextCursor fallback**: When the last post in the result window has a null URL (extraction failure), scans backwards for the nearest post with a non-null URL instead of returning `null`.

### Root cause

LinkedIn's main feed virtualises off-screen posts out of the DOM. The previous strategy replaced `allPosts` on each scrape iteration (`allPosts = scraped`), so the array never exceeded the ~8-13 posts visible at any time. With `count: 25`, `hasMore = (0 + 25 < 13)` evaluated to `false`, producing `nextCursor: null`.

### What this does NOT fix (follow-up)

Cross-call cursor resolution: each `getFeed` call navigates to a fresh feed page, and LinkedIn reshuffles on each load, so a cursor URL from call N is unlikely to be found in call N+1's DOM. In-session continuation (skipping navigation on cursor calls) is tracked as a separate enhancement.

Closes #731

## Test plan

- [x] Unit test: `returns nextCursor from nearest post with URL when last post URL is null` (new)
- [x] Unit test: all 35 existing get-feed tests pass (scroll, stale-detection, cursor, pagination)
- [x] Full monorepo test suite: 475 tests pass
- [x] Lint clean
- [ ] E2E: run `pnpm test:e2e:file get-feed` locally to verify real LinkedIn feed pagination

🤖 Generated with [Claude Code](https://claude.com/claude-code)