### PR TITLE
(feat) core,mcp,cli: support LinkedHelper 2.113.28 workspaces

### DIFF
--- a/packages/cli/src/handlers/index.ts
+++ b/packages/cli/src/handlers/index.ts
@@ -61,6 +61,7 @@ export { handleSearchPosts } from "./search-posts.js";
 export { handleListCollections } from "./list-collections.js";
 export { handleLaunchApp } from "./launch-app.js";
 export { handleListAccounts } from "./list-accounts.js";
+export { handleListWorkspaces } from "./list-workspaces.js";
 export { handleRemovePeopleFromCollection } from "./remove-people-from-collection.js";
 export { handleQuitApp } from "./quit-app.js";
 export { handleReactToPost } from "./react-to-post.js";

--- a/packages/cli/src/handlers/list-workspaces.test.ts
+++ b/packages/cli/src/handlers/list-workspaces.test.ts
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return {
+    ...actual,
+    LauncherService: vi.fn(),
+    resolveAppPort: vi.fn(),
+  };
+});
+
+import {
+  LauncherService,
+  LinkedHelperNotRunningError,
+  resolveAppPort,
+  type Workspace,
+} from "@lhremote/core";
+
+import { handleListWorkspaces } from "./list-workspaces.js";
+import { mockLauncher } from "./testing/mock-helpers.js";
+
+const SAMPLE_WORKSPACES: Workspace[] = [
+  {
+    id: 473509,
+    name: "Personal workspace",
+    deleted: false,
+    workspaceUser: {
+      id: 518351,
+      userId: 438509,
+      workspaceId: 473509,
+      role: "owner",
+      deleted: false,
+    },
+    selected: false,
+  },
+  {
+    id: 20338,
+    name: "PELYKH Consulting",
+    deleted: false,
+    workspaceUser: {
+      id: 33440,
+      userId: 438509,
+      workspaceId: 20338,
+      role: "admin",
+      deleted: false,
+    },
+    selected: true,
+  },
+];
+
+describe("handleListWorkspaces", () => {
+  const originalExitCode = process.exitCode;
+
+  beforeEach(() => {
+    process.exitCode = undefined;
+    vi.clearAllMocks();
+    vi.mocked(resolveAppPort).mockResolvedValue(9222);
+  });
+
+  afterEach(() => {
+    process.exitCode = originalExitCode;
+    vi.restoreAllMocks();
+  });
+
+  it("prints JSON array with --json", async () => {
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockReturnValue(true);
+
+    mockLauncher({
+      listWorkspaces: vi.fn().mockResolvedValue(SAMPLE_WORKSPACES),
+    });
+
+    await handleListWorkspaces({ json: true });
+
+    const firstCall = stdoutSpy.mock.calls[0] as [string];
+    expect(JSON.parse(firstCall[0])).toEqual(SAMPLE_WORKSPACES);
+  });
+
+  it("prints marker and role in the default formatted table", async () => {
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockReturnValue(true);
+
+    mockLauncher({
+      listWorkspaces: vi.fn().mockResolvedValue(SAMPLE_WORKSPACES),
+    });
+
+    await handleListWorkspaces({});
+
+    const writes = stdoutSpy.mock.calls.map((c) => c[0] as string);
+    expect(writes).toContain("  473509\tPersonal workspace\t[owner]\n");
+    expect(writes).toContain("* 20338\tPELYKH Consulting\t[admin]\n");
+  });
+
+  it("prints message when no workspaces", async () => {
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockReturnValue(true);
+
+    mockLauncher({ listWorkspaces: vi.fn().mockResolvedValue([]) });
+
+    await handleListWorkspaces({});
+
+    expect(stdoutSpy).toHaveBeenCalledWith("No workspaces found\n");
+  });
+
+  it("sets exitCode 1 when not running", async () => {
+    const stderrSpy = vi
+      .spyOn(process.stderr, "write")
+      .mockReturnValue(true);
+
+    vi.mocked(LauncherService).mockImplementation(function () {
+      return {
+        connect: vi
+          .fn()
+          .mockRejectedValue(new LinkedHelperNotRunningError(9222)),
+        disconnect: vi.fn(),
+      } as unknown as LauncherService;
+    });
+
+    await handleListWorkspaces({});
+
+    expect(process.exitCode).toBe(1);
+    expect(stderrSpy).toHaveBeenCalled();
+  });
+
+  it("disconnects after successful call", async () => {
+    vi.spyOn(process.stdout, "write").mockReturnValue(true);
+
+    const { disconnect } = mockLauncher({
+      listWorkspaces: vi.fn().mockResolvedValue([]),
+    });
+
+    await handleListWorkspaces({});
+
+    expect(disconnect).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/cli/src/handlers/list-workspaces.ts
+++ b/packages/cli/src/handlers/list-workspaces.ts
@@ -8,7 +8,9 @@ import { errorMessage, LauncherService, resolveAppPort } from "@lhremote/core";
  *
  * Lists LinkedHelper workspaces the current LH user belongs to.
  * Workspaces are a LinkedHelper 2.113.x feature; on earlier versions
- * the command prints nothing (no workspaces exist).
+ * the workspace service is absent, the returned list is empty, and
+ * the command prints "No workspaces found" (the same output as a
+ * modern launcher where the user happens to belong to no workspaces).
  */
 export async function handleListWorkspaces(options: {
   cdpPort?: number;

--- a/packages/cli/src/handlers/list-workspaces.ts
+++ b/packages/cli/src/handlers/list-workspaces.ts
@@ -3,13 +3,18 @@
 
 import { errorMessage, LauncherService, resolveAppPort } from "@lhremote/core";
 
-/** Handle the {@link https://github.com/alexey-pelykh/lhremote#account--instance | list-accounts} CLI command. */
-export async function handleListAccounts(options: {
+/**
+ * Handle the `list-workspaces` CLI command.
+ *
+ * Lists LinkedHelper workspaces the current LH user belongs to.
+ * Workspaces are a LinkedHelper 2.113.x feature; on earlier versions
+ * the command prints nothing (no workspaces exist).
+ */
+export async function handleListWorkspaces(options: {
   cdpPort?: number;
   cdpHost?: string;
   allowRemote?: boolean;
   json?: boolean;
-  allWorkspaces?: boolean;
 }): Promise<void> {
   let port: number;
   try {
@@ -36,22 +41,17 @@ export async function handleListAccounts(options: {
   }
 
   try {
-    const accounts = await launcher.listAccounts(
-      options.allWorkspaces ? { includeAllWorkspaces: true } : undefined,
-    );
+    const workspaces = await launcher.listWorkspaces();
 
     if (options.json) {
-      process.stdout.write(JSON.stringify(accounts, null, 2) + "\n");
-    } else if (accounts.length === 0) {
-      process.stdout.write("No accounts found\n");
+      process.stdout.write(JSON.stringify(workspaces, null, 2) + "\n");
+    } else if (workspaces.length === 0) {
+      process.stdout.write("No workspaces found\n");
     } else {
-      for (const account of accounts) {
-        const email = account.email ? ` <${account.email}>` : "";
-        const workspace = account.workspaceName
-          ? ` [${account.workspaceName}]`
-          : "";
+      for (const ws of workspaces) {
+        const marker = ws.selected ? "*" : " ";
         process.stdout.write(
-          `${String(account.id)}\t${account.name}${email}${workspace}\n`,
+          `${marker} ${String(ws.id)}\t${ws.name}\t[${ws.workspaceUser.role}]\n`,
         );
       }
     }

--- a/packages/cli/src/handlers/testing/mock-helpers.ts
+++ b/packages/cli/src/handlers/testing/mock-helpers.ts
@@ -47,6 +47,7 @@ export function mockLauncher(
       connect: vi.fn().mockResolvedValue(undefined),
       disconnect,
       listAccounts: vi.fn().mockResolvedValue([]),
+      listWorkspaces: vi.fn().mockResolvedValue([]),
       ...overrides,
     } as unknown as LauncherService;
   });

--- a/packages/cli/src/program.test.ts
+++ b/packages/cli/src/program.test.ts
@@ -40,6 +40,7 @@ describe("createProgram", () => {
     expect(commandNames).toContain("launch-app");
     expect(commandNames).toContain("quit-app");
     expect(commandNames).toContain("list-accounts");
+    expect(commandNames).toContain("list-workspaces");
     expect(commandNames).toContain("start-instance");
     expect(commandNames).toContain("stop-instance");
     expect(commandNames).toContain("query-profile");
@@ -105,7 +106,7 @@ describe("createProgram", () => {
     expect(commandNames).toContain("dismiss-feed-post");
     expect(commandNames).toContain("unfollow-from-feed");
     expect(commandNames).toContain("hide-feed-author");
-    expect(commandNames).toHaveLength(70);
+    expect(commandNames).toHaveLength(71);
   });
 
   describe("launch-app", () => {

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -62,6 +62,7 @@ import {
   handleLaunchApp,
   handleListAccounts,
   handleListReferenceData,
+  handleListWorkspaces,
   handleQueryMessages,
   handleQueryProfile,
   handleQueryProfiles,
@@ -149,12 +150,22 @@ export function createProgram(): Command {
 
   program
     .command("list-accounts")
-    .description("List LinkedHelper accounts")
+    .description("List LinkedHelper accounts (selected workspace by default)")
     .option("--cdp-port <port>", "CDP debugging port (auto-discovered when omitted)", parsePositiveInt)
     .option("--cdp-host <host>", "CDP host (default: 127.0.0.1)")
     .option("--allow-remote", "SECURITY: allow non-loopback CDP connections (enables remote code execution on target)")
     .option("--json", "Output as JSON")
+    .option("--all-workspaces", "List accounts across every workspace the LH user belongs to, not just the selected one (LinkedHelper 2.113.x+)")
     .action(handleListAccounts);
+
+  program
+    .command("list-workspaces")
+    .description("List LinkedHelper workspaces the current user belongs to (2.113.x+)")
+    .option("--cdp-port <port>", "CDP debugging port (auto-discovered when omitted)", parsePositiveInt)
+    .option("--cdp-host <host>", "CDP host (default: 127.0.0.1)")
+    .option("--allow-remote", "SECURITY: allow non-loopback CDP connections (enables remote code execution on target)")
+    .option("--json", "Output as JSON")
+    .action(handleListWorkspaces);
 
   program
     .command("start-instance")

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -93,6 +93,20 @@ export type {
   ThrottleStatus,
   UIHealthStatus,
   UrlBuilderResult,
+  Workspace,
+  WorkspaceAccess,
+  WorkspaceAccessLevel,
+  WorkspaceInvitationStatus,
+  WorkspaceUser,
+  WorkspaceUserRole,
+} from "./types/index.js";
+
+export {
+  canStartInstance,
+  isOwnerOrExtended,
+  isRestrictedOrHigher,
+  isViewOnlyOrHigher,
+  WORKSPACE_ACCESS_LEVEL_ORDER,
 } from "./types/index.js";
 
 // Services

--- a/packages/core/src/services/launcher.test.ts
+++ b/packages/core/src/services/launcher.test.ts
@@ -361,6 +361,140 @@ describe("LauncherService", () => {
       expect(listCall).toBeDefined();
       expect(listCall?.[1]).toBe(true);
     });
+
+    it("emits includeAll=false by default", async () => {
+      await service.connect();
+      mockEvaluate.mockClear();
+      nextEvaluateResult = [];
+
+      await service.listAccounts();
+
+      const listCall = mockEvaluate.mock.calls.find(
+        (c) => typeof c[0] === "string" && c[0].includes("const includeAll"),
+      );
+      expect(listCall?.[0]).toContain("const includeAll = false");
+    });
+
+    it("emits includeAll=true when includeAllWorkspaces option is set", async () => {
+      await service.connect();
+      mockEvaluate.mockClear();
+      nextEvaluateResult = [];
+
+      await service.listAccounts({ includeAllWorkspaces: true });
+
+      const listCall = mockEvaluate.mock.calls.find(
+        (c) => typeof c[0] === "string" && c[0].includes("const includeAll"),
+      );
+      expect(listCall?.[0]).toContain("const includeAll = true");
+    });
+
+    it("propagates workspace fields in returned accounts", async () => {
+      await service.connect();
+      nextEvaluateResult = [
+        {
+          id: 363386,
+          liId: 363386,
+          name: "Alexey",
+          email: "alexey@example.com",
+          workspaceId: 20338,
+          workspaceName: "PELYKH Consulting",
+          workspaceAccess: { level: "owner" as const },
+        },
+      ];
+
+      const accounts = await service.listAccounts();
+
+      expect(accounts).toHaveLength(1);
+      expect(accounts[0]).toMatchObject({
+        id: 363386,
+        workspaceId: 20338,
+        workspaceName: "PELYKH Consulting",
+        workspaceAccess: { level: "owner" },
+      });
+    });
+
+    it("throws ServiceError when cross-workspace listing fails", async () => {
+      await service.connect();
+      nextEvaluateResult = { __error: "cross-workspace listing failed: boom" };
+
+      await expect(
+        service.listAccounts({ includeAllWorkspaces: true }),
+      ).rejects.toThrow(ServiceError);
+    });
+  });
+
+  describe("listWorkspaces", () => {
+    it("returns parsed workspaces", async () => {
+      await service.connect();
+      nextEvaluateResult = [
+        {
+          id: 473509,
+          name: "Personal workspace",
+          deleted: false,
+          workspaceUser: {
+            id: 518351,
+            userId: 438509,
+            workspaceId: 473509,
+            role: "owner",
+            deleted: false,
+          },
+          selected: false,
+        },
+        {
+          id: 20338,
+          name: "PELYKH Consulting",
+          deleted: false,
+          workspaceUser: {
+            id: 33440,
+            userId: 438509,
+            workspaceId: 20338,
+            role: "owner",
+            deleted: false,
+          },
+          selected: true,
+        },
+      ];
+
+      const workspaces = await service.listWorkspaces();
+
+      expect(workspaces).toHaveLength(2);
+      const selected = workspaces.find((w) => w.selected);
+      expect(selected?.id).toBe(20338);
+      expect(selected?.workspaceUser.role).toBe("owner");
+    });
+
+    it("returns empty array on a launcher without workspace service", async () => {
+      await service.connect();
+      nextEvaluateResult = [];
+
+      const workspaces = await service.listWorkspaces();
+
+      expect(workspaces).toEqual([]);
+    });
+
+    it("throws WrongPortError when webpack registry is unavailable", async () => {
+      await service.connect();
+      nextEvaluateResult = null;
+
+      await expect(service.listWorkspaces()).rejects.toThrow(WrongPortError);
+    });
+
+    it("throws ServiceError when not connected", async () => {
+      await expect(service.listWorkspaces()).rejects.toThrow(ServiceError);
+    });
+
+    it("embeds the workspace service resolution snippet", async () => {
+      await service.connect();
+      nextEvaluateResult = [];
+
+      await service.listWorkspaces();
+
+      const call = mockEvaluate.mock.calls.find(
+        (c) => typeof c[0] === "string" && c[0].includes("_workspacesBS"),
+      );
+      expect(call).toBeDefined();
+      expect(call?.[1]).toBe(true);
+    });
   });
 
   describe("dismissInstanceDialog", () => {

--- a/packages/core/src/services/launcher.ts
+++ b/packages/core/src/services/launcher.ts
@@ -10,6 +10,7 @@ import type {
   PopupState,
   StartInstanceResult,
   UIHealthStatus,
+  Workspace,
 } from "../types/index.js";
 import {
   LinkedHelperNotRunningError,
@@ -29,20 +30,92 @@ import {
  */
 export class LauncherService {
   /**
-   * CDP expression snippet that waits for the webpack module registry
-   * and sets `wpRequire` in the enclosing scope.  Callers must check
-   * `wpRequire` for null and handle the failure case themselves.
+   * CDP snippet that resolves LinkedHelper frontend service singletons
+   * via the webpack module registry and exposes them on `lhSvc`.
+   *
+   * The snippet is designed to be cache-aware: the first invocation
+   * per page navigation performs a marker-based scan of the webpack
+   * module registry and stashes the resolved services on
+   * `window.__lhrServices`. Subsequent invocations read from the cache.
+   *
+   * **Why marker-based?** Webpack module IDs are not stable across
+   * LinkedHelper releases. Between v2.113.11 and v2.113.28, three of
+   * the four service modules we depend on shifted IDs. The only
+   * reliable way to locate services is to scan for module exports
+   * with characteristic fields (e.g. `_workspacesBS` for the workspace
+   * service). See `research/linkedhelper/architecture/V2113-WEBPACK-MODULE-IDS.md`.
+   *
+   * Each resolved service is exposed under a dotless alias for quick
+   * access in subsequent expressions:
+   *
+   * - `lhSvc.auth` — authService (userId, role, isLoggedIn)
+   * - `lhSvc.user` — userService (currentUserBS, fetchUser)
+   * - `lhSvc.runningLi` — runningLiAccountsService
+   *   (extendedLinkedInAccountsBS, getLinkedInAccount, startLinkedInAccountLocal)
+   * - `lhSvc.feSettings` — frontendSettingsService (getFrontendSettings, _cacheBS)
+   * - `lhSvc.workspace` — workspaceService
+   *   (_workspacesBS, _selectedWorkspaceBS, api, refreshWorkspaces); may be
+   *   `null` on LinkedHelper versions that predate workspaces
+   *
+   * Callers must check `lhSvc` for null and handle the failure case.
    */
-  private static readonly WEBPACK_INIT = `
+  private static readonly LH_SERVICES_INIT = `
     const _wpDeadline = Date.now() + 15000;
     while (!window.webpackChunk_linked_helper_front && Date.now() < _wpDeadline) {
       await new Promise(r => setTimeout(r, 250));
     }
-    let wpRequire = null;
-    if (window.webpackChunk_linked_helper_front) {
+    let lhSvc = null;
+    if (window.__lhrServices) {
+      lhSvc = window.__lhrServices;
+    } else if (window.webpackChunk_linked_helper_front) {
+      let _wpReq = null;
       window.webpackChunk_linked_helper_front.push(
-        [[Symbol()], {}, (req) => { wpRequire = req; }]
+        [[Symbol()], {}, (req) => { _wpReq = req; }]
       );
+      if (_wpReq) {
+        const _specs = {
+          auth:        { exportKey: 'authService',              markers: ['userId', 'role'] },
+          user:        { exportKey: 'default',                  markers: ['currentUserBS', 'fetchUser'] },
+          runningLi:   { exportKey: 'runningLiAccountsService', markers: ['extendedLinkedInAccountsBS', 'getLinkedInAccount'] },
+          feSettings:  { exportKey: 'frontendSettingsService',  markers: ['getFrontendSettings', '_cacheBS'] },
+          workspace:   { exportKey: 'A',                        markers: ['_workspacesBS', '_selectedWorkspaceBS'] },
+        };
+        const _resolved = {};
+        for (const _id of Object.keys(_wpReq.m || {})) {
+          let _mod;
+          try { _mod = _wpReq(_id); } catch (_e) { continue; }
+          if (!_mod) continue;
+          for (const _name of Object.keys(_specs)) {
+            if (_resolved[_name]) continue;
+            const _spec = _specs[_name];
+            const _v = _mod[_spec.exportKey];
+            if (_v && typeof _v === 'object' && _spec.markers.every(m => m in _v)) {
+              _resolved[_name] = _v;
+              continue;
+            }
+            for (const _k of Object.keys(_mod)) {
+              const _w = _mod[_k];
+              if (!_w || typeof _w !== 'object') continue;
+              if (_spec.markers.every(m => m in _w)) {
+                _resolved[_name] = _w;
+                break;
+              }
+            }
+          }
+          if (Object.keys(_resolved).length === Object.keys(_specs).length) break;
+        }
+        if (_resolved.auth && _resolved.user && _resolved.runningLi && _resolved.feSettings) {
+          // workspace may legitimately be missing on pre-2.113.x launchers
+          lhSvc = {
+            auth: _resolved.auth,
+            user: _resolved.user,
+            runningLi: _resolved.runningLi,
+            feSettings: _resolved.feSettings,
+            workspace: _resolved.workspace || null,
+          };
+          window.__lhrServices = lhSvc;
+        }
+      }
     }`;
 
   private readonly port: number;
@@ -144,15 +217,15 @@ export class LauncherService {
           const remote = require('@electron/remote');
           const mainWindow = remote.getGlobal('mainWindow');
 
-          ${LauncherService.WEBPACK_INIT}
-          if (!wpRequire) {
-            return { success: false, error: 'webpack module registry not available' };
+          ${LauncherService.LH_SERVICES_INIT}
+          if (!lhSvc) {
+            return { success: false, error: 'LinkedHelper frontend services not available (webpack registry empty or core services missing)' };
           }
 
-          const authService = wpRequire(2742).authService;
-          const userService = wpRequire(75381).userService;
-          const liAccountsSvc = wpRequire(44354).runningLiAccountsService;
-          const feSettingsSvc = wpRequire(81954).frontendSettingsService;
+          const authService = lhSvc.auth;
+          const userService = lhSvc.user;
+          const liAccountsSvc = lhSvc.runningLi;
+          const feSettingsSvc = lhSvc.feSettings;
 
           // 2. Get the account object from the service cache.
           //    Using refetch: false because the LH backend API now
@@ -173,7 +246,15 @@ export class LauncherService {
             }
           }
           if (!account) {
-            return { success: false, error: 'Account not found in cache after 30s' };
+            return { success: false, error: 'Account not found in cache after 30s. On v2.113.x+, the running-accounts cache is filtered to the selected workspace; the account may be in a different workspace.' };
+          }
+
+          // 2a. Gate on workspace access level (v2.113.x+).
+          //     The launcher refuses to start instances with view_only
+          //     or no_access, so fail fast with a clear error.
+          const accessLevel = account.workspaceAccess?.level;
+          if (accessLevel === 'view_only' || accessLevel === 'no_access') {
+            return { success: false, error: 'Workspace access level "' + accessLevel + '" does not allow starting an instance (requires restricted or higher)' };
           }
 
           // 3. Read userId and user profile
@@ -274,39 +355,95 @@ export class LauncherService {
   }
 
   /**
-   * List all accounts configured in LinkedHelper.
+   * List LinkedHelper accounts visible to the current LH user.
    *
-   * Accounts are read from the renderer-side webpack service cache
-   * (`runningLiAccountsService.extendedLinkedInAccountsBS`).  The
-   * launcher populates this cache on startup via IPC; we poll until
-   * it becomes available rather than calling `refetchLinkedInAccounts`
-   * (whose backend API now rejects the old embed format with 400).
+   * Default behaviour (back-compat with pre-workspace clients):
+   * returns only accounts in the **currently selected workspace** —
+   * the same set the launcher UI shows. This reflects the state of
+   * `runningLiAccountsService.extendedLinkedInAccountsBS`, which
+   * LinkedHelper 2.113.x filters to the selected workspace.
+   *
+   * With `{ includeAllWorkspaces: true }`, queries every workspace
+   * the user belongs to and returns the union of owned LinkedIn
+   * accounts (requires `workspaceService.api.getWorkspaceUserOwnedLiAccounts`,
+   * available only on v2.113.x+). Use this when you need to drive
+   * accounts that live outside the currently selected workspace.
+   *
+   * @param options.includeAllWorkspaces If `true`, enumerate all
+   *   workspaces and list accounts across them. Defaults to `false`.
    */
-  async listAccounts(): Promise<Account[]> {
+  async listAccounts(options?: {
+    includeAllWorkspaces?: boolean;
+  }): Promise<Account[]> {
     const client = this.ensureConnected();
+
+    const includeAllWorkspaces = options?.includeAllWorkspaces ?? false;
 
     const accounts = await this.launcherEvaluate<Account[] | null>(
       client,
       `(async () => {
-        ${LauncherService.WEBPACK_INIT}
-        if (!wpRequire) return null;
+        ${LauncherService.LH_SERVICES_INIT}
+        if (!lhSvc) return null;
 
-        const svc = wpRequire(44354).runningLiAccountsService;
+        const svc = lhSvc.runningLi;
+        const wsSvc = lhSvc.workspace;
+        const includeAll = ${String(includeAllWorkspaces)};
 
-        // Poll until the cache is populated by the launcher's startup
-        // process (same pattern as startInstance's account polling).
+        const mapAccount = (a, ws) => ({
+          id: a.id,
+          liId: a.id,
+          name: a.fullName ?? '',
+          email: a.email ?? undefined,
+          workspaceId: a.workspaceId ?? ws?.id,
+          workspaceName: ws?.name,
+          workspaceAccess: a.workspaceAccess
+            ? { level: a.workspaceAccess.level }
+            : undefined,
+        });
+
+        if (includeAll && wsSvc) {
+          // Cross-workspace listing: iterate workspaces and call
+          // getWorkspaceUserOwnedLiAccounts(wsUserId, { minLevel: 'view_only' })
+          // to get everything the current user can see.
+          try {
+            const wsResult = await wsSvc.api.getWorkspaces(
+              { userId: lhSvc.auth.userId, deleted: false },
+              false,
+            );
+            const workspaces = wsResult?.data ?? [];
+            const seen = new Map();
+            for (const ws of workspaces) {
+              if (!ws.workspaceUser) continue;
+              try {
+                const res = await wsSvc.api.getWorkspaceUserOwnedLiAccounts(
+                  ws.workspaceUser.id,
+                  { minLevel: 'view_only' },
+                );
+                for (const a of res?.data ?? []) {
+                  if (seen.has(a.id)) continue;
+                  seen.set(a.id, mapAccount(a, ws));
+                }
+              } catch (_e) {
+                // 403/404 on a workspace is tolerable; skip it
+              }
+            }
+            return Array.from(seen.values());
+          } catch (e) {
+            return { __error: 'cross-workspace listing failed: ' + e.message };
+          }
+        }
+
+        // Default: read from the selected-workspace cache the launcher
+        // maintains. Poll until the cache is populated by the startup
+        // process.
+        const selectedWs = wsSvc?._selectedWorkspaceBS?.value ?? null;
         const cacheDeadline = Date.now() + 30000;
         while (Date.now() < cacheDeadline) {
           const raw = svc.extendedLinkedInAccountsBS?.value;
           if (raw) {
             const entries = Array.isArray(raw) ? raw : Object.values(raw);
             if (entries.length > 0) {
-              return entries.map(a => ({
-                id: a.id,
-                liId: a.id,
-                name: a.fullName ?? '',
-                email: a.email ?? undefined,
-              }));
+              return entries.map(a => mapAccount(a, selectedWs));
             }
           }
           await new Promise(r => setTimeout(r, 500));
@@ -320,7 +457,81 @@ export class LauncherService {
       throw new WrongPortError(this.port);
     }
 
+    if (!Array.isArray(accounts) && typeof accounts === "object") {
+      const errObj = accounts as { __error?: string };
+      if (errObj.__error) {
+        throw new ServiceError(errObj.__error);
+      }
+    }
+
     return accounts;
+  }
+
+  /**
+   * List workspaces the current LH user belongs to.
+   *
+   * Workspaces are a LinkedHelper 2.113.x feature. On earlier
+   * versions this method returns an empty array (the workspace
+   * service module is absent). On v2.113.x+ it returns every
+   * workspace the user is a member of, with the user's role and
+   * an indication of which workspace is currently selected.
+   *
+   * @see `research/linkedhelper/architecture/WORKSPACES.md`
+   */
+  async listWorkspaces(): Promise<Workspace[]> {
+    const client = this.ensureConnected();
+
+    const workspaces = await this.launcherEvaluate<Workspace[] | null>(
+      client,
+      `(async () => {
+        ${LauncherService.LH_SERVICES_INIT}
+        if (!lhSvc) return null;
+        const wsSvc = lhSvc.workspace;
+        if (!wsSvc) return [];
+
+        // Prefer the in-memory cache if populated; otherwise refetch.
+        let cached = wsSvc._workspacesBS?.value ?? null;
+        if (!cached) {
+          try { await wsSvc.refreshWorkspaces(); } catch (_e) {}
+          cached = wsSvc._workspacesBS?.value ?? null;
+        }
+        if (!cached) {
+          // Fall back to a direct API call
+          try {
+            const res = await wsSvc.api.getWorkspaces(
+              { userId: lhSvc.auth.userId, deleted: false },
+              false,
+            );
+            cached = res?.data ?? [];
+          } catch (_e) {
+            cached = [];
+          }
+        }
+
+        const selectedId = wsSvc._selectedWorkspaceBS?.value?.id ?? null;
+        return (cached || []).map(w => ({
+          id: w.id,
+          name: w.name,
+          deleted: !!w.deleted,
+          workspaceUser: w.workspaceUser ? {
+            id: w.workspaceUser.id,
+            userId: w.workspaceUser.userId,
+            workspaceId: w.workspaceUser.workspaceId,
+            role: w.workspaceUser.role,
+            deleted: !!w.workspaceUser.deleted,
+          } : null,
+          selected: w.id === selectedId,
+        })).filter(w => w.workspaceUser !== null);
+      })()`,
+      true,
+    );
+
+    if (workspaces === null) {
+      throw new WrongPortError(this.port);
+    }
+
+    // Drop the null-filter sentinel we used inside the evaluated snippet.
+    return workspaces as Workspace[];
   }
 
   /**

--- a/packages/core/src/types/account.ts
+++ b/packages/core/src/types/account.ts
@@ -1,15 +1,41 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
+import type { WorkspaceAccess } from "./workspace.js";
+
 /**
  * A LinkedHelper account.
  *
  * Each account corresponds to a LinkedIn identity managed by
  * LinkedHelper and has its own database partition.
+ *
+ * Starting with LinkedHelper 2.113.x, every account belongs to a
+ * workspace and exposes a per-user access level. See
+ * {@link Account.workspaceId} and {@link Account.workspaceAccess}.
  */
 export interface Account {
   id: number;
   liId: number;
   name: string;
   email?: string | undefined;
+  /**
+   * ID of the workspace that owns this account (v2.113.x+).
+   *
+   * Omitted when the underlying LinkedHelper version predates workspaces
+   * or when the account was discovered without a workspace context.
+   */
+  workspaceId?: number | undefined;
+  /**
+   * Name of the owning workspace (v2.113.x+), included as a convenience
+   * so that consumers do not need a separate `listWorkspaces` call.
+   */
+  workspaceName?: string | undefined;
+  /**
+   * Per-user access level on this account (v2.113.x+).
+   *
+   * `view_only` and `no_access` mean the current LH user cannot
+   * start an instance for this account — the launcher will refuse
+   * with a "wrong-access:full" stopping reason.
+   */
+  workspaceAccess?: WorkspaceAccess | undefined;
 }

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -33,6 +33,23 @@ export type {
 export type { Account } from "./account.js";
 
 export type {
+  Workspace,
+  WorkspaceAccess,
+  WorkspaceAccessLevel,
+  WorkspaceInvitationStatus,
+  WorkspaceUser,
+  WorkspaceUserRole,
+} from "./workspace.js";
+
+export {
+  canStartInstance,
+  isOwnerOrExtended,
+  isRestrictedOrHigher,
+  isViewOnlyOrHigher,
+  WORKSPACE_ACCESS_LEVEL_ORDER,
+} from "./workspace.js";
+
+export type {
   Chat,
   ChatParticipant,
   ConversationMessages,

--- a/packages/core/src/types/workspace.test.ts
+++ b/packages/core/src/types/workspace.test.ts
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { describe, expect, it } from "vitest";
+import {
+  canStartInstance,
+  isOwnerOrExtended,
+  isRestrictedOrHigher,
+  isViewOnlyOrHigher,
+  type Workspace,
+  WORKSPACE_ACCESS_LEVEL_ORDER,
+  type WorkspaceAccessLevel,
+} from "./workspace.js";
+
+const ALL_LEVELS: WorkspaceAccessLevel[] = [
+  "no_access",
+  "view_only",
+  "restricted",
+  "extended",
+  "owner",
+];
+
+describe("WORKSPACE_ACCESS_LEVEL_ORDER", () => {
+  it("matches the launcher's numeric enum", () => {
+    expect(WORKSPACE_ACCESS_LEVEL_ORDER.owner).toBe(3);
+    expect(WORKSPACE_ACCESS_LEVEL_ORDER.extended).toBe(2);
+    expect(WORKSPACE_ACCESS_LEVEL_ORDER.restricted).toBe(1);
+    expect(WORKSPACE_ACCESS_LEVEL_ORDER.view_only).toBe(0);
+    expect(WORKSPACE_ACCESS_LEVEL_ORDER.no_access).toBe(-1);
+  });
+
+  it("is strictly ordered", () => {
+    expect(WORKSPACE_ACCESS_LEVEL_ORDER.owner)
+      .toBeGreaterThan(WORKSPACE_ACCESS_LEVEL_ORDER.extended);
+    expect(WORKSPACE_ACCESS_LEVEL_ORDER.extended)
+      .toBeGreaterThan(WORKSPACE_ACCESS_LEVEL_ORDER.restricted);
+    expect(WORKSPACE_ACCESS_LEVEL_ORDER.restricted)
+      .toBeGreaterThan(WORKSPACE_ACCESS_LEVEL_ORDER.view_only);
+    expect(WORKSPACE_ACCESS_LEVEL_ORDER.view_only)
+      .toBeGreaterThan(WORKSPACE_ACCESS_LEVEL_ORDER.no_access);
+  });
+});
+
+describe("canStartInstance", () => {
+  it("allows restricted, extended, and owner", () => {
+    expect(canStartInstance("restricted")).toBe(true);
+    expect(canStartInstance("extended")).toBe(true);
+    expect(canStartInstance("owner")).toBe(true);
+  });
+
+  it("blocks view_only and no_access", () => {
+    expect(canStartInstance("view_only")).toBe(false);
+    expect(canStartInstance("no_access")).toBe(false);
+  });
+
+  it("is a total function on every access level", () => {
+    for (const level of ALL_LEVELS) {
+      expect(typeof canStartInstance(level)).toBe("boolean");
+    }
+  });
+});
+
+describe("isRestrictedOrHigher", () => {
+  it("is true for restricted, extended, owner", () => {
+    expect(isRestrictedOrHigher("restricted")).toBe(true);
+    expect(isRestrictedOrHigher("extended")).toBe(true);
+    expect(isRestrictedOrHigher("owner")).toBe(true);
+  });
+
+  it("is false for view_only and no_access", () => {
+    expect(isRestrictedOrHigher("view_only")).toBe(false);
+    expect(isRestrictedOrHigher("no_access")).toBe(false);
+  });
+});
+
+describe("isViewOnlyOrHigher", () => {
+  it("is true for view_only and above", () => {
+    expect(isViewOnlyOrHigher("view_only")).toBe(true);
+    expect(isViewOnlyOrHigher("restricted")).toBe(true);
+    expect(isViewOnlyOrHigher("extended")).toBe(true);
+    expect(isViewOnlyOrHigher("owner")).toBe(true);
+  });
+
+  it("is false for no_access", () => {
+    expect(isViewOnlyOrHigher("no_access")).toBe(false);
+  });
+});
+
+describe("isOwnerOrExtended", () => {
+  it("is true only for extended and owner", () => {
+    expect(isOwnerOrExtended("owner")).toBe(true);
+    expect(isOwnerOrExtended("extended")).toBe(true);
+  });
+
+  it("is false for restricted and below", () => {
+    expect(isOwnerOrExtended("restricted")).toBe(false);
+    expect(isOwnerOrExtended("view_only")).toBe(false);
+    expect(isOwnerOrExtended("no_access")).toBe(false);
+  });
+});
+
+describe("Workspace type", () => {
+  it("allows a full workspace shape", () => {
+    const ws: Workspace = {
+      id: 20338,
+      name: "PELYKH Consulting",
+      deleted: false,
+      workspaceUser: {
+        id: 33440,
+        userId: 438509,
+        workspaceId: 20338,
+        role: "owner",
+        deleted: false,
+      },
+      selected: true,
+    };
+    expect(ws.id).toBe(20338);
+    expect(ws.workspaceUser.role).toBe("owner");
+    expect(ws.selected).toBe(true);
+  });
+});

--- a/packages/core/src/types/workspace.ts
+++ b/packages/core/src/types/workspace.ts
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+/**
+ * LinkedHelper workspace types.
+ *
+ * Introduced in LinkedHelper 2.113.x. A workspace is a backend-side
+ * container that groups LinkedIn accounts and tracks per-user access
+ * levels. Each LH user can belong to multiple workspaces and has a
+ * role (owner/admin/member/guest) in each. See
+ * `research/linkedhelper/architecture/WORKSPACES.md` in the research
+ * repo for the full architectural background.
+ */
+
+/** Role of an LH user within a workspace. Controls management permissions. */
+export type WorkspaceUserRole = "owner" | "admin" | "member" | "guest";
+
+/** Invitation status of a workspace user. */
+export type WorkspaceInvitationStatus =
+  | "pending"
+  | "accepted"
+  | "declined"
+  | "cancelled";
+
+/**
+ * Per-LinkedIn-account, per-workspace-user access level.
+ *
+ * Ordered enum: `owner` > `extended` > `restricted` > `view_only` > `no_access`.
+ * The launcher treats `view_only` and `no_access` as blocking for
+ * `startInstance` and will refuse to start an instance with a
+ * `"account-stopped:wrong-access:full"` reason.
+ */
+export type WorkspaceAccessLevel =
+  | "owner"
+  | "extended"
+  | "restricted"
+  | "view_only"
+  | "no_access";
+
+/** Numeric order for {@link WorkspaceAccessLevel}, matching the launcher enum. */
+export const WORKSPACE_ACCESS_LEVEL_ORDER: Readonly<
+  Record<WorkspaceAccessLevel, number>
+> = {
+  owner: 3,
+  extended: 2,
+  restricted: 1,
+  view_only: 0,
+  no_access: -1,
+};
+
+/** Workspace access information attached to a LinkedIn account. */
+export interface WorkspaceAccess {
+  level: WorkspaceAccessLevel;
+}
+
+/** LH user's membership in a workspace. */
+export interface WorkspaceUser {
+  /** Workspace user ID (distinct from LH user ID). */
+  id: number;
+  /** LH user ID. */
+  userId: number;
+  workspaceId: number;
+  role: WorkspaceUserRole;
+  deleted: boolean;
+}
+
+/**
+ * A LinkedHelper workspace.
+ *
+ * Workspaces are backend-only (not stored in the local SQLite database).
+ * Only workspaces the current LH user belongs to are visible.
+ */
+export interface Workspace {
+  id: number;
+  name: string;
+  deleted: boolean;
+  /** Current user's membership in this workspace. */
+  workspaceUser: WorkspaceUser;
+  /** Whether this is the user's currently selected workspace. */
+  selected: boolean;
+}
+
+/** Whether an account with the given access level can start an instance. */
+export function canStartInstance(level: WorkspaceAccessLevel): boolean {
+  return WORKSPACE_ACCESS_LEVEL_ORDER[level] >=
+    WORKSPACE_ACCESS_LEVEL_ORDER.restricted;
+}
+
+/** `true` if `level` is `restricted` or higher. */
+export function isRestrictedOrHigher(level: WorkspaceAccessLevel): boolean {
+  return WORKSPACE_ACCESS_LEVEL_ORDER[level] >
+    WORKSPACE_ACCESS_LEVEL_ORDER.view_only;
+}
+
+/** `true` if `level` is `view_only` or higher. */
+export function isViewOnlyOrHigher(level: WorkspaceAccessLevel): boolean {
+  return WORKSPACE_ACCESS_LEVEL_ORDER[level] >=
+    WORKSPACE_ACCESS_LEVEL_ORDER.view_only;
+}
+
+/** `true` if `level` is `extended` or `owner`. */
+export function isOwnerOrExtended(level: WorkspaceAccessLevel): boolean {
+  return WORKSPACE_ACCESS_LEVEL_ORDER[level] >
+    WORKSPACE_ACCESS_LEVEL_ORDER.restricted;
+}

--- a/packages/mcp/src/server.test.ts
+++ b/packages/mcp/src/server.test.ts
@@ -79,6 +79,7 @@ describe("createServer", () => {
     expect(names).toContain("launch-app");
     expect(names).toContain("quit-app");
     expect(names).toContain("list-accounts");
+    expect(names).toContain("list-workspaces");
     expect(names).toContain("start-instance");
     expect(names).toContain("stop-instance");
     expect(names).toContain("query-profile");
@@ -145,6 +146,6 @@ describe("createServer", () => {
     expect(names).toContain("dismiss-feed-post");
     expect(names).toContain("unfollow-from-feed");
     expect(names).toContain("hide-feed-author");
-    expect(names).toHaveLength(71);
+    expect(names).toHaveLength(72);
   });
 });

--- a/packages/mcp/src/tools/index.ts
+++ b/packages/mcp/src/tools/index.ts
@@ -60,6 +60,7 @@ import { registerListLinkedInReferenceData } from "./list-linkedin-reference-dat
 import { registerLaunchApp } from "./launch-app.js";
 import { registerListCollections } from "./list-collections.js";
 import { registerListAccounts } from "./list-accounts.js";
+import { registerListWorkspaces } from "./list-workspaces.js";
 import { registerQuitApp } from "./quit-app.js";
 import { registerStartInstance } from "./start-instance.js";
 import { registerStopInstance } from "./stop-instance.js";
@@ -132,6 +133,7 @@ export {
   registerLaunchApp,
   registerListCollections,
   registerListAccounts,
+  registerListWorkspaces,
   registerListLinkedInReferenceData,
   registerQueryMessages,
   registerRemovePeopleFromCollection,
@@ -187,6 +189,7 @@ export function registerAllTools(server: McpServer): void {
   registerLaunchApp(server);
   registerQuitApp(server);
   registerListAccounts(server);
+  registerListWorkspaces(server);
   registerStartInstance(server);
   registerStopInstance(server);
   registerQueryMessages(server);

--- a/packages/mcp/src/tools/list-accounts.ts
+++ b/packages/mcp/src/tools/list-accounts.ts
@@ -3,17 +3,24 @@
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { LauncherService, resolveLauncherPort } from "@lhremote/core";
+import { z } from "zod";
 import { buildCdpOptions, cdpConnectionSchema, mcpCatchAll, mcpSuccess } from "../helpers.js";
 
 /** Register the {@link https://github.com/alexey-pelykh/lhremote#list-accounts | list-accounts} MCP tool. */
 export function registerListAccounts(server: McpServer): void {
   server.tool(
     "list-accounts",
-    "List available LinkedHelper accounts",
+    "List available LinkedHelper accounts. By default returns accounts in the currently selected workspace (LinkedHelper 2.113.x+). Pass includeAllWorkspaces=true to enumerate accounts across every workspace the current LH user belongs to.",
     {
       ...cdpConnectionSchema,
+      includeAllWorkspaces: z
+        .boolean()
+        .optional()
+        .describe(
+          "When true, enumerate accounts across every workspace the user belongs to, not just the selected workspace. Default: false.",
+        ),
     },
-    async ({ cdpPort, cdpHost, allowRemote }) => {
+    async ({ cdpPort, cdpHost, allowRemote, includeAllWorkspaces }) => {
       try {
         const port = await resolveLauncherPort(cdpPort, cdpHost);
         const launcher = new LauncherService(port, buildCdpOptions({ cdpHost, allowRemote }));
@@ -25,7 +32,10 @@ export function registerListAccounts(server: McpServer): void {
         }
 
         try {
-          const accounts = await launcher.listAccounts();
+          const options = includeAllWorkspaces === true
+            ? { includeAllWorkspaces: true }
+            : undefined;
+          const accounts = await launcher.listAccounts(options);
           return mcpSuccess(JSON.stringify(accounts, null, 2));
         } catch (error) {
           return mcpCatchAll(error, "Failed to list accounts");

--- a/packages/mcp/src/tools/list-workspaces.test.ts
+++ b/packages/mcp/src/tools/list-workspaces.test.ts
@@ -1,0 +1,142 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return {
+    ...actual,
+    LauncherService: vi.fn(),
+  };
+});
+
+import {
+  LauncherService,
+  LinkedHelperNotRunningError,
+  type Workspace,
+} from "@lhremote/core";
+
+import { registerListWorkspaces } from "./list-workspaces.js";
+import { createMockServer } from "./testing/mock-server.js";
+
+function mockLauncher(overrides: Partial<LauncherService> = {}) {
+  const disconnect = vi.fn();
+  vi.mocked(LauncherService).mockImplementation(function () {
+    return {
+      connect: vi.fn().mockResolvedValue(undefined),
+      disconnect,
+      listWorkspaces: vi.fn().mockResolvedValue([]),
+      ...overrides,
+    } as unknown as LauncherService;
+  });
+  return { disconnect };
+}
+
+const SAMPLE_WORKSPACES: Workspace[] = [
+  {
+    id: 20338,
+    name: "PELYKH Consulting",
+    deleted: false,
+    workspaceUser: {
+      id: 33440,
+      userId: 438509,
+      workspaceId: 20338,
+      role: "owner",
+      deleted: false,
+    },
+    selected: true,
+  },
+];
+
+describe("registerListWorkspaces", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("registers a tool named list-workspaces", () => {
+    const { server } = createMockServer();
+    registerListWorkspaces(server);
+
+    expect(server.tool).toHaveBeenCalledOnce();
+    expect(server.tool).toHaveBeenCalledWith(
+      "list-workspaces",
+      expect.any(String),
+      expect.any(Object),
+      expect.any(Function),
+    );
+  });
+
+  it("returns workspaces as JSON", async () => {
+    const { server, getHandler } = createMockServer();
+    registerListWorkspaces(server);
+
+    mockLauncher({
+      listWorkspaces: vi.fn().mockResolvedValue(SAMPLE_WORKSPACES),
+    });
+
+    const handler = getHandler("list-workspaces");
+    const result = (await handler({ cdpPort: 9222 })) as {
+      content: [{ text: string }];
+    };
+
+    expect(JSON.parse(result.content[0].text)).toEqual(SAMPLE_WORKSPACES);
+  });
+
+  it("returns empty array when no workspaces", async () => {
+    const { server, getHandler } = createMockServer();
+    registerListWorkspaces(server);
+
+    mockLauncher({ listWorkspaces: vi.fn().mockResolvedValue([]) });
+
+    const handler = getHandler("list-workspaces");
+    const result = (await handler({ cdpPort: 9222 })) as {
+      content: [{ text: string }];
+    };
+
+    expect(JSON.parse(result.content[0].text)).toEqual([]);
+  });
+
+  it("returns error when LinkedHelper not running", async () => {
+    const { server, getHandler } = createMockServer();
+    registerListWorkspaces(server);
+
+    vi.mocked(LauncherService).mockImplementation(function () {
+      return {
+        connect: vi
+          .fn()
+          .mockRejectedValue(new LinkedHelperNotRunningError(9222)),
+        disconnect: vi.fn(),
+      } as unknown as LauncherService;
+    });
+
+    const handler = getHandler("list-workspaces");
+    const result = await handler({ cdpPort: 9222 });
+
+    expect(result).toEqual({
+      isError: true,
+      content: [
+        {
+          type: "text",
+          text: "LinkedHelper is not running. Use launch-app first.",
+        },
+      ],
+    });
+  });
+
+  it("disconnects after successful call", async () => {
+    const { server, getHandler } = createMockServer();
+    registerListWorkspaces(server);
+
+    const { disconnect } = mockLauncher();
+
+    const handler = getHandler("list-workspaces");
+    await handler({ cdpPort: 9222 });
+
+    expect(disconnect).toHaveBeenCalledOnce();
+  });
+});

--- a/packages/mcp/src/tools/list-workspaces.ts
+++ b/packages/mcp/src/tools/list-workspaces.ts
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { LauncherService, resolveLauncherPort } from "@lhremote/core";
+import { buildCdpOptions, cdpConnectionSchema, mcpCatchAll, mcpSuccess } from "../helpers.js";
+
+/**
+ * Register the list-workspaces MCP tool.
+ *
+ * Workspaces are a LinkedHelper 2.113.x feature. Each LH user may
+ * belong to multiple workspaces and has a role (owner/admin/member/guest)
+ * in each. The tool returns the user's selected workspace alongside
+ * every other workspace they belong to, with the user's role and a
+ * `selected` flag.
+ *
+ * On older LinkedHelper versions the workspace service is absent and
+ * this tool returns an empty list.
+ */
+export function registerListWorkspaces(server: McpServer): void {
+  server.tool(
+    "list-workspaces",
+    "List LinkedHelper workspaces the current LH user belongs to. Each workspace includes the user's role and a `selected` flag indicating the currently active workspace. Returns an empty list on LinkedHelper versions that predate workspaces (pre-2.113.x).",
+    {
+      ...cdpConnectionSchema,
+    },
+    async ({ cdpPort, cdpHost, allowRemote }) => {
+      try {
+        const port = await resolveLauncherPort(cdpPort, cdpHost);
+        const launcher = new LauncherService(port, buildCdpOptions({ cdpHost, allowRemote }));
+
+        try {
+          await launcher.connect();
+        } catch (error) {
+          return mcpCatchAll(error, "Failed to connect to LinkedHelper");
+        }
+
+        try {
+          const workspaces = await launcher.listWorkspaces();
+          return mcpSuccess(JSON.stringify(workspaces, null, 2));
+        } catch (error) {
+          return mcpCatchAll(error, "Failed to list workspaces");
+        } finally {
+          launcher.disconnect();
+        }
+      } catch (error) {
+        return mcpCatchAll(error, "Failed to list workspaces");
+      }
+    },
+  );
+}

--- a/turbo.json
+++ b/turbo.json
@@ -11,7 +11,7 @@
     },
     "test:e2e": {
       "dependsOn": ["build", "^test:e2e"],
-      "passThroughEnv": ["LHREMOTE_E2E_PERSON_ID", "LHREMOTE_E2E_POST_URL"],
+      "passThroughEnv": ["LHREMOTE_E2E_PERSON_ID", "LHREMOTE_E2E_POST_URL", "LHREMOTE_E2E_COMMENT_URN"],
       "cache": false
     },
     "lint": {


### PR DESCRIPTION
## Summary

- Support LinkedHelper 2.113.x first-class workspace concept: account cache is filtered to the selected workspace, each LH user can belong to multiple workspaces, each account has a per-user access level
- Replace hard-coded webpack module IDs with a marker-based resolver (v2.113.28 shifted 3 of 4 module IDs, breaking v0.14.0)
- New `listWorkspaces()`, `list-workspaces` MCP tool and CLI command; `listAccounts({ includeAllWorkspaces })` + `--all-workspaces` option; access-level gate in `startInstance`
- Drive-by: add `LHREMOTE_E2E_COMMENT_URN` to `turbo.json` `passThroughEnv` so engagement E2E tests receive the var

## Background

LinkedHelper 2.113.x introduced a backend-side workspace hierarchy:

```
LH user ──(member of)──> workspaces ──(grants access to)──> LinkedIn accounts
```

Each membership has a **role** (`owner`/`admin`/`member`/`guest`) and each LI account exposes a **per-user access level** (`no_access` / `view_only` / `restricted` / `extended` / `owner`). The launcher tracks a **selected workspace** in backend-persisted `frontendSettings.selectedWorkspaceId` and `runningLiAccountsService.extendedLinkedInAccountsBS` contains **only accounts in the selected workspace**.

Additionally, between v2.113.11 and v2.113.28, three of four webpack module IDs lhremote relied on shifted:

| Service | v2.113.11 | v2.113.28 |
|---|---|---|
| `authService` | 2742 | **2742** (stable) |
| `userService` | 75381 | **10064** (`default` export) |
| `runningLiAccountsService` | 44354 | **37925** |
| `frontendSettingsService` | 81954 | **72687** |

lhremote v0.14.0 hard-codes the old IDs, so on v2.113.28 both `listAccounts()` and `startInstance()` fail with `Cannot read properties of undefined (reading 'call')`.

## Changes

**`@lhremote/core`**

- `services/launcher.ts`
  - `LH_SERVICES_INIT` snippet replaces `WEBPACK_INIT` — marker-based scan with `window.__lhrServices` cache
  - `listAccounts({ includeAllWorkspaces })` — default preserves selected-workspace view; with the option iterates every workspace via `workspaceService.api.getWorkspaceUserOwnedLiAccounts(wsUserId, { minLevel: 'view_only' })`
  - New `listWorkspaces()` — returns the user's workspaces with role and `selected` flag
  - `startInstance()` now fails fast when `workspaceAccess.level` is `view_only` or `no_access`
- `types/workspace.ts` — new: `Workspace`, `WorkspaceUser`, `WorkspaceAccess`, `WorkspaceAccessLevel`, `WorkspaceUserRole`, `WorkspaceInvitationStatus`; helpers `canStartInstance`, `isRestrictedOrHigher`, `isViewOnlyOrHigher`, `isOwnerOrExtended`; `WORKSPACE_ACCESS_LEVEL_ORDER` constant
- `types/account.ts` — added optional `workspaceId`, `workspaceName`, `workspaceAccess` fields
- Root `index.ts` re-exports the new types and helpers

**`@lhremote/mcp`**

- New `list-workspaces` tool
- `list-accounts` tool gains optional `includeAllWorkspaces` parameter

**`@lhremote/cli`**

- New `list-workspaces` command (`--json` supported)
- `list-accounts` command gains `--all-workspaces` flag and prints workspace name in formatted output

**Repo**

- `turbo.json`: add `LHREMOTE_E2E_COMMENT_URN` to `test:e2e.passThroughEnv` so engagement E2E tests receive the env var

## Test plan

- [x] `pnpm build` — green (all 5 packages)
- [x] `pnpm lint` — green (8 tasks)
- [x] `pnpm test` — green (2535 total: 1509 core + 480 MCP + 546 CLI)
  - [x] 12 new `workspace.ts` helper tests
  - [x] 7 new `launcher.test.ts` tests (`includeAllWorkspaces` option, `listWorkspaces`, workspace field propagation, cross-workspace error path)
  - [x] 5 new `cli/handlers/list-workspaces.test.ts` tests
  - [x] 5 new `mcp/tools/list-workspaces.test.ts` tests
- [x] Verified against running LinkedHelper v2.113.28:
  - `LauncherService.listAccounts()` returns selected-workspace accounts with `workspaceId`, `workspaceName`, `workspaceAccess.level`
  - `LauncherService.listAccounts({ includeAllWorkspaces: true })` returns cross-workspace account list
  - `LauncherService.listWorkspaces()` returns both observed workspaces with `selected` flag
  - `lhremote-cli list-workspaces` shows selection marker and role
  - `lhremote-cli list-accounts [--all-workspaces]` shows workspace name in each row
- [x] `list-accounts.e2e.test.ts` — all 6 E2E tests pass against live v2.113.28
- [x] Full E2E suite: 264 passed, 22 skipped, 6 failed + 1 suite failure — all pre-existing v2.113.28 issues in untouched code (`collection.ts` `mws.call`, `AppService.quit`, `dismiss-feed-post` content quirk)

## Research

Full reverse-engineering notes are in the private research repo:

- `research/linkedhelper/architecture/WORKSPACES.md`
- `research/linkedhelper/architecture/V2113-WEBPACK-MODULE-IDS.md`
- `research/linkedhelper/data/WORKSPACE-DATA-MODEL.md`

Closes #734

🤖 Generated with [Claude Code](https://claude.com/claude-code)