### PR TITLE
(fix) core: use action-button aria-labels for profile readiness

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,7 @@ Do **not** dismiss or ignore Copilot feedback. Every comment must be explicitly 
 - Run a single E2E file: `pnpm --filter @lhremote/e2e test:e2e:file <pattern>` (e.g., `list-accounts`). Do **not** use `--` before the pattern — pnpm forwards it literally and vitest ignores args after `--` for file filtering.
 - E2E tests must assert preconditions explicitly — never silently skip via `if (accounts.length > 0)`. Use `resolveAccountId(port)` from `@lhremote/core/testing` which throws if no accounts exist.
 - Shared E2E helpers (`resolveAccountId`, `forceStopInstance`, `assertDefined`, `getE2EPersonId`) are exported from `@lhremote/core/testing` — do not duplicate them locally in test files.
+- `navigateToProfile` can capture timeout diagnostics (URL, `document.title`, DOM probes, full-page screenshot) under `${os.tmpdir()}/lhremote-diagnostics/` on `CDPTimeoutError`. Activation is gated on `LHREMOTE_CAPTURE_DIAGNOSTICS=1`; E2E runs set it via `vitest.e2e.config.ts`, CLI/MCP are default-off (see ADR-007). Inspect these artifacts before changing profile selectors.
 
 ## Infrastructure
 
@@ -86,6 +87,7 @@ Architecture Decision Records live in `docs/adr/` and explain *why* the codebase
 | [004](docs/adr/004-three-tier-testing-strategy.md) | Three-tier testing strategy | `*.test.ts`, `*.integration.test.ts`, `packages/e2e/` |
 | [005](docs/adr/005-error-hierarchy-design.md) | Error hierarchy design | `packages/core/src/*/errors.ts` |
 | [006](docs/adr/006-operations-layer.md) | Operations layer | `packages/core/src/operations/` |
+| [007](docs/adr/007-profile-ready-selector-strategy.md) | Profile page readiness selector strategy | `packages/core/src/operations/navigate-to-profile.ts` |
 
 ## Task Tracking
 

--- a/docs/adr/007-profile-ready-selector-strategy.md
+++ b/docs/adr/007-profile-ready-selector-strategy.md
@@ -10,7 +10,7 @@ Accepted (2026-04-19)
 
 The original implementation used `main h1` with a 30-second timeout. On 2026-04-19, both profile-page E2E tests (`unfollow-profile`, `hide-feed-author-profile`) began failing with identical `Timed out waiting for element "main h1" after 30000ms` errors. Diagnostic instrumentation confirmed the profile page was otherwise healthy (correct URL, correct `document.title`, `<main>` present, Message/Follow buttons rendered) — LinkedIn simply no longer wraps the profile name in an `<h1>` element.
 
-This is not an isolated failure. Historical evidence from `research/linkedin/feed-dom-selectors-20260326.md` shows LinkedIn periodically removes semantic markers from its feed and profile DOM. Any selector strategy rooted in DOM headings or CSS class names has an expected half-life on the order of weeks-to-months.
+This is not an isolated failure. Combined with prior selector breakages observed in LinkedIn feed and profile automation, this incident reinforces that LinkedIn periodically removes or reshapes semantic markers in its DOM. Any selector strategy rooted in DOM headings or CSS class names has an expected half-life on the order of weeks-to-months.
 
 ## Decision
 
@@ -70,6 +70,5 @@ Any single match indicates the profile card has hydrated far enough for follow-s
 
 ## Related
 
-- Research: `../research/linkedin/profile-page-dom-20260419.md`
 - Code: `packages/core/src/operations/navigate-to-profile.ts`
 - Branch: `fix/navigate-to-profile-diagnostics`

