### PR TITLE
e2e: assert text/authorName/timestamp non-null in feed, search, and activity tests

### DIFF
--- a/packages/e2e/src/get-feed.e2e.test.ts
+++ b/packages/e2e/src/get-feed.e2e.test.ts
@@ -116,11 +116,11 @@ describeE2E("get-feed operation", () => {
 
       // Content extraction: at least 50% of posts should have non-null fields
       const minRequired = Math.ceil(parsed.posts.length / 2);
-      const postsWithText = parsed.posts.filter((p) => p.text !== null);
+      const postsWithText = parsed.posts.filter((p) => p.text != null);
       expect(postsWithText.length).toBeGreaterThanOrEqual(minRequired);
-      const postsWithAuthorName = parsed.posts.filter((p) => p.authorName !== null);
+      const postsWithAuthorName = parsed.posts.filter((p) => p.authorName != null);
       expect(postsWithAuthorName.length).toBeGreaterThanOrEqual(minRequired);
-      const postsWithTimestamp = parsed.posts.filter((p) => p.timestamp !== null);
+      const postsWithTimestamp = parsed.posts.filter((p) => p.timestamp != null);
       expect(postsWithTimestamp.length).toBeGreaterThanOrEqual(minRequired);
     }, 60_000);
 
@@ -168,11 +168,11 @@ describeE2E("get-feed operation", () => {
 
       // Content extraction: at least 50% of posts should have non-null fields
       const minRequired = Math.ceil(parsed.posts.length / 2);
-      const postsWithText = parsed.posts.filter((p) => p.text !== null);
+      const postsWithText = parsed.posts.filter((p) => p.text != null);
       expect(postsWithText.length).toBeGreaterThanOrEqual(minRequired);
-      const postsWithAuthorName = parsed.posts.filter((p) => p.authorName !== null);
+      const postsWithAuthorName = parsed.posts.filter((p) => p.authorName != null);
       expect(postsWithAuthorName.length).toBeGreaterThanOrEqual(minRequired);
-      const postsWithTimestamp = parsed.posts.filter((p) => p.timestamp !== null);
+      const postsWithTimestamp = parsed.posts.filter((p) => p.timestamp != null);
       expect(postsWithTimestamp.length).toBeGreaterThanOrEqual(minRequired);
     }, 60_000);
 

