### PR TITLE
(chore) release: bump version to 0.16.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "lhremote",
       "source": "./",
       "description": "LinkedHelper automation toolkit — MCP server and workflow guidance for Claude Code",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "author": {
         "name": "Alexey Pelykh"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lhremote",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "LinkedHelper automation toolkit — MCP server and workflow guidance for Claude Code",
   "author": {
     "name": "Alexey Pelykh",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/alexey-pelykh/lhremote",
     "source": "github"
   },
-  "version": "0.15.0",
+  "version": "0.16.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "lhremote",
-      "version": "0.15.0",
+      "version": "0.16.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary

Bump plugin and server version fields to 0.16.0 for the upcoming release.

### Changes since v0.15.0

- **(fix)** `get-feed`: migrate DOM selectors to expandable-text-box + aria-label
- **(fix)** `get-feed`: harden author name and timestamp extraction
- **(fix)** `get-feed`: null-safe textContent access in scrape script
- **(fix)** `search-posts`: migrate DOM selectors to expandable-text-box + aria-label
- **(fix)** `get-profile-activity`: extract authorName from menu button aria-label
- **(fix)** `get-profile-activity`: harden aria-label parsing per Copilot review
- **(test)** e2e: assert content extraction fields non-null in feed, search, and activity tests
- **(fix)** e2e: compute minRequired threshold once per test block
- **(fix)** e2e: use nullish check for content extraction assertions
- **(fix)** e2e: relax timestamp assertion to >=1 post

🤖 Generated with [Claude Code](https://claude.com/claude-code)