--- a/docs/adr/007-profile-ready-selector-strategy.md
+++ b/docs/adr/007-profile-ready-selector-strategy.md
@@ -1,0 +1,75 @@
+# ADR-007: Profile Page Readiness Selector Strategy
+
+## Status
+
+Accepted (2026-04-19)
+
+## Context
+
+`navigateToProfile` (`packages/core/src/operations/navigate-to-profile.ts`) synchronizes a just-issued CDP `Page.navigate` against the target profile's DOM being ready for subsequent interaction. `client.navigate()` is fire-and-forget at the CDP layer — it sends `Page.navigate` and returns immediately without awaiting load events — so a DOM-level selector wait is the only synchronization point before downstream detection queries run (`PROFILE_FOLLOWING_BUTTON_SELECTOR`, `PROFILE_MORE_BUTTON_SELECTOR`, etc.).
+
+The original implementation used `main h1` with a 30-second timeout. On 2026-04-19, both profile-page E2E tests (`unfollow-profile`, `hide-feed-author-profile`) began failing with identical `Timed out waiting for element "main h1" after 30000ms` errors. Diagnostic instrumentation confirmed the profile page was otherwise healthy (correct URL, correct `document.title`, `<main>` present, Message/Follow buttons rendered) — LinkedIn simply no longer wraps the profile name in an `<h1>` element.
+
+This is not an isolated failure. Historical evidence from `research/linkedin/feed-dom-selectors-20260326.md` shows LinkedIn periodically removes semantic markers from its feed and profile DOM. Any selector strategy rooted in DOM headings or CSS class names has an expected half-life on the order of weeks-to-months.
+
+## Decision
+
+`PROFILE_READY_SELECTOR` is a **disjunction of profile action-button `aria-label` prefixes**:
+
+```text
+main button[aria-label^="Message"]
+main button[aria-label^="Follow "]
+main button[aria-label^="Following "]
+main button[aria-label^="Connect"]
+main button[aria-label^="Pending"]
+main button[aria-label="More actions"]
+main button[aria-label="More"]
+```
+
+Any single match indicates the profile card has hydrated far enough for follow-state detection, Mute/Unmute menu traversal, or any other interaction used by profile-based operations.
+
+**Rule for future profile-area selectors**: prefer `aria-label` prefixes on interactive elements over DOM headings, CSS classes, or `data-view-name` values. When a new readiness signal is needed, extend `PROFILE_READY_SELECTOR` with additional action-button variants rather than falling back to structural selectors.
+
+**Diagnostic instrumentation is first-class but opt-in**: `navigateToProfile` can capture `{ href, title, DOM probes, screenshot }` on `CDPTimeoutError`. Activation is gated on `LHREMOTE_CAPTURE_DIAGNOSTICS=1`; artifacts land under `${os.tmpdir()}/lhremote-diagnostics/` as `navigate-to-profile-{timestamp}-{publicId}.{json,png}`. E2E tests set this env var via `vitest.e2e.config.ts`, so every test run produces diagnostics without code changes. Production callers (CLI, MCP server) remain default-off — screenshots of LinkedIn profile pages contain personal data and must not be written silently. Future LinkedIn DOM changes are still classifiable (re-run with the env var set) without code changes.
+
+## Consequences
+
+**Positive**
+
+- Survives LinkedIn DOM redesigns that preserve accessibility semantics (the common case). `aria-label` strings are i18n-anchored, not CSS-architecture-anchored.
+- Single source of truth: the detection-button selectors in `unfollow-profile.ts` and `hide-feed-author-profile.ts` and the readiness selector share the same structural assumption.
+- No dependency on profile content that varies by connection degree, privacy, or profile completeness.
+- Next timeout produces classifiable evidence instead of opaque failure.
+
+**Negative**
+
+- **Locale coupling**: `aria-label^="Message"`, `Follow`, etc. are English-locale strings. Non-English LinkedIn sessions will not match. Acceptable for now (LH default locale is English); a locale-aware extension is required before internationalization.
+- Selector is longer than a single heading selector; slightly noisier in logs and stack traces.
+- **Self-profile edge case**: viewing one's own profile shows no action buttons. Out of scope — profile-write operations (unfollow, mute) cannot target self.
+
+**Neutral**
+
+- Existing selectors in `unfollow-profile.ts` and `hide-feed-author-profile.ts` that already use `main button[aria-label^=...]` patterns need no change; they are consistent with this decision.
+
+## Follow-ups
+
+- **Generalize diagnostic capture**: The current capture lives inline in `navigate-to-profile.ts`. When a second CDP operation needs the same pattern, lift it to a shared helper (e.g. `packages/core/src/cdp/diagnostics.ts`) keyed on the same `LHREMOTE_CAPTURE_DIAGNOSTICS` env var. Not worth doing for a single call site.
+- **Locale-aware readiness**: When a non-English LinkedIn locale enters scope, extend `PROFILE_READY_SELECTOR` with localized `aria-label` prefixes (or key off a locale-independent attribute if one emerges).
+
+## Alternatives considered
+
+| Alternative | Rejected because |
+|---|---|
+| `main` alone | Matches before content hydrates — races with the downstream detection query. |
+| `main section.artdeco-card` | Depends on CSS class (`artdeco-card`); LinkedIn has redesigned card classes before. |
+| `main div[data-view-name="profile-card-recent-activity"]` | Activity card is absent on profiles with no recent activity. |
+| New heading selector (e.g. `.text-heading-xlarge`) | Same failure class as `h1` — locks us into whichever class LinkedIn ships this month. |
+| Wait for `Page.loadEventFired` then short delay | SPA client-side routing fires load events before the profile data resolves. |
+| `waitForEvent("Page.frameStoppedLoading")` | Same root issue — SPA navigations don't always trigger frame load events. |
+| Keep `main h1` + fall back | Adds latency on every run once the primary selector is known-dead. |
+
+## Related
+
+- Research: `../research/linkedin/profile-page-dom-20260419.md`
+- Code: `packages/core/src/operations/navigate-to-profile.ts`
+- Branch: `fix/navigate-to-profile-diagnostics`

--- a/packages/core/src/operations/navigate-to-profile.test.ts
+++ b/packages/core/src/operations/navigate-to-profile.test.ts
@@ -186,22 +186,47 @@ describe("captureProfileLoadFailure", () => {
     ).resolves.toBeUndefined();
   });
 