--- a/packages/e2e/src/get-feed.e2e.test.ts
+++ b/packages/e2e/src/get-feed.e2e.test.ts
@@ -113,6 +113,14 @@ describeE2E("get-feed operation", () => {
       expect(typeof post.commentCount).toBe("number");
       expect(typeof post.shareCount).toBe("number");
       expect(Array.isArray(post.hashtags)).toBe(true);
+
+      // Content extraction: at least 50% of posts should have non-null fields
+      const postsWithText = parsed.posts.filter((p) => p.text !== null);
+      expect(postsWithText.length).toBeGreaterThanOrEqual(Math.ceil(parsed.posts.length / 2));
+      const postsWithAuthorName = parsed.posts.filter((p) => p.authorName !== null);
+      expect(postsWithAuthorName.length).toBeGreaterThanOrEqual(Math.ceil(parsed.posts.length / 2));
+      const postsWithTimestamp = parsed.posts.filter((p) => p.timestamp !== null);
+      expect(postsWithTimestamp.length).toBeGreaterThanOrEqual(Math.ceil(parsed.posts.length / 2));
     }, 60_000);
 
     it("get-feed prints human-friendly output", async () => {
@@ -156,6 +164,14 @@ describeE2E("get-feed operation", () => {
       const post = parsed.posts[0] as FeedPost;
       expect(post).toHaveProperty("url");
       expect(typeof post.reactionCount).toBe("number");
+
+      // Content extraction: at least 50% of posts should have non-null fields
+      const postsWithText = parsed.posts.filter((p) => p.text !== null);
+      expect(postsWithText.length).toBeGreaterThanOrEqual(Math.ceil(parsed.posts.length / 2));
+      const postsWithAuthorName = parsed.posts.filter((p) => p.authorName !== null);
+      expect(postsWithAuthorName.length).toBeGreaterThanOrEqual(Math.ceil(parsed.posts.length / 2));
+      const postsWithTimestamp = parsed.posts.filter((p) => p.timestamp !== null);
+      expect(postsWithTimestamp.length).toBeGreaterThanOrEqual(Math.ceil(parsed.posts.length / 2));
     }, 60_000);
 
     it("get-feed tool paginates with cursor", async () => {

--- a/packages/e2e/src/get-feed.e2e.test.ts
+++ b/packages/e2e/src/get-feed.e2e.test.ts
@@ -115,12 +115,13 @@ describeE2E("get-feed operation", () => {
       expect(Array.isArray(post.hashtags)).toBe(true);
 
       // Content extraction: at least 50% of posts should have non-null fields
+      const minRequired = Math.ceil(parsed.posts.length / 2);
       const postsWithText = parsed.posts.filter((p) => p.text !== null);
-      expect(postsWithText.length).toBeGreaterThanOrEqual(Math.ceil(parsed.posts.length / 2));
+      expect(postsWithText.length).toBeGreaterThanOrEqual(minRequired);
       const postsWithAuthorName = parsed.posts.filter((p) => p.authorName !== null);
-      expect(postsWithAuthorName.length).toBeGreaterThanOrEqual(Math.ceil(parsed.posts.length / 2));
+      expect(postsWithAuthorName.length).toBeGreaterThanOrEqual(minRequired);
       const postsWithTimestamp = parsed.posts.filter((p) => p.timestamp !== null);
-      expect(postsWithTimestamp.length).toBeGreaterThanOrEqual(Math.ceil(parsed.posts.length / 2));
+      expect(postsWithTimestamp.length).toBeGreaterThanOrEqual(minRequired);
     }, 60_000);
 
     it("get-feed prints human-friendly output", async () => {
@@ -166,12 +167,13 @@ describeE2E("get-feed operation", () => {
       expect(typeof post.reactionCount).toBe("number");
 
       // Content extraction: at least 50% of posts should have non-null fields
+      const minRequired = Math.ceil(parsed.posts.length / 2);
       const postsWithText = parsed.posts.filter((p) => p.text !== null);
-      expect(postsWithText.length).toBeGreaterThanOrEqual(Math.ceil(parsed.posts.length / 2));
+      expect(postsWithText.length).toBeGreaterThanOrEqual(minRequired);
       const postsWithAuthorName = parsed.posts.filter((p) => p.authorName !== null);
-      expect(postsWithAuthorName.length).toBeGreaterThanOrEqual(Math.ceil(parsed.posts.length / 2));
+      expect(postsWithAuthorName.length).toBeGreaterThanOrEqual(minRequired);
       const postsWithTimestamp = parsed.posts.filter((p) => p.timestamp !== null);
-      expect(postsWithTimestamp.length).toBeGreaterThanOrEqual(Math.ceil(parsed.posts.length / 2));
+      expect(postsWithTimestamp.length).toBeGreaterThanOrEqual(minRequired);
     }, 60_000);
 
     it("get-feed tool paginates with cursor", async () => {

--- a/packages/e2e/src/get-profile-activity.e2e.test.ts
+++ b/packages/e2e/src/get-profile-activity.e2e.test.ts
@@ -141,10 +141,11 @@ describeE2E("get-profile-activity operation", () => {
       }
 
       // Content extraction: at least 50% of posts should have non-null fields
+      const minRequired = Math.ceil(parsed.posts.length / 2);
       const postsWithText = parsed.posts.filter((p) => p.text !== null);
-      expect(postsWithText.length).toBeGreaterThanOrEqual(Math.ceil(parsed.posts.length / 2));
+      expect(postsWithText.length).toBeGreaterThanOrEqual(minRequired);
       const postsWithAuthorName = parsed.posts.filter((p) => p.authorName !== null);
-      expect(postsWithAuthorName.length).toBeGreaterThanOrEqual(Math.ceil(parsed.posts.length / 2));
+      expect(postsWithAuthorName.length).toBeGreaterThanOrEqual(minRequired);
     }, 120_000);
 
     it("get-profile-activity prints human-friendly output", async () => {
@@ -198,10 +199,11 @@ describeE2E("get-profile-activity operation", () => {
       expect(Array.isArray(parsed.posts)).toBe(true);
 
       // Content extraction: at least 50% of posts should have non-null fields
+      const minRequired = Math.ceil(parsed.posts.length / 2);
       const postsWithText = parsed.posts.filter((p) => p.text !== null);
-      expect(postsWithText.length).toBeGreaterThanOrEqual(Math.ceil(parsed.posts.length / 2));
+      expect(postsWithText.length).toBeGreaterThanOrEqual(minRequired);
       const postsWithAuthorName = parsed.posts.filter((p) => p.authorName !== null);
-      expect(postsWithAuthorName.length).toBeGreaterThanOrEqual(Math.ceil(parsed.posts.length / 2));
+      expect(postsWithAuthorName.length).toBeGreaterThanOrEqual(minRequired);
     }, 120_000);
   });
 });

--- a/packages/e2e/src/get-profile-activity.e2e.test.ts
+++ b/packages/e2e/src/get-profile-activity.e2e.test.ts
@@ -139,6 +139,12 @@ describeE2E("get-profile-activity operation", () => {
         expect(typeof post.commentCount).toBe("number");
         expect(typeof post.shareCount).toBe("number");
       }
+
+      // Content extraction: at least 50% of posts should have non-null fields
+      const postsWithText = parsed.posts.filter((p) => p.text !== null);
+      expect(postsWithText.length).toBeGreaterThanOrEqual(Math.ceil(parsed.posts.length / 2));
+      const postsWithAuthorName = parsed.posts.filter((p) => p.authorName !== null);
+      expect(postsWithAuthorName.length).toBeGreaterThanOrEqual(Math.ceil(parsed.posts.length / 2));
     }, 120_000);
 
     it("get-profile-activity prints human-friendly output", async () => {
@@ -190,6 +196,12 @@ describeE2E("get-profile-activity operation", () => {
 
       expect(parsed.profilePublicId).toBe(profilePublicId);
       expect(Array.isArray(parsed.posts)).toBe(true);
+
+      // Content extraction: at least 50% of posts should have non-null fields
+      const postsWithText = parsed.posts.filter((p) => p.text !== null);
+      expect(postsWithText.length).toBeGreaterThanOrEqual(Math.ceil(parsed.posts.length / 2));
+      const postsWithAuthorName = parsed.posts.filter((p) => p.authorName !== null);
+      expect(postsWithAuthorName.length).toBeGreaterThanOrEqual(Math.ceil(parsed.posts.length / 2));
     }, 120_000);
   });
 });

--- a/packages/e2e/src/get-profile-activity.e2e.test.ts
+++ b/packages/e2e/src/get-profile-activity.e2e.test.ts
@@ -142,9 +142,9 @@ describeE2E("get-profile-activity operation", () => {
 
       // Content extraction: at least 50% of posts should have non-null fields
       const minRequired = Math.ceil(parsed.posts.length / 2);
-      const postsWithText = parsed.posts.filter((p) => p.text !== null);
+      const postsWithText = parsed.posts.filter((p) => p.text != null);
       expect(postsWithText.length).toBeGreaterThanOrEqual(minRequired);
-      const postsWithAuthorName = parsed.posts.filter((p) => p.authorName !== null);
+      const postsWithAuthorName = parsed.posts.filter((p) => p.authorName != null);
       expect(postsWithAuthorName.length).toBeGreaterThanOrEqual(minRequired);
     }, 120_000);
 
@@ -200,9 +200,9 @@ describeE2E("get-profile-activity operation", () => {
 
       // Content extraction: at least 50% of posts should have non-null fields
       const minRequired = Math.ceil(parsed.posts.length / 2);
-      const postsWithText = parsed.posts.filter((p) => p.text !== null);
+      const postsWithText = parsed.posts.filter((p) => p.text != null);
       expect(postsWithText.length).toBeGreaterThanOrEqual(minRequired);
-      const postsWithAuthorName = parsed.posts.filter((p) => p.authorName !== null);
+      const postsWithAuthorName = parsed.posts.filter((p) => p.authorName != null);
       expect(postsWithAuthorName.length).toBeGreaterThanOrEqual(minRequired);
     }, 120_000);
   });

