### PR TITLE
(chore) release: bump version to 0.14.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "lhremote",
       "source": "./",
       "description": "LinkedHelper automation toolkit — MCP server and workflow guidance for Claude Code",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "author": {
         "name": "Alexey Pelykh"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lhremote",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "description": "LinkedHelper automation toolkit — MCP server and workflow guidance for Claude Code",
   "author": {
     "name": "Alexey Pelykh",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/alexey-pelykh/lhremote",
     "source": "github"
   },
-  "version": "0.13.0",
+  "version": "0.14.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "lhremote",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary

- Bump `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, and `server.json` from `0.13.0` to `0.14.0`
- Prepares minor release tag `v0.14.0`

## Changes since v0.13.0

- c04f0c1 (fix) get-feed: accumulate posts across scrolls, fix nextCursor null

## Test plan

- [x] `pnpm lint` passes locally
- [ ] CI build + lint + test matrix green
- [ ] After merge: create GitHub Release `v0.14.0` to trigger npm publish via `release.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)