-  it("sanitizes publicId before using it in the artifact filename", async () => {
+  it("sanitizes publicId so path separators in the decoded slug can't escape the diagnostics dir", async () => {
     process.env.LHREMOTE_CAPTURE_DIAGNOSTICS = "1";
     const client = makeClient();
+    const { writeFile } = await import("node:fs/promises");
+    const writeFileMock = vi.mocked(writeFile);
+    writeFileMock.mockClear();
 
-    // Any of these would otherwise escape the base directory or produce
-    // invalid filenames on Windows/macOS.  sanitizeForFilename replaces
-    // every non-`[a-zA-Z0-9._-]` char with `_`.
+    // `extractPublicId` URL-decodes before returning, so `%2F`, `%5C`,
+    // and traversal fragments can reach this code.  Sanitization must
+    // replace any path separator in the slug so the final path stays
+    // a direct child of `${tmpdir()}/lhremote-diagnostics/`.
     await captureProfileLoadFailure(client, "../../../etc/passwd");
-    await captureProfileLoadFailure(client, "slug with spaces");
+    await captureProfileLoadFailure(client, "slug\\with\\backslashes");
     await captureProfileLoadFailure(client, "slug/with/slashes");
+    await captureProfileLoadFailure(client, "slug with spaces");
 
-    // The function completes without throwing for any of these inputs;
-    // filesystem writes are mocked.  The sanitization is verified
-    // indirectly by the absence of an exception — direct path assertion
-    // would couple the test to the mocked mkdir/writeFile signatures.
-    expect(client.evaluate).toHaveBeenCalledTimes(3);
+    // Each capture writes a .json (and attempts a .png) — at minimum
+    // the .json calls must have been made for all four inputs.
+    expect(writeFileMock.mock.calls.length).toBeGreaterThanOrEqual(4);
+
+    for (const call of writeFileMock.mock.calls) {
+      const filePath = String(call[0]);
+      const lastSep = Math.max(filePath.lastIndexOf("/"), filePath.lastIndexOf("\\"));
+      const baseDir = lastSep >= 0 ? filePath.slice(0, lastSep) : "";
+      const filename = lastSep >= 0 ? filePath.slice(lastSep + 1) : filePath;
+
+      // The basename must contain no path separator — otherwise the
+      // file would escape baseDir when joined.
+      expect(filename).not.toMatch(/[/\\]/);
+      // The basename must follow the expected shape: the
+      // navigate-to-profile prefix + timestamp + sanitized slug +
+      // extension.  No stray `..` segments that are separated from
+      // other chars by `/` — we already asserted no `/` — so the
+      // filename as a whole stays in-directory.
+      expect(filename).toMatch(
+        /^navigate-to-profile-[\w.-]+\.(json|png)$/,
+      );
+      // And the parent directory must still end at the diagnostics
+      // base dir.
+      expect(baseDir).toMatch(/lhremote-diagnostics$/);
+    }
   });
 });
 

--- a/packages/core/src/operations/navigate-to-profile.test.ts
+++ b/packages/core/src/operations/navigate-to-profile.test.ts
@@ -1,9 +1,21 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-import { describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { buildProfileUrl, extractPublicId, LINKEDIN_PROFILE_RE } from "./navigate-to-profile.js";
+import type { CDPClient } from "../cdp/client.js";
+import {
+  buildProfileUrl,
+  captureProfileLoadFailure,
+  extractPublicId,
+  LINKEDIN_PROFILE_RE,
+  PROFILE_READY_SELECTOR,
+} from "./navigate-to-profile.js";
+
+vi.mock("node:fs/promises", () => ({
+  mkdir: vi.fn().mockResolvedValue(undefined),
+  writeFile: vi.fn().mockResolvedValue(undefined),
+}));
 
 describe("LINKEDIN_PROFILE_RE", () => {
   it.each([
@@ -73,6 +85,123 @@ describe("extractPublicId", () => {
     ["/in/jane-doe/"], // no scheme
   ])("throws on invalid URL %s", (url) => {
     expect(() => extractPublicId(url)).toThrow("Invalid LinkedIn profile URL");
+  });
+});
+
+describe("PROFILE_READY_SELECTOR", () => {
+  // ADR-007: readiness signal is the profile action-button row, keyed on
+  // stable aria-labels.  These assertions pin the intended variants so a
+  // future "cleanup" that drops a variant is caught here rather than at
+  // E2E run time.
+  it.each([
+    ['main button[aria-label^="Message"]'],
+    ['main button[aria-label^="Follow "]'],
+    ['main button[aria-label^="Following "]'],
+    ['main button[aria-label^="Connect"]'],
+    ['main button[aria-label^="Pending"]'],
+    ['main button[aria-label="More actions"]'],
+    ['main button[aria-label="More"]'],
+  ])("includes %s", (fragment) => {
+    expect(PROFILE_READY_SELECTOR).toContain(fragment);
+  });
+
+  it("is a comma-separated disjunction, not a compound selector", () => {
+    expect(PROFILE_READY_SELECTOR).toContain(", ");
+    // Must not accidentally chain selectors without separation.
+    expect(PROFILE_READY_SELECTOR).not.toMatch(/\]main/);
+  });
+});
+
+describe("captureProfileLoadFailure", () => {
+  const originalEnv = process.env.LHREMOTE_CAPTURE_DIAGNOSTICS;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.LHREMOTE_CAPTURE_DIAGNOSTICS;
+    } else {
+      process.env.LHREMOTE_CAPTURE_DIAGNOSTICS = originalEnv;
+    }
+  });
+
+  function makeClient(): CDPClient {
+    return {
+      evaluate: vi.fn().mockResolvedValue({
+        href: "https://www.linkedin.com/in/jane-doe/",
+        title: "Jane Doe | LinkedIn",
+        hasMain: true,
+        hasH1: false,
+        hasMainH1: false,
+        bodyTextSnippet: "Jane Doe\nSoftware Engineer\n",
+      }),
+      send: vi.fn().mockResolvedValue({ data: "aGVsbG8=" }),
+    } as unknown as CDPClient;
+  }
+
+  it("is a no-op when LHREMOTE_CAPTURE_DIAGNOSTICS is unset", async () => {
+    delete process.env.LHREMOTE_CAPTURE_DIAGNOSTICS;
+    const client = makeClient();
+
+    await captureProfileLoadFailure(client, "jane-doe");
+
+    expect(client.evaluate).not.toHaveBeenCalled();
+    expect(client.send).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when LHREMOTE_CAPTURE_DIAGNOSTICS is any truthy-but-not-\"1\" value", async () => {
+    process.env.LHREMOTE_CAPTURE_DIAGNOSTICS = "true";
+    const client = makeClient();
+
+    await captureProfileLoadFailure(client, "jane-doe");
+
+    expect(client.evaluate).not.toHaveBeenCalled();
+    expect(client.send).not.toHaveBeenCalled();
+  });
+
+  it("captures DOM probes and screenshot when LHREMOTE_CAPTURE_DIAGNOSTICS=1", async () => {
+    process.env.LHREMOTE_CAPTURE_DIAGNOSTICS = "1";
+    const client = makeClient();
+
+    await captureProfileLoadFailure(client, "jane-doe");
+
+    expect(client.evaluate).toHaveBeenCalledTimes(1);
+    expect(client.send).toHaveBeenCalledWith("Page.captureScreenshot", {
+      format: "png",
+      captureBeyondViewport: true,
+    });
+  });
+
+  it("swallows capture-side errors rather than masking the caller's timeout", async () => {
+    process.env.LHREMOTE_CAPTURE_DIAGNOSTICS = "1";
+    const client = {
+      evaluate: vi.fn().mockRejectedValue(new Error("evaluate failed")),
+      send: vi.fn(),
+    } as unknown as CDPClient;
+
+    await expect(
+      captureProfileLoadFailure(client, "jane-doe"),
+    ).resolves.toBeUndefined();
+  });
+
+  it("sanitizes publicId before using it in the artifact filename", async () => {
+    process.env.LHREMOTE_CAPTURE_DIAGNOSTICS = "1";
+    const client = makeClient();
+
+    // Any of these would otherwise escape the base directory or produce
+    // invalid filenames on Windows/macOS.  sanitizeForFilename replaces
+    // every non-`[a-zA-Z0-9._-]` char with `_`.
+    await captureProfileLoadFailure(client, "../../../etc/passwd");
+    await captureProfileLoadFailure(client, "slug with spaces");
+    await captureProfileLoadFailure(client, "slug/with/slashes");
+
+    // The function completes without throwing for any of these inputs;
+    // filesystem writes are mocked.  The sanitization is verified
+    // indirectly by the absence of an exception — direct path assertion
+    // would couple the test to the mocked mkdir/writeFile signatures.
+    expect(client.evaluate).toHaveBeenCalledTimes(3);
   });
 });
 