--- a/packages/e2e/src/search-posts.e2e.test.ts
+++ b/packages/e2e/src/search-posts.e2e.test.ts
@@ -116,12 +116,13 @@ describeE2E("search-posts operation", () => {
       expect(typeof post.commentCount).toBe("number");
 
       // Content extraction: at least 50% of posts should have non-null fields
+      const minRequired = Math.ceil(parsed.posts.length / 2);
       const postsWithText = parsed.posts.filter((p) => p.text !== null);
-      expect(postsWithText.length).toBeGreaterThanOrEqual(Math.ceil(parsed.posts.length / 2));
+      expect(postsWithText.length).toBeGreaterThanOrEqual(minRequired);
       const postsWithAuthorName = parsed.posts.filter((p) => p.authorName !== null);
-      expect(postsWithAuthorName.length).toBeGreaterThanOrEqual(Math.ceil(parsed.posts.length / 2));
+      expect(postsWithAuthorName.length).toBeGreaterThanOrEqual(minRequired);
       const postsWithTimestamp = parsed.posts.filter((p) => p.timestamp !== null);
-      expect(postsWithTimestamp.length).toBeGreaterThanOrEqual(Math.ceil(parsed.posts.length / 2));
+      expect(postsWithTimestamp.length).toBeGreaterThanOrEqual(minRequired);
     }, 60_000);
 
     it("search-posts prints human-friendly output", async () => {
@@ -168,12 +169,13 @@ describeE2E("search-posts operation", () => {
       expect(postsWithUrls.length).toBeGreaterThan(0);
 
       // Content extraction: at least 50% of posts should have non-null fields
+      const minRequired = Math.ceil(parsed.posts.length / 2);
       const postsWithText = parsed.posts.filter((p) => p.text !== null);
-      expect(postsWithText.length).toBeGreaterThanOrEqual(Math.ceil(parsed.posts.length / 2));
+      expect(postsWithText.length).toBeGreaterThanOrEqual(minRequired);
       const postsWithAuthorName = parsed.posts.filter((p) => p.authorName !== null);
-      expect(postsWithAuthorName.length).toBeGreaterThanOrEqual(Math.ceil(parsed.posts.length / 2));
+      expect(postsWithAuthorName.length).toBeGreaterThanOrEqual(minRequired);
       const postsWithTimestamp = parsed.posts.filter((p) => p.timestamp !== null);
-      expect(postsWithTimestamp.length).toBeGreaterThanOrEqual(Math.ceil(parsed.posts.length / 2));
+      expect(postsWithTimestamp.length).toBeGreaterThanOrEqual(minRequired);
     }, 60_000);
 
     it("search-posts tool paginates with cursor", async () => {

--- a/packages/e2e/src/search-posts.e2e.test.ts
+++ b/packages/e2e/src/search-posts.e2e.test.ts
@@ -117,11 +117,11 @@ describeE2E("search-posts operation", () => {
 
       // Content extraction: at least 50% of posts should have non-null fields
       const minRequired = Math.ceil(parsed.posts.length / 2);
-      const postsWithText = parsed.posts.filter((p) => p.text !== null);
+      const postsWithText = parsed.posts.filter((p) => p.text != null);
       expect(postsWithText.length).toBeGreaterThanOrEqual(minRequired);
-      const postsWithAuthorName = parsed.posts.filter((p) => p.authorName !== null);
+      const postsWithAuthorName = parsed.posts.filter((p) => p.authorName != null);
       expect(postsWithAuthorName.length).toBeGreaterThanOrEqual(minRequired);
-      const postsWithTimestamp = parsed.posts.filter((p) => p.timestamp !== null);
+      const postsWithTimestamp = parsed.posts.filter((p) => p.timestamp != null);
       expect(postsWithTimestamp.length).toBeGreaterThanOrEqual(minRequired);
     }, 60_000);
 
@@ -170,11 +170,11 @@ describeE2E("search-posts operation", () => {
 
       // Content extraction: at least 50% of posts should have non-null fields
       const minRequired = Math.ceil(parsed.posts.length / 2);
-      const postsWithText = parsed.posts.filter((p) => p.text !== null);
+      const postsWithText = parsed.posts.filter((p) => p.text != null);
       expect(postsWithText.length).toBeGreaterThanOrEqual(minRequired);
-      const postsWithAuthorName = parsed.posts.filter((p) => p.authorName !== null);
+      const postsWithAuthorName = parsed.posts.filter((p) => p.authorName != null);
       expect(postsWithAuthorName.length).toBeGreaterThanOrEqual(minRequired);
-      const postsWithTimestamp = parsed.posts.filter((p) => p.timestamp !== null);
+      const postsWithTimestamp = parsed.posts.filter((p) => p.timestamp != null);
       expect(postsWithTimestamp.length).toBeGreaterThanOrEqual(minRequired);
     }, 60_000);
 

--- a/packages/e2e/src/search-posts.e2e.test.ts
+++ b/packages/e2e/src/search-posts.e2e.test.ts
@@ -114,6 +114,14 @@ describeE2E("search-posts operation", () => {
       const post = parsed.posts[0] as (typeof parsed.posts)[number];
       expect(typeof post.reactionCount).toBe("number");
       expect(typeof post.commentCount).toBe("number");
+
+      // Content extraction: at least 50% of posts should have non-null fields
+      const postsWithText = parsed.posts.filter((p) => p.text !== null);
+      expect(postsWithText.length).toBeGreaterThanOrEqual(Math.ceil(parsed.posts.length / 2));
+      const postsWithAuthorName = parsed.posts.filter((p) => p.authorName !== null);
+      expect(postsWithAuthorName.length).toBeGreaterThanOrEqual(Math.ceil(parsed.posts.length / 2));
+      const postsWithTimestamp = parsed.posts.filter((p) => p.timestamp !== null);
+      expect(postsWithTimestamp.length).toBeGreaterThanOrEqual(Math.ceil(parsed.posts.length / 2));
     }, 60_000);
 
     it("search-posts prints human-friendly output", async () => {
@@ -158,6 +166,14 @@ describeE2E("search-posts operation", () => {
       // Verify at least one post has a URL
       const postsWithUrls = parsed.posts.filter((p) => p.url !== null);
       expect(postsWithUrls.length).toBeGreaterThan(0);
+
+      // Content extraction: at least 50% of posts should have non-null fields
+      const postsWithText = parsed.posts.filter((p) => p.text !== null);
+      expect(postsWithText.length).toBeGreaterThanOrEqual(Math.ceil(parsed.posts.length / 2));
+      const postsWithAuthorName = parsed.posts.filter((p) => p.authorName !== null);
+      expect(postsWithAuthorName.length).toBeGreaterThanOrEqual(Math.ceil(parsed.posts.length / 2));
+      const postsWithTimestamp = parsed.posts.filter((p) => p.timestamp !== null);
+      expect(postsWithTimestamp.length).toBeGreaterThanOrEqual(Math.ceil(parsed.posts.length / 2));
     }, 60_000);
 
     it("search-posts tool paginates with cursor", async () => {


### PR DESCRIPTION
## Summary

- Add content extraction assertions to `get-feed`, `search-posts`, and `get-profile-activity` E2E tests
- Each test now verifies that at least 50% of returned posts have non-null `text`, `authorName`, and `timestamp` (activity tests check `text` and `authorName` only)
- Catches systematic extraction failures like #737 while tolerating individual post type variation (promoted, reshares, polls, image-only)

Closes #744

## Test plan

- [ ] CI passes (build, lint — E2E tests are local-only)
- [ ] Assertions are additive — existing test behavior unchanged
- [ ] Threshold uses `Math.ceil(posts.length / 2)` to enforce ≥50%

🤖 Generated with [Claude Code](https://claude.com/claude-code)