### PR TITLE
fix(get-feed): migrate DOM selectors to expandable-text-box + aria-label

### DIFF
--- a/packages/core/src/operations/get-feed.ts
+++ b/packages/core/src/operations/get-feed.ts
@@ -60,12 +60,19 @@ export interface RawDomPost {
  * `Runtime.evaluate`.  Returns an array of {@link RawDomPost} objects
  * (without URNs — those are extracted separately via the three-dot menu).
  *
- * ## Discovery strategy (2026-03 onwards)
+ * ## Discovery strategy (2026-04 onwards)
  *
  * LinkedIn's SSR feed uses `div[data-testid="mainFeed"]` as the feed
  * list (`role="list"`) and `div[role="listitem"]` for each post.
  * CSS class names are obfuscated hashes (CSS Modules), so the script
- * relies on semantic attributes and structural heuristics.
+ * relies on semantic attributes (`data-testid`, `aria-label`) and
+ * structural position within author links.
+ *
+ * - **Post text**: `[data-testid="expandable-text-box"]` (clone, strip
+ *   `expandable-text-button` child, take `textContent`).
+ * - **Author name**: menu button `aria-label` prefix strip.
+ * - **Author headline**: 3rd `<p>` in the text-bearing author link.
+ * - **Timestamp**: last `<p>` matching `\d+[smhdw]` in that link.
  *
  * Post URNs are NOT available in the DOM.  They are extracted in a
  * separate phase by opening each post's three-dot menu, clicking
@@ -109,46 +116,60 @@ const SCRAPE_FEED_POSTS_SCRIPT = `(() => {
     let authorName = null;
     let authorHeadline = null;
     let authorProfileUrl = null;
+    let timestamp = null;
 
     const authorLink = item.querySelector('a[href*="/in/"], a[href*="/company/"]');
     if (authorLink) {
       authorProfileUrl = authorLink.href.split('?')[0] || null;
-      const nameEl = authorLink.querySelector('span[dir="ltr"], span[aria-hidden="true"]')
-        || authorLink;
-      const rawName = (nameEl.textContent || '').trim();
-      authorName = rawName || null;
     }
 
-    // Author headline: look for a short descriptive text near the author.
-    const allSpans = item.querySelectorAll('span');
-    for (const span of allSpans) {
-      const txt = (span.textContent || '').trim();
-      if (
-        txt &&
-        txt.length > 5 &&
-        txt.length < 200 &&
-        txt !== authorName &&
-        !txt.match(/^\\d+[smhdw]$/) &&
-        !txt.match(/^\\d[\\d,]*\\s+(reactions?|comments?|reposts?|likes?)$/i) &&
-        !txt.match(/^Follow$|^Promoted$/i)
-      ) {
-        authorHeadline = txt;
-        break;
+    // Author name: strip known prefix from the menu button's aria-label.
+    // The menu button is already validated above (line that sets menuBtn).
+    const menuLabel = menuBtn.getAttribute('aria-label') || '';
+    authorName = menuLabel.replace('Open control menu for post by ', '') || null;
+
+    // Author headline + timestamp: find the text-bearing second author
+    // link.  Each post has two links to the author profile — the first
+    // contains only an avatar (<figure>), the second contains <p>
+    // elements with name, degree, headline, and timestamp.
+    if (authorLink) {
+      const authorPath = new URL(authorLink.href).pathname;
+      const allLinks = Array.from(item.querySelectorAll('a[href*="' + authorPath + '"]'));
+      const textLink = allLinks.find(function(a) { return a.textContent.trim().length > 0; });
+
+      if (textLink) {
+        const pEls = Array.from(textLink.querySelectorAll('p'));
+
+        // Timestamp: last <p> matching relative-time pattern (e.g. "18h •")
+        for (let i = pEls.length - 1; i >= 0; i--) {
+          const txt = pEls[i].textContent.trim();
+          if (/^\\d+[smhdw]\\s*/.test(txt)) {
+            timestamp = txt.replace(/\\s*[\\u2022\\u00B7]\\s*$/, '').trim();
+            pEls.splice(i, 1);
+            break;
+          }
+        }
+
+        // Headline: 3rd <p> (index 2) — after name and connection degree.
+        // Company posts may have only 2 <p> elements (name + timestamp),
+        // in which case authorHeadline stays null.
+        if (pEls.length >= 3) {
+          authorHeadline = pEls[2].textContent.trim() || null;
+        }
       }
     }
 
     // --- Post text ---
+    // The feed DOM uses data-testid="expandable-text-box" for post body
+    // text.  The optional "… more" button is a child of the text box and
+    // must be stripped before reading textContent.
     let text = null;
-    const ltrSpans = item.querySelectorAll('span[dir="ltr"]');
-    let longestText = '';
-    for (const span of ltrSpans) {
-      const txt = (span.textContent || '').trim();
-      if (txt.length > longestText.length && txt !== authorName && txt !== authorHeadline) {
-        longestText = txt;
-      }
-    }
-    if (longestText.length > 20) {
-      text = longestText;
+    const textBox = item.querySelector('[data-testid="expandable-text-box"]');
+    if (textBox) {
+      const clone = textBox.cloneNode(true);
+      const moreBtn = clone.querySelector('[data-testid="expandable-text-button"]');
+      if (moreBtn) moreBtn.remove();
+      text = clone.textContent.trim() || null;
     }
 
     // --- Media type ---
@@ -176,18 +197,6 @@ const SCRAPE_FEED_POSTS_SCRIPT = `(() => {
     const reactionCount = parseCount(/(\\d[\\d,]*)\\s+reactions?/i);
     const commentCount = parseCount(/(\\d[\\d,]*)\\s+comments?/i);
     const shareCount = parseCount(/(\\d[\\d,]*)\\s+reposts?/i);
-
-    // --- Timestamp ---
-    let timestamp = null;
-    const timeEl = item.querySelector('time');
-    if (timeEl) {
-      const dt = timeEl.getAttribute('datetime');
-      if (dt) timestamp = dt;
-    }
-    if (!timestamp) {
-      const timeMatch = itemText.match(/(?:^|\\s)(\\d+[smhdw])(?:\\s|$|\\u00B7|\\xB7)/);
-      if (timeMatch) timestamp = timeMatch[1];
-    }
 
     posts.push({
       _isNew: _isNew,

--- a/packages/core/src/operations/get-feed.ts
+++ b/packages/core/src/operations/get-feed.ts
@@ -123,10 +123,12 @@ const SCRAPE_FEED_POSTS_SCRIPT = `(() => {
       authorProfileUrl = authorLink.href.split('?')[0] || null;
     }
 
-    // Author name: strip known prefix from the menu button's aria-label.
+    // Author name: extract only when the menu button aria-label matches
+    // the expected "Open control menu for post by <name>" format.
     // The menu button is already validated above (line that sets menuBtn).
     const menuLabel = menuBtn.getAttribute('aria-label') || '';
-    authorName = menuLabel.replace('Open control menu for post by ', '') || null;
+    const authorNameMatch = menuLabel.match(/^Open control menu for post by\\s+(.+)$/);
+    authorName = authorNameMatch ? authorNameMatch[1].trim() || null : null;
 
     // Author headline + timestamp: find the text-bearing second author
     // link.  Each post has two links to the author profile — the first
@@ -140,11 +142,12 @@ const SCRAPE_FEED_POSTS_SCRIPT = `(() => {
       if (textLink) {
         const pEls = Array.from(textLink.querySelectorAll('p'));
 
-        // Timestamp: last <p> matching relative-time pattern (e.g. "18h •")
+        // Timestamp: last <p> containing a relative-time token (e.g. "18h •")
         for (let i = pEls.length - 1; i >= 0; i--) {
           const txt = pEls[i].textContent.trim();
-          if (/^\\d+[smhdw]\\s*/.test(txt)) {
-            timestamp = txt.replace(/\\s*[\\u2022\\u00B7]\\s*$/, '').trim();
+          const timestampMatch = txt.match(/^(\\d+[smhdw])(?:\\s|[\\u2022\\u00B7]|$)/);
+          if (timestampMatch) {
+            timestamp = timestampMatch[1];
             pEls.splice(i, 1);
             break;
           }

--- a/packages/core/src/operations/get-feed.ts
+++ b/packages/core/src/operations/get-feed.ts
@@ -137,14 +137,14 @@ const SCRAPE_FEED_POSTS_SCRIPT = `(() => {
     if (authorLink) {
       const authorPath = new URL(authorLink.href).pathname;
       const allLinks = Array.from(item.querySelectorAll('a[href*="' + authorPath + '"]'));
-      const textLink = allLinks.find(function(a) { return a.textContent.trim().length > 0; });
+      const textLink = allLinks.find(function(a) { return (a.textContent || '').trim().length > 0; });
 
       if (textLink) {
         const pEls = Array.from(textLink.querySelectorAll('p'));
 
         // Timestamp: last <p> containing a relative-time token (e.g. "18h •")
         for (let i = pEls.length - 1; i >= 0; i--) {
-          const txt = pEls[i].textContent.trim();
+          const txt = (pEls[i].textContent || '').trim();
           const timestampMatch = txt.match(/^(\\d+[smhdw])(?:\\s|[\\u2022\\u00B7]|$)/);
           if (timestampMatch) {
             timestamp = timestampMatch[1];
@@ -157,7 +157,7 @@ const SCRAPE_FEED_POSTS_SCRIPT = `(() => {
         // Company posts may have only 2 <p> elements (name + timestamp),
         // in which case authorHeadline stays null.
         if (pEls.length >= 3) {
-          authorHeadline = pEls[2].textContent.trim() || null;
+          authorHeadline = (pEls[2].textContent || '').trim() || null;
         }
       }
     }
@@ -172,7 +172,7 @@ const SCRAPE_FEED_POSTS_SCRIPT = `(() => {
       const clone = textBox.cloneNode(true);
       const moreBtn = clone.querySelector('[data-testid="expandable-text-button"]');
       if (moreBtn) moreBtn.remove();
-      text = clone.textContent.trim() || null;
+      text = (clone.textContent || '').trim() || null;
     }
 
     // --- Media type ---


### PR DESCRIPTION
## Summary

- Migrate `SCRAPE_FEED_POSTS_SCRIPT` from broken `span[dir="ltr"]` / `<time>` selectors to working LinkedIn feed DOM selectors (verified 2026-04-15)
- **Post text**: `[data-testid="expandable-text-box"]` with `expandable-text-button` child removal
- **Author name**: menu button `aria-label` prefix strip (`"Open control menu for post by "`)
- **Author headline**: 3rd `<p>` in text-bearing second author link (handles company posts with only 2 `<p>` elements)
- **Timestamp**: last `<p>` matching `\d+[smhdw]` pattern in author link, with bullet/middle-dot suffix strip

Closes #737
Closes #738

## Test plan

- [x] Unit tests pass (`pnpm test` — 480 tests, all green)
- [x] Lint clean (`pnpm lint`)
- [ ] E2E test `get-feed` passes against live LinkedIn (`pnpm test:e2e`)
- [ ] Verify `text`, `authorName`, `authorHeadline`, `timestamp` are non-null for posts with visible content

🤖 Generated with [Claude Code](https://claude.com/claude-code)