--- a/packages/core/src/operations/navigate-to-profile.test.ts
+++ b/packages/core/src/operations/navigate-to-profile.test.ts
@@ -4,18 +4,24 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { CDPClient } from "../cdp/client.js";
-import {
+
+// Register the fs-promises mock BEFORE importing the module under test.
+// `navigate-to-profile.ts` imports `node:fs/promises` at module load;
+// relying on Vitest's vi.mock hoisting to cover this is brittle under
+// ESM transforms.  Dynamic-import after the mock guarantees the mocked
+// version is the one the module sees.
+vi.mock("node:fs/promises", () => ({
+  mkdir: vi.fn().mockResolvedValue(undefined),
+  writeFile: vi.fn().mockResolvedValue(undefined),
+}));
+
+const {
   buildProfileUrl,
   captureProfileLoadFailure,
   extractPublicId,
   LINKEDIN_PROFILE_RE,
   PROFILE_READY_SELECTOR,
-} from "./navigate-to-profile.js";
-
-vi.mock("node:fs/promises", () => ({
-  mkdir: vi.fn().mockResolvedValue(undefined),
-  writeFile: vi.fn().mockResolvedValue(undefined),
-}));
+} = await import("./navigate-to-profile.js");
 
 describe("LINKEDIN_PROFILE_RE", () => {
   it.each([

--- a/packages/core/src/operations/navigate-to-profile.ts
+++ b/packages/core/src/operations/navigate-to-profile.ts
@@ -139,6 +139,14 @@ function sanitizeForFilename(value: string): string {
 }
 
 /**
+ * Cap on the wall-clock time the diagnostic capture may take before it is
+ * abandoned.  Without this, a misbehaving CDP connection could prolong
+ * error propagation by up to `CDPClient.send`'s own timeout per call
+ * (`Runtime.evaluate` + `Page.captureScreenshot`).
+ */
+const DIAGNOSTIC_CAPTURE_TIMEOUT_MS = 10_000;
+
+/**
  * Best-effort diagnostic capture when `navigateToProfile` times out waiting
  * for the profile action-button row.  Writes
  * `navigate-to-profile-{timestamp}-{publicId}.json` (URL, title, DOM
@@ -156,8 +164,14 @@ function sanitizeForFilename(value: string): string {
  * `publicId` is sanitized before interpolation into the filename to
  * prevent path traversal via URL-decoded slugs.
  *
- * Any capture-side failure is swallowed; the original timeout must
- * propagate unchanged.
+ * The diagnostics directory is created with mode `0o700` and files with
+ * mode `0o600` (POSIX; no-op on Windows) so that personal data in a
+ * shared `os.tmpdir()` is not exposed to other local users.
+ *
+ * The whole capture is bounded by
+ * {@link DIAGNOSTIC_CAPTURE_TIMEOUT_MS}; any capture-side failure or
+ * overrun is swallowed so the original timeout always propagates
+ * unchanged.
  *
  * @internal Exported for unit testing only; not part of the public API.
  */
@@ -166,49 +180,71 @@ export async function captureProfileLoadFailure(
   publicId: string,
 ): Promise<void> {
   if (process.env.LHREMOTE_CAPTURE_DIAGNOSTICS !== "1") return;
+  let bound: NodeJS.Timeout | undefined;
   try {
-    const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
-    const baseDir = join(tmpdir(), "lhremote-diagnostics");
-    await mkdir(baseDir, { recursive: true });
-    const prefix = join(
-      baseDir,
-      `navigate-to-profile-${timestamp}-${sanitizeForFilename(publicId)}`,
-    );
-
-    const info = await client.evaluate<{
-      href: string;
-      title: string;
-      hasMain: boolean;
-      hasH1: boolean;
-      hasMainH1: boolean;
-      bodyTextSnippet: string;
-    }>(`(() => ({
-      href: location.href,
-      title: document.title,
-      hasMain: document.querySelector("main") !== null,
-      hasH1: document.querySelector("h1") !== null,
-      hasMainH1: document.querySelector("main h1") !== null,
-      bodyTextSnippet: (document.body ? document.body.innerText : "").slice(0, 800),
-    }))()`);
-
-    await writeFile(`${prefix}.json`, JSON.stringify(info, null, 2), "utf8");
-
-    try {
-      const screenshot = (await client.send("Page.captureScreenshot", {
-        format: "png",
-        captureBeyondViewport: true,
-      })) as { data?: string };
-      if (screenshot.data) {
-        await writeFile(`${prefix}.png`, Buffer.from(screenshot.data, "base64"));
-      }
-    } catch {
-      // Screenshot is best-effort; info.json is the primary artifact.
-    }
-
-    console.warn(
-      `[navigateToProfile] timeout diagnostics written: ${prefix}.{json,png}`,
-    );
+    await Promise.race([
+      captureProfileLoadFailureInner(client, publicId),
+      new Promise<void>((resolve) => {
+        bound = setTimeout(resolve, DIAGNOSTIC_CAPTURE_TIMEOUT_MS);
+      }),
+    ]);
   } catch {
     // Capture itself failed; do not mask the caller's timeout.
+  } finally {
+    if (bound !== undefined) clearTimeout(bound);
   }
+}
+
+async function captureProfileLoadFailureInner(
+  client: CDPClient,
+  publicId: string,
+): Promise<void> {
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const baseDir = join(tmpdir(), "lhremote-diagnostics");
+  // 0o700: owner-only rwx.  POSIX-only; no-op on Windows.
+  await mkdir(baseDir, { recursive: true, mode: 0o700 });
+  const prefix = join(
+    baseDir,
+    `navigate-to-profile-${timestamp}-${sanitizeForFilename(publicId)}`,
+  );
+
+  const info = await client.evaluate<{
+    href: string;
+    title: string;
+    hasMain: boolean;
+    hasH1: boolean;
+    hasMainH1: boolean;
+    bodyTextSnippet: string;
+  }>(`(() => ({
+    href: location.href,
+    title: document.title,
+    hasMain: document.querySelector("main") !== null,
+    hasH1: document.querySelector("h1") !== null,
+    hasMainH1: document.querySelector("main h1") !== null,
+    bodyTextSnippet: (document.body ? document.body.innerText : "").slice(0, 800),
+  }))()`);
+
+  // 0o600: owner-only rw.  POSIX-only; no-op on Windows.
+  await writeFile(`${prefix}.json`, JSON.stringify(info, null, 2), {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+
+  try {
+    const screenshot = (await client.send("Page.captureScreenshot", {
+      format: "png",
+      captureBeyondViewport: true,
+    })) as { data?: string };
+    if (screenshot.data) {
+      await writeFile(`${prefix}.png`, Buffer.from(screenshot.data, "base64"), {
+        mode: 0o600,
+      });
+    }
+  } catch {
+    // Screenshot is best-effort; info.json is the primary artifact.
+  }
+
+  console.warn(
+    `[navigateToProfile] timeout diagnostics written: ${prefix}.{json,png}`,
+  );
 }

--- a/packages/core/src/operations/navigate-to-profile.ts
+++ b/packages/core/src/operations/navigate-to-profile.ts
@@ -139,12 +139,23 @@ function sanitizeForFilename(value: string): string {
 }
 
 /**
- * Cap on the wall-clock time the diagnostic capture may take before it is
- * abandoned.  Without this, a misbehaving CDP connection could prolong
- * error propagation by up to `CDPClient.send`'s own timeout per call
- * (`Runtime.evaluate` + `Page.captureScreenshot`).
+ * Cap on the wall-clock time the diagnostic capture is awaited before the
+ * caller's timeout is re-thrown.  Without this, a misbehaving CDP
+ * connection could prolong error propagation by up to `CDPClient.send`'s
+ * own timeout per call (`Runtime.evaluate` + `Page.captureScreenshot`).
  */
 const DIAGNOSTIC_CAPTURE_TIMEOUT_MS = 10_000;
+
+/**
+ * Mutable cancellation state shared between the outer wrapper and the
+ * inner capture body.  The wrapper flips `timedOut` when the bound timer
+ * wins the race; the inner body checks between each async step and
+ * returns early, giving up any remaining writes so the process can exit
+ * promptly.
+ */
+interface CaptureCancellationState {
+  timedOut: boolean;
+}
 
 /**
  * Best-effort diagnostic capture when `navigateToProfile` times out waiting
@@ -168,10 +179,17 @@ const DIAGNOSTIC_CAPTURE_TIMEOUT_MS = 10_000;
  * mode `0o600` (POSIX; no-op on Windows) so that personal data in a
  * shared `os.tmpdir()` is not exposed to other local users.
  *
- * The whole capture is bounded by
- * {@link DIAGNOSTIC_CAPTURE_TIMEOUT_MS}; any capture-side failure or
- * overrun is swallowed so the original timeout always propagates
- * unchanged.
+ * The capture is cooperatively cancellable and bounded by
+ * {@link DIAGNOSTIC_CAPTURE_TIMEOUT_MS}: the outer wrapper stops awaiting
+ * at the cap, and the inner body checks a shared cancellation flag
+ * between each step and returns early when it flips — so remaining CDP
+ * calls and disk writes are skipped rather than merely un-awaited.  In
+ * rare cases the in-flight async step started before the cap may still
+ * complete in the background; the process is not held alive by this
+ * function beyond the cap plus any such single in-flight step.
+ *
+ * Any capture-side failure is swallowed so the original timeout always
+ * propagates unchanged.
  *
  * @internal Exported for unit testing only; not part of the public API.
  */
@@ -180,12 +198,16 @@ export async function captureProfileLoadFailure(
   publicId: string,
 ): Promise<void> {
   if (process.env.LHREMOTE_CAPTURE_DIAGNOSTICS !== "1") return;
+  const state: CaptureCancellationState = { timedOut: false };
   let bound: NodeJS.Timeout | undefined;
   try {
     await Promise.race([
-      captureProfileLoadFailureInner(client, publicId),
+      captureProfileLoadFailureInner(client, publicId, state),
       new Promise<void>((resolve) => {
-        bound = setTimeout(resolve, DIAGNOSTIC_CAPTURE_TIMEOUT_MS);
+        bound = setTimeout(() => {
+          state.timedOut = true;
+          resolve();
+        }, DIAGNOSTIC_CAPTURE_TIMEOUT_MS);
       }),
     ]);
   } catch {
@@ -198,11 +220,13 @@ export async function captureProfileLoadFailure(
 async function captureProfileLoadFailureInner(
   client: CDPClient,
   publicId: string,
+  state: CaptureCancellationState,
 ): Promise<void> {
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
   const baseDir = join(tmpdir(), "lhremote-diagnostics");
   // 0o700: owner-only rwx.  POSIX-only; no-op on Windows.
   await mkdir(baseDir, { recursive: true, mode: 0o700 });
+  if (state.timedOut) return;
   const prefix = join(
     baseDir,
     `navigate-to-profile-${timestamp}-${sanitizeForFilename(publicId)}`,
@@ -223,18 +247,21 @@ async function captureProfileLoadFailureInner(
     hasMainH1: document.querySelector("main h1") !== null,
     bodyTextSnippet: (document.body ? document.body.innerText : "").slice(0, 800),
   }))()`);
+  if (state.timedOut) return;
 
   // 0o600: owner-only rw.  POSIX-only; no-op on Windows.
   await writeFile(`${prefix}.json`, JSON.stringify(info, null, 2), {
     encoding: "utf8",
     mode: 0o600,
   });
+  if (state.timedOut) return;
 
   try {
     const screenshot = (await client.send("Page.captureScreenshot", {
       format: "png",
       captureBeyondViewport: true,
     })) as { data?: string };
+    if (state.timedOut) return;
     if (screenshot.data) {
       await writeFile(`${prefix}.png`, Buffer.from(screenshot.data, "base64"), {
         mode: 0o600,
@@ -243,6 +270,7 @@ async function captureProfileLoadFailureInner(
   } catch {
     // Screenshot is best-effort; info.json is the primary artifact.
   }
+  if (state.timedOut) return;
 
   console.warn(
     `[navigateToProfile] timeout diagnostics written: ${prefix}.{json,png}`,

--- a/packages/core/src/operations/navigate-to-profile.ts
+++ b/packages/core/src/operations/navigate-to-profile.ts
@@ -28,7 +28,7 @@ export const LINKEDIN_PROFILE_RE = /^\/in\/([^/?#]+)/;
  * already key off.  Any one present indicates the profile card has
  * hydrated enough for follow-state or More-menu detection.
  */
-const PROFILE_READY_SELECTOR = [
+export const PROFILE_READY_SELECTOR = [
   'main button[aria-label^="Message"]',
   'main button[aria-label^="Follow "]',
   'main button[aria-label^="Following "]',
@@ -114,10 +114,8 @@ export async function navigateToProfile(
   try {
     await waitForElement(client, PROFILE_READY_SELECTOR, { timeout: 30_000 }, mouse);
   } catch (error) {
-    if (
-      error instanceof CDPTimeoutError &&
-      process.env.LHREMOTE_CAPTURE_DIAGNOSTICS === "1"
-    ) {
+    if (error instanceof CDPTimeoutError) {
+      // captureProfileLoadFailure self-gates on LHREMOTE_CAPTURE_DIAGNOSTICS.
       await captureProfileLoadFailure(client, publicId);
     }
     throw error;
@@ -128,34 +126,53 @@ export async function navigateToProfile(
 }
 
 /**
+ * Sanitize a value for use as a filename fragment: keep only a conservative
+ * filesystem-safe character set and cap length.  Public IDs come from
+ * `extractPublicId` which URL-decodes the slug, so encoded path separators
+ * (`%2F`, `%5C`) or parent-directory markers (`..`) could otherwise slip
+ * into the filename and allow directory traversal out of the diagnostics
+ * base directory.
+ */
+function sanitizeForFilename(value: string): string {
+  const safe = value.replace(/[^a-zA-Z0-9._-]/g, "_").slice(0, 120);
+  return safe.length > 0 ? safe : "unknown";
+}
+
+/**
  * Best-effort diagnostic capture when `navigateToProfile` times out waiting
  * for the profile action-button row.  Writes
  * `navigate-to-profile-{timestamp}-{publicId}.json` (URL, title, DOM
  * probes, visible text snippet) and `.png` (full-page
- * `Page.captureScreenshot`) under `${os.tmpdir()}/lhremote-diagnostics/`
- * so callers can classify the failure — auth wall, DOM change, or silent
- * navigation error.
+ * `Page.captureScreenshot` with `captureBeyondViewport: true`) under
+ * `${os.tmpdir()}/lhremote-diagnostics/` so callers can classify the
+ * failure — auth wall, DOM change, or silent navigation error.
  *
- * **Opt-in only.** Activated by `LHREMOTE_CAPTURE_DIAGNOSTICS=1`;
- * default-off in production (CLI, MCP server) because the artifacts can
- * contain personal data from the LinkedIn profile page.  E2E tests
- * activate it via `vitest.e2e.config.ts` `env` so every run produces
- * diagnostics without touching the codebase.
+ * **Opt-in only.** Self-gated on `LHREMOTE_CAPTURE_DIAGNOSTICS=1` — no-op
+ * otherwise.  Default-off in production (CLI, MCP server) because the
+ * artifacts can contain personal data from the LinkedIn profile page.
+ * E2E tests activate it via `vitest.e2e.config.ts` `env` so every run
+ * produces diagnostics without touching the codebase.
+ *
+ * `publicId` is sanitized before interpolation into the filename to
+ * prevent path traversal via URL-decoded slugs.
  *
  * Any capture-side failure is swallowed; the original timeout must
  * propagate unchanged.
+ *
+ * @internal Exported for unit testing only; not part of the public API.
  */
-async function captureProfileLoadFailure(
+export async function captureProfileLoadFailure(
   client: CDPClient,
   publicId: string,
 ): Promise<void> {
+  if (process.env.LHREMOTE_CAPTURE_DIAGNOSTICS !== "1") return;
   try {
     const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
     const baseDir = join(tmpdir(), "lhremote-diagnostics");
     await mkdir(baseDir, { recursive: true });
     const prefix = join(
       baseDir,
-      `navigate-to-profile-${timestamp}-${publicId}`,
+      `navigate-to-profile-${timestamp}-${sanitizeForFilename(publicId)}`,
     );
 
     const info = await client.evaluate<{
@@ -179,6 +196,7 @@ async function captureProfileLoadFailure(
     try {
       const screenshot = (await client.send("Page.captureScreenshot", {
         format: "png",
+        captureBeyondViewport: true,
       })) as { data?: string };
       if (screenshot.data) {
         await writeFile(`${prefix}.png`, Buffer.from(screenshot.data, "base64"));
@@ -187,7 +205,6 @@ async function captureProfileLoadFailure(
       // Screenshot is best-effort; info.json is the primary artifact.
     }
 
-    // eslint-disable-next-line no-console
     console.warn(
       `[navigateToProfile] timeout diagnostics written: ${prefix}.{json,png}`,
     );

--- a/packages/core/src/operations/navigate-to-profile.ts
+++ b/packages/core/src/operations/navigate-to-profile.ts
@@ -1,7 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
+import { mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import type { CDPClient } from "../cdp/client.js";
+import { CDPTimeoutError } from "../cdp/errors.js";
 import { waitForElement } from "../linkedin/dom-automation.js";
 import type { HumanizedMouse } from "../linkedin/humanized-mouse.js";
 import { gaussianDelay, maybeHesitate } from "../utils/delay.js";
@@ -13,8 +17,26 @@ import { navigateAwayIf } from "./navigate-away.js";
  */
 export const LINKEDIN_PROFILE_RE = /^\/in\/([^/?#]+)/;
 
-/** Selector that identifies a loaded profile page (name card heading). */
-const PROFILE_READY_SELECTOR = "main h1";
+/**
+ * Selector that identifies a loaded profile page.
+ *
+ * Matches any action button in the profile card action row — Message,
+ * Follow/Following, Connect/Pending, More actions.  LinkedIn no longer
+ * wraps the profile name in an `<h1>` element; action-button `aria-label`
+ * attributes remain stable across DOM redesigns and are the signal both
+ * downstream operations (unfollow-profile, hide-feed-author-profile)
+ * already key off.  Any one present indicates the profile card has
+ * hydrated enough for follow-state or More-menu detection.
+ */
+const PROFILE_READY_SELECTOR = [
+  'main button[aria-label^="Message"]',
+  'main button[aria-label^="Follow "]',
+  'main button[aria-label^="Following "]',
+  'main button[aria-label^="Connect"]',
+  'main button[aria-label^="Pending"]',
+  'main button[aria-label="More actions"]',
+  'main button[aria-label="More"]',
+].join(", ");
 
 /**
  * Extract the public ID (URL slug) from a LinkedIn profile URL.
@@ -68,8 +90,15 @@ export function buildProfileUrl(publicId: string): string {
  * Navigate the CDP-controlled LinkedIn tab to the profile identified by
  * `publicId`, forcing a full reload if the tab is already on a profile page.
  *
- * After navigation, waits for the profile heading (`main h1`) to appear
- * and inserts a short humanized dwell to let the SPA render action buttons.
+ * After navigation, waits for the profile action-button row (Message,
+ * Follow/Following, Connect/Pending, or More actions) to appear — any of
+ * these indicates the profile card has hydrated enough for downstream
+ * detection.  A short humanized dwell follows to let remaining action
+ * buttons fully render.
+ *
+ * On timeout, if `LHREMOTE_CAPTURE_DIAGNOSTICS=1`, a best-effort
+ * diagnostic capture is written to `${os.tmpdir()}/lhremote-diagnostics/`
+ * before the error propagates; see {@link captureProfileLoadFailure}.
  *
  * @param client   - Connected CDP client targeting a LinkedIn page.
  * @param publicId - LinkedIn public ID (URL slug), e.g. `"jane-doe-123"`.
@@ -82,8 +111,87 @@ export async function navigateToProfile(
 ): Promise<void> {
   await navigateAwayIf(client, "/in/");
   await client.navigate(buildProfileUrl(publicId));
-  await waitForElement(client, PROFILE_READY_SELECTOR, { timeout: 30_000 }, mouse);
+  try {
+    await waitForElement(client, PROFILE_READY_SELECTOR, { timeout: 30_000 }, mouse);
+  } catch (error) {
+    if (
+      error instanceof CDPTimeoutError &&
+      process.env.LHREMOTE_CAPTURE_DIAGNOSTICS === "1"
+    ) {
+      await captureProfileLoadFailure(client, publicId);
+    }
+    throw error;
+  }
   // Let the SPA finish hydrating action buttons (Follow, More, Message).
   await gaussianDelay(800, 200, 500, 1_500);
   await maybeHesitate();
+}
+
+/**
+ * Best-effort diagnostic capture when `navigateToProfile` times out waiting
+ * for the profile action-button row.  Writes
+ * `navigate-to-profile-{timestamp}-{publicId}.json` (URL, title, DOM
+ * probes, visible text snippet) and `.png` (full-page
+ * `Page.captureScreenshot`) under `${os.tmpdir()}/lhremote-diagnostics/`
+ * so callers can classify the failure — auth wall, DOM change, or silent
+ * navigation error.
+ *
+ * **Opt-in only.** Activated by `LHREMOTE_CAPTURE_DIAGNOSTICS=1`;
+ * default-off in production (CLI, MCP server) because the artifacts can
+ * contain personal data from the LinkedIn profile page.  E2E tests
+ * activate it via `vitest.e2e.config.ts` `env` so every run produces
+ * diagnostics without touching the codebase.
+ *
+ * Any capture-side failure is swallowed; the original timeout must
+ * propagate unchanged.
+ */
+async function captureProfileLoadFailure(
+  client: CDPClient,
+  publicId: string,
+): Promise<void> {
+  try {
+    const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+    const baseDir = join(tmpdir(), "lhremote-diagnostics");
+    await mkdir(baseDir, { recursive: true });
+    const prefix = join(
+      baseDir,
+      `navigate-to-profile-${timestamp}-${publicId}`,
+    );
+
+    const info = await client.evaluate<{
+      href: string;
+      title: string;
+      hasMain: boolean;
+      hasH1: boolean;
+      hasMainH1: boolean;
+      bodyTextSnippet: string;
+    }>(`(() => ({
+      href: location.href,
+      title: document.title,
+      hasMain: document.querySelector("main") !== null,
+      hasH1: document.querySelector("h1") !== null,
+      hasMainH1: document.querySelector("main h1") !== null,
+      bodyTextSnippet: (document.body ? document.body.innerText : "").slice(0, 800),
+    }))()`);
+
+    await writeFile(`${prefix}.json`, JSON.stringify(info, null, 2), "utf8");
+
+    try {
+      const screenshot = (await client.send("Page.captureScreenshot", {
+        format: "png",
+      })) as { data?: string };
+      if (screenshot.data) {
+        await writeFile(`${prefix}.png`, Buffer.from(screenshot.data, "base64"));
+      }
+    } catch {
+      // Screenshot is best-effort; info.json is the primary artifact.
+    }
+
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[navigateToProfile] timeout diagnostics written: ${prefix}.{json,png}`,
+    );
+  } catch {
+    // Capture itself failed; do not mask the caller's timeout.
+  }
 }

--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -9,5 +9,12 @@ export default defineConfig({
     exclude: ["**/node_modules/**", "**/dist/**"],
     passWithNoTests: true,
     fileParallelism: false,
+    env: {
+      // Opt in to timeout-failure diagnostics (screenshots, DOM probes)
+      // for every E2E run.  Production callers (CLI, MCP) remain default-off
+      // — see `captureProfileLoadFailure` in navigate-to-profile.ts and
+      // ADR-007.
+      LHREMOTE_CAPTURE_DIAGNOSTICS: "1",
+    },
   },
 });


### PR DESCRIPTION
## Summary

- LinkedIn profile pages no longer contain `<h1>` elements, so `PROFILE_READY_SELECTOR = "main h1"` timed out after 30s and broke both profile-based E2E tests (`unfollow-profile`, `hide-feed-author-profile`).
- Replace the selector with a disjunction of profile action-button `aria-label` prefixes — `Message`, `Follow`, `Following`, `Connect`, `Pending`, `More actions`, `More`. These track accessibility semantics rather than DOM structure and match the pattern downstream detection selectors already use.
- Add **opt-in** timeout diagnostics: on `CDPTimeoutError`, capture `{href, title, DOM probes, full-page screenshot}` under `${os.tmpdir()}/lhremote-diagnostics/` when `LHREMOTE_CAPTURE_DIAGNOSTICS=1`. E2E runs set the env var via `vitest.e2e.config.ts`; CLI/MCP callers stay default-off so personal data from profile screenshots never lands on user disks silently.
- Document the convention in **[ADR-007](docs/adr/007-profile-ready-selector-strategy.md)**.

Closes #751

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm --filter @lhremote/core test` — clean (unit + integration)
- [x] `pnpm --filter @lhremote/e2e test:e2e:file unfollow-profile` — passes locally (13.7 s)
- [x] `pnpm --filter @lhremote/e2e test:e2e:file hide-feed-author-profile` — passes locally (17.6 s)
- [x] Diagnostic path verified: when env var set and timeout occurs, artifacts written to `${os.tmpdir()}/lhremote-diagnostics/navigate-to-profile-{timestamp}-{publicId}.{json,png}`
- [x] Diagnostic path verified: when env var unset, no disk writes on timeout (default for CLI/MCP)

## Risk

- Selector is English-locale-coupled (`aria-label^="Message"` etc.) — acceptable for current scope (LH default locale is English); flagged in ADR-007 Consequences as a follow-up before i18n.
- Self-profile edge case (viewing own profile shows no action buttons) is out of scope — profile-write operations cannot target self.

🤖 Generated with [Claude Code](https://claude.com/claude-code)