### PR TITLE
(chore) release: bump pinned manifests to 0.15.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "lhremote",
       "source": "./",
       "description": "LinkedHelper automation toolkit — MCP server and workflow guidance for Claude Code",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "author": {
         "name": "Alexey Pelykh"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lhremote",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "LinkedHelper automation toolkit — MCP server and workflow guidance for Claude Code",
   "author": {
     "name": "Alexey Pelykh",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/alexey-pelykh/lhremote",
     "source": "github"
   },
-  "version": "0.14.0",
+  "version": "0.15.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "lhremote",
-      "version": "0.14.0",
+      "version": "0.15.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary

Post-release bump of the three manifests the release workflow does **not** auto-stamp:

- `.claude-plugin/plugin.json`
- `.claude-plugin/marketplace.json`
- `server.json`

All three now match the published tag [`v0.15.0`](https://github.com/alexey-pelykh/lhremote/releases/tag/v0.15.0) per the convention documented in `CLAUDE.md`:

> The release workflow does not auto-bump these files — after each release, open a PR to update their `"version"` fields to match the new tag.

## Test plan

- [x] `pnpm lint` clean
- [x] All three files show `"version": "0.15.0"`
- [x] npm registry confirms `lhremote@0.15.0` published