### PR TITLE
(fix) core,mcp,cli: accept /company/ URLs in unfollow-profile

### DIFF
--- a/docs/adr/007-profile-ready-selector-strategy.md
+++ b/docs/adr/007-profile-ready-selector-strategy.md
@@ -1,8 +1,10 @@
-# ADR-007: Profile Page Readiness Selector Strategy
+# ADR-007: Profile and Company Page Readiness Selector Strategy
 
 ## Status
 
-Accepted (2026-04-19)
+Accepted (2026-04-19); amended 2026-04-29 to extend the readiness selector's
+empirical scope from member profile pages to LinkedIn organization
+(`/company/{slug}/`) pages — see § Amendments.
 
 ## Context
 
@@ -68,7 +70,49 @@ Any single match indicates the profile card has hydrated far enough for follow-s
 | `waitForEvent("Page.frameStoppedLoading")` | Same root issue — SPA navigations don't always trigger frame load events. |
 | Keep `main h1` + fall back | Adds latency on every run once the primary selector is known-dead. |
 
+## Amendments
+
+### 2026-04-29 — Company-page coverage (`navigateToCompany`)
+
+`navigateToCompany` was added alongside `navigateToProfile` to support
+unfollowing LinkedIn organization pages (`/company/{slug}/`) — see
+issue #757. Both functions reuse `PROFILE_READY_SELECTOR` because the
+selector's CSS-disjunction semantics make the profile-only variants
+(`Message`, `Connect`, `Pending`) unreachable on company pages without
+producing a false positive — they simply do not match. `Follow `,
+`Following `, and the `More` / `More actions` overflow buttons are
+present on both surfaces and provide the readiness signal.
+
+**Empirical scope of this amendment**:
+
+- The original 2026-04-19 study (this ADR's body) verified the
+  selector against rendered profile-page DOM (`/in/{publicId}/`).
+- The 2026-04-29 extension to company pages was justified analytically
+  (CSS OR semantics + reporter testimony in issue #757 that "the
+  Following toggle on company pages works the same way as on personal
+  profiles") and verified at the unit level (mock-based dispatch
+  tests) plus E2E-test infrastructure parameterized on
+  `LHREMOTE_E2E_COMPANY_URL`. The empirical company-page DOM has not
+  been studied with the same depth as profile pages — when the next
+  selector regression occurs on company pages, the diagnostic capture
+  (now kind-tagged: `navigate-to-company-{ts}-{slug}.{json,png}`)
+  should produce evidence equivalent to the original profile-page
+  study.
+- If the empirical premise turns out to be false on company pages
+  (e.g., LinkedIn renders `Follow company` instead of `Follow `, or
+  exposes the toggle through a different aria-label shape), the
+  remediation path is to extend `PROFILE_READY_SELECTOR` with the
+  observed company-page variants, not to fork the selector.
+
+**Diagnostic filename rule extends to company navigation**: artifacts
+land at `${os.tmpdir()}/lhremote-diagnostics/navigate-to-{profile,company}-{timestamp}-{slug}.{json,png}`,
+where the kind tag identifies which navigator timed out. Caller-label
+in the `console.warn` line follows the same convention
+(`[navigateToProfile]` vs `[navigateToCompany]`).
+
 ## Related
 
 - Code: `packages/core/src/operations/navigate-to-profile.ts`
-- Branch: `fix/navigate-to-profile-diagnostics`
+- Branch: `fix/navigate-to-profile-diagnostics` (initial selector
+  decision); `fix/unfollow-profile-company-urls` (2026-04-29 amendment)
+- Issues: #757 (company-page extension)

--- a/packages/cli/src/handlers/unfollow-profile.ts
+++ b/packages/cli/src/handlers/unfollow-profile.ts
@@ -39,17 +39,29 @@ export async function handleUnfollowProfile(
     return;
   }
 
+  const targetLabel = result.targetKind === "company" ? "Company" : "Profile";
+  const pageLabel =
+    result.targetKind === "company" ? "company page" : "profile page";
+
   if (result.priorState === "not_following") {
     process.stdout.write(
-      `Profile "${result.publicId}" was not being followed (no action taken)\n`,
+      `${targetLabel} "${result.publicId}" was not being followed (no action taken)\n`,
     );
     return;
   }
 
   if (result.priorState === "unknown") {
+    // "private/blocked" describes member profiles; companies are
+    // "restricted" rather than "private", so use kind-specific wording
+    // so the message accurately describes why the page may have hidden
+    // the Follow / Following toggle.
+    const accessReason =
+      result.targetKind === "company"
+        ? "restricted/unavailable company"
+        : "private/blocked profile";
     process.stdout.write(
       `Could not detect follow state for "${result.publicId}" ` +
-        "(private/blocked profile, or LinkedIn DOM changed — no action taken)\n",
+        `(${accessReason}, or LinkedIn DOM changed — no action taken)\n`,
     );
     return;
   }
@@ -57,13 +69,13 @@ export async function handleUnfollowProfile(
   const name = result.unfollowedName ?? result.publicId;
   if (result.dryRun) {
     process.stdout.write(
-      `[dry-run] Would unfollow "${name}" from their profile page\n` +
-        `  Profile: ${result.profileUrl}\n`,
+      `[dry-run] Would unfollow "${name}" from the ${pageLabel}\n` +
+        `  ${targetLabel}: ${result.profileUrl}\n`,
     );
   } else {
     process.stdout.write(
-      `Unfollowed "${name}" from their profile page\n` +
-        `  Profile: ${result.profileUrl}\n`,
+      `Unfollowed "${name}" from the ${pageLabel}\n` +
+        `  ${targetLabel}: ${result.profileUrl}\n`,
     );
   }
 }

--- a/packages/cli/src/program.ts
+++ b/packages/cli/src/program.ts
@@ -834,8 +834,8 @@ export function createProgram(): Command {
 
   program
     .command("unfollow-profile")
-    .description("Unfollow a LinkedIn profile by navigating to the profile page and clicking Following → Unfollow")
-    .argument("<profileUrl>", "LinkedIn profile URL")
+    .description("Unfollow a LinkedIn member profile or organization page by navigating to it and clicking Following → Unfollow")
+    .argument("<profileUrl>", "LinkedIn profile URL (/in/{publicId}/) or company URL (/company/{slug}/)")
     .option("--cdp-port <port>", "CDP debugging port (auto-discovered when omitted)", parsePositiveInt)
     .option("--cdp-host <host>", "CDP host (default: 127.0.0.1)")
     .option("--allow-remote", "SECURITY: allow non-loopback CDP connections (enables remote code execution on target)")

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -422,10 +422,15 @@ export {
   type UnfollowProfileInput,
   type UnfollowProfileOutput,
   type UnfollowProfilePriorState,
-  // Profile navigation helpers
+  // Profile and company navigation helpers
+  buildCompanyUrl,
   buildProfileUrl,
+  extractFollowableTarget,
   extractPublicId,
+  type FollowableTarget,
+  LINKEDIN_COMPANY_RE,
   LINKEDIN_PROFILE_RE,
+  navigateToCompany,
   navigateToProfile,
   // Individual actions (ephemeral campaign)
   type EphemeralActionInput,

--- a/packages/core/src/operations/index.ts
+++ b/packages/core/src/operations/index.ts
@@ -282,10 +282,15 @@ export {
   type VisitProfileOutput,
 } from "./visit-profile.js";
 export {
+  buildCompanyUrl,
   buildProfileUrl,
+  extractFollowableTarget,
   extractPublicId,
+  LINKEDIN_COMPANY_RE,
   LINKEDIN_PROFILE_RE,
+  navigateToCompany,
   navigateToProfile,
+  type FollowableTarget,
 } from "./navigate-to-profile.js";
 
 // Post interaction

--- a/packages/core/src/operations/navigate-to-profile.test.ts
+++ b/packages/core/src/operations/navigate-to-profile.test.ts
@@ -16,9 +16,13 @@ vi.mock("node:fs/promises", () => ({
 }));
 
 const {
+  buildCompanyUrl,
   buildProfileUrl,
+  captureCompanyLoadFailure,
   captureProfileLoadFailure,
+  extractFollowableTarget,
   extractPublicId,
+  LINKEDIN_COMPANY_RE,
   LINKEDIN_PROFILE_RE,
   PROFILE_READY_SELECTOR,
 } = await import("./navigate-to-profile.js");
@@ -40,6 +44,28 @@ describe("LINKEDIN_PROFILE_RE", () => {
     ["in/jane-doe/"], // no leading slash
   ])("does NOT match pathname %s", (pathname) => {
     expect(LINKEDIN_PROFILE_RE.exec(pathname)).toBeNull();
+  });
+});
+
+describe("LINKEDIN_COMPANY_RE", () => {
+  it.each([
+    ["/company/acme/", "acme"],
+    ["/company/acme", "acme"],
+    ["/company/mirohq/", "mirohq"],
+    ["/company/slug-with-dashes-123/", "slug-with-dashes-123"],
+    ["/company/acme/about/", "acme"],
+    ["/company/acme/people/", "acme"],
+  ])("matches pathname %s", (pathname, expected) => {
+    const match = LINKEDIN_COMPANY_RE.exec(pathname);
+    expect(match?.[1]).toBe(expected);
+  });
+
+  it.each([
+    ["/in/jane-doe/"],
+    ["/foo/bar"],
+    ["company/acme/"], // no leading slash
+  ])("does NOT match pathname %s", (pathname) => {
+    expect(LINKEDIN_COMPANY_RE.exec(pathname)).toBeNull();
   });
 });
 
@@ -75,7 +101,8 @@ describe("extractPublicId", () => {
   });
 
   it.each([
-    // Non-profile LinkedIn paths
+    // Non-profile LinkedIn paths — extractPublicId is profile-only;
+    // extractFollowableTarget covers /company/.
     ["https://www.linkedin.com/company/acme/"],
     ["https://www.linkedin.com/feed/"],
     // Non-LinkedIn hosts
@@ -92,6 +119,138 @@ describe("extractPublicId", () => {
   ])("throws on invalid URL %s", (url) => {
     expect(() => extractPublicId(url)).toThrow("Invalid LinkedIn profile URL");
   });
+
+  it("converts URIError from malformed percent-encoding into the validation error", () => {
+    // `%ZZ` is syntactically a percent-escape but invalid hex; native
+    // `decodeURIComponent` throws `URIError`.  The function must catch
+    // and re-throw the standard validation error so callers see one
+    // uniform error class and message.
+    expect(() => extractPublicId("https://www.linkedin.com/in/foo%ZZ/")).toThrow(
+      "Invalid LinkedIn profile URL",
+    );
+  });
+});
+
+describe("extractFollowableTarget", () => {
+  it("returns a profile target for /in/{publicId}/ URLs", () => {
+    expect(extractFollowableTarget("https://www.linkedin.com/in/jane-doe/")).toEqual({
+      kind: "profile",
+      publicId: "jane-doe",
+    });
+  });
+
+  it("returns a company target for /company/{slug}/ URLs", () => {
+    expect(
+      extractFollowableTarget("https://www.linkedin.com/company/mirohq/"),
+    ).toEqual({
+      kind: "company",
+      slug: "mirohq",
+    });
+  });
+
+  it("returns a company target without a trailing slash", () => {
+    expect(
+      extractFollowableTarget("https://www.linkedin.com/company/acme"),
+    ).toEqual({
+      kind: "company",
+      slug: "acme",
+    });
+  });
+
+  it("captures only the slug segment from /company/{slug}/about/", () => {
+    expect(
+      extractFollowableTarget("https://www.linkedin.com/company/acme/about/"),
+    ).toEqual({
+      kind: "company",
+      slug: "acme",
+    });
+  });
+
+  it("URL-decodes percent-encoded company slugs", () => {
+    expect(
+      extractFollowableTarget("https://www.linkedin.com/company/jos%C3%A9-corp/"),
+    ).toEqual({
+      kind: "company",
+      slug: "josé-corp",
+    });
+  });
+
+  it("strips query and fragment for company URLs", () => {
+    expect(
+      extractFollowableTarget(
+        "https://www.linkedin.com/company/acme/?foo=bar#baz",
+      ),
+    ).toEqual({
+      kind: "company",
+      slug: "acme",
+    });
+  });
+
+  it("accepts locale subdomains for company URLs", () => {
+    expect(
+      extractFollowableTarget("https://fr.linkedin.com/company/acme/"),
+    ).toEqual({
+      kind: "company",
+      slug: "acme",
+    });
+  });
+
+  it("accepts http scheme for company URLs", () => {
+    expect(
+      extractFollowableTarget("http://www.linkedin.com/company/acme/"),
+    ).toEqual({
+      kind: "company",
+      slug: "acme",
+    });
+  });
+
+  it("accepts linkedin.com without www for company URLs", () => {
+    expect(
+      extractFollowableTarget("https://linkedin.com/company/acme"),
+    ).toEqual({
+      kind: "company",
+      slug: "acme",
+    });
+  });
+
+  it.each([
+    // Non-followable LinkedIn paths
+    ["https://www.linkedin.com/feed/"],
+    ["https://www.linkedin.com/groups/123/"],
+    ["https://www.linkedin.com/school/mit/"],
+    // Non-LinkedIn hosts
+    ["https://example.com/in/jane-doe/"],
+    ["https://example.com/company/acme/"],
+    ["https://notlinkedin.com/company/acme/"],
+    ["https://linkedin.com.evil.com/company/acme/"],
+    // Embedded link in a non-LinkedIn URL — must NOT match
+    ["https://example.com/?next=https://www.linkedin.com/company/acme/"],
+    ["https://example.com/#https://www.linkedin.com/company/acme/"],
+    // Malformed / unparseable
+    ["not-a-url"],
+    [""],
+    ["/company/acme/"], // no scheme
+  ])("throws on invalid URL %s", (url) => {
+    expect(() => extractFollowableTarget(url)).toThrow(
+      "Invalid LinkedIn profile or company URL",
+    );
+  });
+
+  it.each([
+    // `%ZZ` is syntactically a percent-escape but invalid hex; native
+    // `decodeURIComponent` throws `URIError`.  Both the profile and the
+    // company branch must catch and re-throw the standard validation
+    // error so callers see one uniform error class and message.
+    ["https://www.linkedin.com/in/foo%ZZ/"],
+    ["https://www.linkedin.com/company/acme%ZZ/"],
+  ])(
+    "converts URIError from malformed percent-encoding into the validation error: %s",
+    (url) => {
+      expect(() => extractFollowableTarget(url)).toThrow(
+        "Invalid LinkedIn profile or company URL",
+      );
+    },
+  );
 });
 
 describe("PROFILE_READY_SELECTOR", () => {
@@ -252,5 +411,96 @@ describe("buildProfileUrl", () => {
   it("round-trips through extractPublicId", () => {
     const slug = "some-weird-slug-123";
     expect(extractPublicId(buildProfileUrl(slug))).toBe(slug);
+  });
+});
+
+describe("buildCompanyUrl", () => {
+  it("builds the canonical company URL", () => {
+    expect(buildCompanyUrl("mirohq")).toBe(
+      "https://www.linkedin.com/company/mirohq/",
+    );
+  });
+
+  it("URL-encodes non-ASCII slugs", () => {
+    expect(buildCompanyUrl("josé-corp")).toBe(
+      "https://www.linkedin.com/company/jos%C3%A9-corp/",
+    );
+  });
+
+  it("round-trips through extractFollowableTarget", () => {
+    const slug = "some-weird-slug-123";
+    const target = extractFollowableTarget(buildCompanyUrl(slug));
+    expect(target).toEqual({ kind: "company", slug });
+  });
+});
+
+describe("captureCompanyLoadFailure", () => {
+  const originalEnv = process.env.LHREMOTE_CAPTURE_DIAGNOSTICS;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.LHREMOTE_CAPTURE_DIAGNOSTICS;
+    } else {
+      process.env.LHREMOTE_CAPTURE_DIAGNOSTICS = originalEnv;
+    }
+  });
+
+  function makeClient(): CDPClient {
+    return {
+      evaluate: vi.fn().mockResolvedValue({
+        href: "https://www.linkedin.com/company/mirohq/",
+        title: "Miro | LinkedIn",
+        hasMain: true,
+        hasH1: false,
+        hasMainH1: false,
+        bodyTextSnippet: "Miro\nVisual collaboration\n",
+      }),
+      send: vi.fn().mockResolvedValue({ data: "aGVsbG8=" }),
+    } as unknown as CDPClient;
+  }
+
+  it("is a no-op when LHREMOTE_CAPTURE_DIAGNOSTICS is unset", async () => {
+    delete process.env.LHREMOTE_CAPTURE_DIAGNOSTICS;
+    const client = makeClient();
+
+    await captureCompanyLoadFailure(client, "mirohq");
+
+    expect(client.evaluate).not.toHaveBeenCalled();
+    expect(client.send).not.toHaveBeenCalled();
+  });
+
+  it("captures DOM probes and screenshot when LHREMOTE_CAPTURE_DIAGNOSTICS=1", async () => {
+    process.env.LHREMOTE_CAPTURE_DIAGNOSTICS = "1";
+    const client = makeClient();
+
+    await captureCompanyLoadFailure(client, "mirohq");
+
+    expect(client.evaluate).toHaveBeenCalledTimes(1);
+    expect(client.send).toHaveBeenCalledWith("Page.captureScreenshot", {
+      format: "png",
+      captureBeyondViewport: true,
+    });
+  });
+
+  it("writes diagnostics with the navigate-to-company prefix (not navigate-to-profile)", async () => {
+    process.env.LHREMOTE_CAPTURE_DIAGNOSTICS = "1";
+    const client = makeClient();
+    const { writeFile } = await import("node:fs/promises");
+    const writeFileMock = vi.mocked(writeFile);
+    writeFileMock.mockClear();
+
+    await captureCompanyLoadFailure(client, "mirohq");
+
+    expect(writeFileMock.mock.calls.length).toBeGreaterThanOrEqual(1);
+    for (const call of writeFileMock.mock.calls) {
+      const filePath = String(call[0]);
+      const lastSep = Math.max(filePath.lastIndexOf("/"), filePath.lastIndexOf("\\"));
+      const filename = lastSep >= 0 ? filePath.slice(lastSep + 1) : filePath;
+      expect(filename).toMatch(/^navigate-to-company-[\w.-]+\.(json|png)$/);
+    }
   });
 });

--- a/packages/core/src/operations/navigate-to-profile.ts
+++ b/packages/core/src/operations/navigate-to-profile.ts
@@ -18,15 +18,40 @@ import { navigateAwayIf } from "./navigate-away.js";
 export const LINKEDIN_PROFILE_RE = /^\/in\/([^/?#]+)/;
 
 /**
- * Selector that identifies a loaded profile page.
+ * Regex matching a LinkedIn company URL *pathname* (not the full URL) and
+ * capturing the company slug from the first `/company/{slug}` segment.
  *
- * Matches any action button in the profile card action row — Message,
+ * LinkedIn's company pages live at `/company/{slug}/` and expose the same
+ * Follow / Following toggle as member profiles, so org-level unfollow
+ * workflows can target them with the same DOM-detection strategy.
+ */
+export const LINKEDIN_COMPANY_RE = /^\/company\/([^/?#]+)/;
+
+/**
+ * Discriminated union representing a LinkedIn followable entity — either a
+ * member profile or an organization page.  Returned by
+ * {@link extractFollowableTarget} so that downstream code can dispatch
+ * navigation and naming based on the target kind.
+ */
+export type FollowableTarget =
+  | { readonly kind: "profile"; readonly publicId: string }
+  | { readonly kind: "company"; readonly slug: string };
+
+/**
+ * Selector that identifies a loaded profile or company page.
+ *
+ * Matches any action button in the page's primary action row — Message,
  * Follow/Following, Connect/Pending, More actions.  LinkedIn no longer
  * wraps the profile name in an `<h1>` element; action-button `aria-label`
  * attributes remain stable across DOM redesigns and are the signal both
  * downstream operations (unfollow-profile, hide-feed-author-profile)
- * already key off.  Any one present indicates the profile card has
- * hydrated enough for follow-state or More-menu detection.
+ * already key off.  Any one present indicates the page has hydrated
+ * enough for follow-state or More-menu detection.
+ *
+ * Company pages do not render Message/Connect/Pending, but they do render
+ * Follow/Following/More — and this selector is a comma-separated
+ * disjunction (CSS OR semantics), so any matching button satisfies the
+ * readiness gate for both profiles and company pages.
  */
 export const PROFILE_READY_SELECTOR = [
   'main button[aria-label^="Message"]',
@@ -73,7 +98,17 @@ export function extractPublicId(url: string): string {
       `Invalid LinkedIn profile URL: ${url}. Expected format: https://www.linkedin.com/in/<public-id>`,
     );
   }
-  return decodeURIComponent(match[1]);
+  // Malformed percent-encoding (e.g. `%ZZ`) makes `decodeURIComponent`
+  // throw `URIError`; convert to the standard validation error so callers
+  // see a uniform message and can route by error.message rather than
+  // distinguishing two unrelated error classes.
+  try {
+    return decodeURIComponent(match[1]);
+  } catch {
+    throw new Error(
+      `Invalid LinkedIn profile URL: ${url}. Expected format: https://www.linkedin.com/in/<public-id>`,
+    );
+  }
 }
 
 /**
@@ -84,6 +119,90 @@ export function extractPublicId(url: string): string {
  */
 export function buildProfileUrl(publicId: string): string {
   return `https://www.linkedin.com/in/${encodeURIComponent(publicId)}/`;
+}
+
+/**
+ * Build a canonical LinkedIn company URL from a slug.
+ *
+ * The slug is URL-encoded before interpolation so values containing
+ * characters that require percent-encoding produce valid URLs.
+ */
+export function buildCompanyUrl(slug: string): string {
+  return `https://www.linkedin.com/company/${encodeURIComponent(slug)}/`;
+}
+
+/**
+ * Extract the followable target (profile or company) from a LinkedIn URL.
+ *
+ * The URL is parsed with {@link URL} and validated: the hostname must end
+ * with `linkedin.com` and the pathname must start with either
+ * `/in/{publicId}` (member profile) or `/company/{slug}` (organization
+ * page).  The captured slug is URL-decoded before being returned.
+ * Relative URLs, query-embedded LinkedIn links (e.g. `?next=...`), and
+ * non-LinkedIn hosts are all rejected with a descriptive error.
+ *
+ * Profile-only callers should continue to use {@link extractPublicId}
+ * (it throws on company URLs); use this function when both kinds of
+ * follow targets are valid input — for example, in `unfollow-profile`,
+ * which mirrors LinkedIn's Following toggle on both pages.
+ *
+ * @throws If `url` is not a well-formed LinkedIn profile or company URL.
+ */
+export function extractFollowableTarget(url: string): FollowableTarget {
+  const expectedFormat =
+    "Expected format: https://www.linkedin.com/in/<public-id> " +
+    "or https://www.linkedin.com/company/<slug>";
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(
+      `Invalid LinkedIn profile or company URL: ${url}. ${expectedFormat}`,
+    );
+  }
+
+  const host = parsed.hostname.toLowerCase();
+  const isLinkedInHost = host === "linkedin.com" || host.endsWith(".linkedin.com");
+  if (!isLinkedInHost) {
+    throw new Error(
+      `Invalid LinkedIn profile or company URL: ${url}. ${expectedFormat}`,
+    );
+  }
+
+  // Malformed percent-encoding (e.g. `%ZZ`) makes `decodeURIComponent`
+  // throw `URIError`; convert to the standard validation error here so
+  // callers see a uniform `Invalid LinkedIn profile or company URL`
+  // message instead of a `URIError` leaking through.
+  const safeDecode = (segment: string): string => {
+    try {
+      return decodeURIComponent(segment);
+    } catch {
+      throw new Error(
+        `Invalid LinkedIn profile or company URL: ${url}. ${expectedFormat}`,
+      );
+    }
+  };
+
+  const profileMatch = LINKEDIN_PROFILE_RE.exec(parsed.pathname);
+  if (profileMatch?.[1]) {
+    return {
+      kind: "profile" as const,
+      publicId: safeDecode(profileMatch[1]),
+    };
+  }
+
+  const companyMatch = LINKEDIN_COMPANY_RE.exec(parsed.pathname);
+  if (companyMatch?.[1]) {
+    return {
+      kind: "company" as const,
+      slug: safeDecode(companyMatch[1]),
+    };
+  }
+
+  throw new Error(
+    `Invalid LinkedIn profile or company URL: ${url}. ${expectedFormat}`,
+  );
 }
 
 /**
@@ -126,12 +245,52 @@ export async function navigateToProfile(
 }
 
 /**
+ * Navigate the CDP-controlled LinkedIn tab to the organization page
+ * identified by `slug`, forcing a full reload if the tab is already on a
+ * company page.
+ *
+ * Company pages expose the same Follow / Following toggle as member
+ * profiles, so the readiness wait reuses {@link PROFILE_READY_SELECTOR} —
+ * its `Follow ` / `Following ` / `More` aria-label fragments match on
+ * company pages, and the comma-separated disjunction tolerates the
+ * absence of person-only buttons (Message, Connect, Pending).
+ *
+ * On timeout, if `LHREMOTE_CAPTURE_DIAGNOSTICS=1`, a best-effort
+ * diagnostic capture is written to `${os.tmpdir()}/lhremote-diagnostics/`
+ * before the error propagates; see {@link captureCompanyLoadFailure}.
+ *
+ * @param client - Connected CDP client targeting a LinkedIn page.
+ * @param slug   - LinkedIn company slug (URL segment), e.g. `"mirohq"`.
+ * @param mouse  - Optional humanized mouse for idle drift during waits.
+ */
+export async function navigateToCompany(
+  client: CDPClient,
+  slug: string,
+  mouse?: HumanizedMouse | null | undefined,
+): Promise<void> {
+  await navigateAwayIf(client, "/company/");
+  await client.navigate(buildCompanyUrl(slug));
+  try {
+    await waitForElement(client, PROFILE_READY_SELECTOR, { timeout: 30_000 }, mouse);
+  } catch (error) {
+    if (error instanceof CDPTimeoutError) {
+      // captureCompanyLoadFailure self-gates on LHREMOTE_CAPTURE_DIAGNOSTICS.
+      await captureCompanyLoadFailure(client, slug);
+    }
+    throw error;
+  }
+  // Let the SPA finish hydrating action buttons (Follow, More).
+  await gaussianDelay(800, 200, 500, 1_500);
+  await maybeHesitate();
+}
+
+/**
  * Sanitize a value for use as a filename fragment: keep only a conservative
- * filesystem-safe character set and cap length.  Public IDs come from
- * `extractPublicId` which URL-decodes the slug, so encoded path separators
- * (`%2F`, `%5C`) or parent-directory markers (`..`) could otherwise slip
- * into the filename and allow directory traversal out of the diagnostics
- * base directory.
+ * filesystem-safe character set and cap length.  Slugs come from
+ * `extractPublicId` or `extractFollowableTarget`, both of which URL-decode
+ * their captured segments, so encoded path separators (`%2F`, `%5C`) or
+ * parent-directory markers (`..`) could otherwise slip into the filename
+ * and allow directory traversal out of the diagnostics base directory.
  */
 function sanitizeForFilename(value: string): string {
   const safe = value.replace(/[^a-zA-Z0-9._-]/g, "_").slice(0, 120);
@@ -197,12 +356,44 @@ export async function captureProfileLoadFailure(
   client: CDPClient,
   publicId: string,
 ): Promise<void> {
+  await captureNavigationLoadFailure(client, publicId, "profile");
+}
+
+/**
+ * Best-effort diagnostic capture when `navigateToCompany` times out
+ * waiting for the action-button row on a company page.  Mirrors
+ * {@link captureProfileLoadFailure} — same gating, same artifact
+ * structure, same cancellation discipline — but writes
+ * `navigate-to-company-{timestamp}-{slug}.json` / `.png` so the kind of
+ * navigation that failed is identifiable from the filename alone.
+ *
+ * @internal Exported for unit testing only; not part of the public API.
+ */
+export async function captureCompanyLoadFailure(
+  client: CDPClient,
+  slug: string,
+): Promise<void> {
+  await captureNavigationLoadFailure(client, slug, "company");
+}
+
+/**
+ * Shared core of {@link captureProfileLoadFailure} and
+ * {@link captureCompanyLoadFailure}: enforces the env-var gate, the
+ * timeout race, and the cancellation flag, then delegates the actual
+ * capture to {@link captureNavigationLoadFailureInner} with a kind-tagged
+ * filename prefix.
+ */
+async function captureNavigationLoadFailure(
+  client: CDPClient,
+  slug: string,
+  kind: "profile" | "company",
+): Promise<void> {
   if (process.env.LHREMOTE_CAPTURE_DIAGNOSTICS !== "1") return;
   const state: CaptureCancellationState = { timedOut: false };
   let bound: NodeJS.Timeout | undefined;
   try {
     await Promise.race([
-      captureProfileLoadFailureInner(client, publicId, state),
+      captureNavigationLoadFailureInner(client, slug, kind, state),
       new Promise<void>((resolve) => {
         bound = setTimeout(() => {
           state.timedOut = true;
@@ -217,9 +408,10 @@ export async function captureProfileLoadFailure(
   }
 }
 
-async function captureProfileLoadFailureInner(
+async function captureNavigationLoadFailureInner(
   client: CDPClient,
-  publicId: string,
+  slug: string,
+  kind: "profile" | "company",
   state: CaptureCancellationState,
 ): Promise<void> {
   const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
@@ -229,7 +421,7 @@ async function captureProfileLoadFailureInner(
   if (state.timedOut) return;
   const prefix = join(
     baseDir,
-    `navigate-to-profile-${timestamp}-${sanitizeForFilename(publicId)}`,
+    `navigate-to-${kind}-${timestamp}-${sanitizeForFilename(slug)}`,
   );
 
   const info = await client.evaluate<{
@@ -272,7 +464,8 @@ async function captureProfileLoadFailureInner(
   }
   if (state.timedOut) return;
 
+  const callerLabel = kind === "profile" ? "navigateToProfile" : "navigateToCompany";
   console.warn(
-    `[navigateToProfile] timeout diagnostics written: ${prefix}.{json,png}`,
+    `[${callerLabel}] timeout diagnostics written: ${prefix}.{json,png}`,
   );
 }

--- a/packages/core/src/operations/unfollow-profile.test.ts
+++ b/packages/core/src/operations/unfollow-profile.test.ts
@@ -27,16 +27,18 @@ vi.mock("./navigate-to-profile.js", async (importOriginal) => {
   return {
     ...actual,
     navigateToProfile: vi.fn().mockResolvedValue(undefined),
+    navigateToCompany: vi.fn().mockResolvedValue(undefined),
   };
 });
 
 import { CDPClient } from "../cdp/client.js";
 import { discoverTargets } from "../cdp/discovery.js";
 import { retryInteraction } from "../linkedin/dom-automation.js";
-import { navigateToProfile } from "./navigate-to-profile.js";
+import { navigateToCompany, navigateToProfile } from "./navigate-to-profile.js";
 import { unfollowProfile } from "./unfollow-profile.js";
 
 const PROFILE_URL = "https://www.linkedin.com/in/jane-doe/";
+const COMPANY_URL = "https://www.linkedin.com/company/mirohq/";
 const FOLLOWING_SELECTOR = 'main button[aria-label^="Following "]';
 const FOLLOW_SELECTOR = 'main button[aria-label^="Follow "]';
 
@@ -78,7 +80,7 @@ describe("unfollowProfile", () => {
         profileUrl: "https://example.com/not-a-profile",
         cdpPort: 9222,
       }),
-    ).rejects.toThrow("Invalid LinkedIn profile URL");
+    ).rejects.toThrow("Invalid LinkedIn profile or company URL");
 
     expect(discoverTargets).not.toHaveBeenCalled();
   });
@@ -139,6 +141,7 @@ describe("unfollowProfile", () => {
       success: true,
       profileUrl: PROFILE_URL,
       publicId: "jane-doe",
+      targetKind: "profile",
       priorState: "not_following",
       unfollowedName: null,
       dryRun: false,
@@ -159,6 +162,7 @@ describe("unfollowProfile", () => {
       "jane-doe",
       undefined,
     );
+    expect(navigateToCompany).not.toHaveBeenCalled();
   });
 
   it("returns priorState=unknown without clicking when neither button is found", async () => {
@@ -175,6 +179,7 @@ describe("unfollowProfile", () => {
       success: true,
       profileUrl: PROFILE_URL,
       publicId: "jane-doe",
+      targetKind: "profile",
       priorState: "unknown",
       unfollowedName: null,
       dryRun: false,
@@ -201,6 +206,7 @@ describe("unfollowProfile", () => {
       success: true,
       profileUrl: PROFILE_URL,
       publicId: "jane-doe",
+      targetKind: "profile",
       priorState: "following",
       unfollowedName: "Jane Doe",
       dryRun: false,
@@ -279,5 +285,117 @@ describe("unfollowProfile", () => {
     // This pins the selector strategy so accidental changes break the test.
     expect(FOLLOWING_SELECTOR).toBe('main button[aria-label^="Following "]');
     expect(FOLLOW_SELECTOR).toBe('main button[aria-label^="Follow "]');
+  });
+
+  it("accepts a /company/{slug}/ URL and routes navigation to navigateToCompany", async () => {
+    setupMocks();
+    mockClient.evaluate
+      .mockResolvedValueOnce({ state: "not_following", name: null });
+
+    const result = await unfollowProfile({
+      profileUrl: COMPANY_URL,
+      cdpPort: 9222,
+    });
+
+    expect(result).toEqual({
+      success: true,
+      profileUrl: COMPANY_URL,
+      publicId: "mirohq",
+      targetKind: "company",
+      priorState: "not_following",
+      unfollowedName: null,
+      dryRun: false,
+    });
+    expect(navigateToCompany).toHaveBeenCalledWith(
+      mockClient,
+      "mirohq",
+      undefined,
+    );
+    expect(navigateToProfile).not.toHaveBeenCalled();
+  });
+
+  it("clicks Unfollow on a company page when currently following", async () => {
+    setupMocks();
+    mockClient.evaluate
+      // Initial detection: Following "Miro"
+      .mockResolvedValueOnce({ state: "following", name: "Miro" })
+      // Click Following button → returns true
+      .mockResolvedValueOnce(true)
+      // Find "Unfollow Miro" in dialog → returns name
+      .mockResolvedValueOnce("Miro");
+
+    const result = await unfollowProfile({
+      profileUrl: COMPANY_URL,
+      cdpPort: 9222,
+    });
+
+    expect(result).toEqual({
+      success: true,
+      profileUrl: COMPANY_URL,
+      publicId: "mirohq",
+      targetKind: "company",
+      priorState: "following",
+      unfollowedName: "Miro",
+      dryRun: false,
+    });
+    expect(navigateToCompany).toHaveBeenCalledWith(
+      mockClient,
+      "mirohq",
+      undefined,
+    );
+  });
+
+  it("returns priorState=unknown without clicking on a company page when neither button is found", async () => {
+    setupMocks();
+    mockClient.evaluate
+      .mockResolvedValueOnce({ state: "unknown", name: null });
+
+    const result = await unfollowProfile({
+      profileUrl: COMPANY_URL,
+      cdpPort: 9222,
+    });
+
+    expect(result).toEqual({
+      success: true,
+      profileUrl: COMPANY_URL,
+      publicId: "mirohq",
+      targetKind: "company",
+      priorState: "unknown",
+      unfollowedName: null,
+      dryRun: false,
+    });
+    expect(mockClient.evaluate).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to synchronous unfollow on a company page when no dialog appears", async () => {
+    setupMocks();
+    mockClient.evaluate
+      .mockResolvedValueOnce({ state: "following", name: "Miro" })
+      // Click Following button → returns true
+      .mockResolvedValueOnce(true)
+      // Find dialog button → returns null (no dialog)
+      .mockResolvedValueOnce(null)
+      // Verify Follow button now present (synchronous unfollow)
+      .mockResolvedValueOnce(true);
+
+    const result = await unfollowProfile({
+      profileUrl: COMPANY_URL,
+      cdpPort: 9222,
+    });
+
+    expect(result.targetKind).toBe("company");
+    expect(result.priorState).toBe("following");
+    expect(result.unfollowedName).toBe("Miro");
+  });
+
+  it("throws on a company URL with no slug (e.g. https://www.linkedin.com/company/)", async () => {
+    await expect(
+      unfollowProfile({
+        profileUrl: "https://www.linkedin.com/company/",
+        cdpPort: 9222,
+      }),
+    ).rejects.toThrow("Invalid LinkedIn profile or company URL");
+
+    expect(discoverTargets).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/operations/unfollow-profile.ts
+++ b/packages/core/src/operations/unfollow-profile.ts
@@ -7,39 +7,51 @@ import { resolveInstancePort } from "../cdp/index.js";
 import { retryInteraction, waitForElement } from "../linkedin/dom-automation.js";
 import type { HumanizedMouse } from "../linkedin/humanized-mouse.js";
 import { gaussianDelay } from "../utils/delay.js";
-import { extractPublicId, navigateToProfile } from "./navigate-to-profile.js";
+import {
+  extractFollowableTarget,
+  navigateToCompany,
+  navigateToProfile,
+  type FollowableTarget,
+} from "./navigate-to-profile.js";
 import type { ConnectionOptions } from "./types.js";
 
-/** aria-label prefix of a profile's "Following {Name}" toggle button. */
+/** aria-label prefix of a "Following {Name}" toggle button (profile or company). */
 const PROFILE_FOLLOWING_ARIA_PREFIX = "Following ";
 
-/** CSS selector for a profile's "Following {Name}" button (when actively following). */
+/** CSS selector for a "Following {Name}" button (when actively following). */
 const PROFILE_FOLLOWING_BUTTON_SELECTOR = `main button[aria-label^="${PROFILE_FOLLOWING_ARIA_PREFIX}"]`;
 
-/** CSS selector for a profile's "Follow {Name}" button (when not following). */
+/** CSS selector for a "Follow {Name}" button (when not following). */
 const PROFILE_FOLLOW_BUTTON_SELECTOR = 'main button[aria-label^="Follow "]';
 
 /** Prefix of the "Unfollow {Name}" confirmation dialog button. */
 const UNFOLLOW_DIALOG_BUTTON_PREFIX = "Unfollow ";
 
 /**
- * Prior follow state inferred from the profile's action button.
+ * Prior follow state inferred from the page's primary action button
+ * (profile or company).
  *
- * - `following`     — Profile showed a "Following" toggle (we proceed to unfollow).
- * - `not_following` — Profile showed a "Follow" toggle (nothing to do).
+ * - `following`     — The page showed a "Following" toggle (we proceed to unfollow).
+ * - `not_following` — The page showed a "Follow" toggle (nothing to do).
  * - `unknown`       — Neither toggle was visible within the timeout.
  */
 export type UnfollowProfilePriorState = "following" | "not_following" | "unknown";
 
 export interface UnfollowProfileInput extends ConnectionOptions {
-  /** LinkedIn profile URL (e.g. `https://www.linkedin.com/in/{publicId}/`). */
+  /**
+   * LinkedIn profile or company URL.  Both member profiles
+   * (`https://www.linkedin.com/in/{publicId}/`) and organization pages
+   * (`https://www.linkedin.com/company/{slug}/`) are accepted; the
+   * Following toggle behaves the same way on both surfaces, so a single
+   * unfollow path covers both.
+   */
   readonly profileUrl: string;
   /** Optional humanized mouse for natural cursor movement and clicks. */
   readonly mouse?: HumanizedMouse | null | undefined;
   /**
-   * When true, locate the profile and detect the follow state but do not
-   * click Unfollow.  Useful to probe the state of a profile without
-   * mutating it.
+   * When true, locate the page and detect the follow state but do not
+   * click Unfollow.  Useful to probe the state of a profile or company
+   * without mutating it.
    */
   readonly dryRun?: boolean | undefined;
 }
@@ -47,8 +59,17 @@ export interface UnfollowProfileInput extends ConnectionOptions {
 export interface UnfollowProfileOutput {
   readonly success: true;
   readonly profileUrl: string;
-  /** Public ID (URL slug) extracted from the profile URL. */
+  /**
+   * URL slug extracted from `profileUrl` — the LinkedIn public ID for
+   * `/in/{publicId}/` URLs and the company slug for `/company/{slug}/`
+   * URLs.  Use {@link UnfollowProfileOutput.targetKind} to discriminate.
+   */
   readonly publicId: string;
+  /**
+   * Kind of followable target unfollowed.  `"profile"` for member
+   * profiles, `"company"` for organization pages.
+   */
+  readonly targetKind: FollowableTarget["kind"];
   /**
    * State of the follow toggle before this call.  When `"not_following"`,
    * no Unfollow click was performed and `unfollowedName` is `null`.
@@ -56,37 +77,51 @@ export interface UnfollowProfileOutput {
   readonly priorState: UnfollowProfilePriorState;
   /**
    * Name extracted from the Following button's aria-label (e.g. `"Jane Doe"`
-   * from `aria-label="Following Jane Doe"`).  `null` when the profile was
-   * not being followed or the name could not be extracted.
+   * from `aria-label="Following Jane Doe"`, or `"Acme Inc"` from
+   * `aria-label="Following Acme Inc"`).  `null` when the target was not
+   * being followed or the name could not be extracted.
    */
   readonly unfollowedName: string | null;
   readonly dryRun: boolean;
 }
 
 /**
- * Unfollow a LinkedIn profile by navigating to its profile page and
- * clicking the Following → Unfollow toggle.
+ * Unfollow a LinkedIn member profile or organization page by navigating
+ * to it and clicking the Following → Unfollow toggle.
  *
- * Unlike {@link unfollowFromFeed}, this operation does not require the
- * author to be currently visible in the home feed and is independent of
- * feed position.  Use it for bulk feed-hygiene workflows where a list of
- * profiles must be processed without per-target feed fetching.
+ * Both `/in/{publicId}/` and `/company/{slug}/` URLs are accepted —
+ * LinkedIn renders the same Follow / Following toggle on both surfaces,
+ * and the same aria-label-anchored detection works for both.  Use this
+ * over {@link unfollowFromFeed} for bulk feed-hygiene workflows where a
+ * list of authors (people or organizations) must be processed without
+ * per-target feed fetching, including org-level MUTE escalation when the
+ * organization isn't currently surfaced in the feed.
  *
  * The operation:
- * 1. Navigates to the profile page parsed from {@link UnfollowProfileInput.profileUrl}.
- * 2. Detects the follow state via aria-label anchors on the primary action button.
- * 3. If the profile is being followed, clicks the "Following" button, waits for
- *    the confirmation dialog, and clicks "Unfollow {Name}".
- * 4. If the profile is not being followed, returns immediately with
+ * 1. Parses {@link UnfollowProfileInput.profileUrl} into a profile or
+ *    company target and navigates to the corresponding page.
+ * 2. Detects the follow state via aria-label anchors on the primary
+ *    action button.
+ * 3. If the target is being followed, clicks the "Following" button,
+ *    waits for the confirmation dialog, and clicks "Unfollow {Name}".
+ * 4. If the target is not being followed, returns immediately with
  *    `priorState: "not_following"` and no click performed.
  *
- * @param input - Profile URL and CDP connection parameters.
- * @returns Confirmation including the detected prior state and extracted name.
+ * @param input - Profile or company URL and CDP connection parameters.
+ * @returns Confirmation including the detected prior state, extracted
+ *   name, and which kind of target (`"profile"` or `"company"`) was
+ *   processed.
  */
 export async function unfollowProfile(
   input: UnfollowProfileInput,
 ): Promise<UnfollowProfileOutput> {
-  const publicId = extractPublicId(input.profileUrl);
+  const target = extractFollowableTarget(input.profileUrl);
+  // `targetSlug` is the URL segment regardless of target kind — the
+  // member public ID for /in/ URLs or the company slug for /company/
+  // URLs.  Used in error messages and on the output's `publicId` field
+  // (which is documented to alias both kinds; see UnfollowProfileOutput).
+  const targetSlug =
+    target.kind === "profile" ? target.publicId : target.slug;
 
   const cdpPort = await resolveInstancePort(input.cdpPort, input.cdpHost);
   const cdpHost = input.cdpHost ?? "127.0.0.1";
@@ -118,10 +153,15 @@ export async function unfollowProfile(
     const mouse = input.mouse;
     const dryRun = input.dryRun ?? false;
 
-    await navigateToProfile(client, publicId, mouse);
+    if (target.kind === "profile") {
+      await navigateToProfile(client, target.publicId, mouse);
+    } else {
+      await navigateToCompany(client, target.slug, mouse);
+    }
 
     // Detect the current follow state by inspecting the primary action
-    // button on the profile card.  LinkedIn renders exactly one of:
+    // button on the page (profile or company).  LinkedIn renders exactly
+    // one of:
     //   - `Following {Name}` — currently following, click opens confirm dialog
     //   - `Follow {Name}`    — not following, nothing to do
     const detection = await client.evaluate<{
@@ -151,7 +191,8 @@ export async function unfollowProfile(
       return {
         success: true as const,
         profileUrl: input.profileUrl,
-        publicId,
+        publicId: targetSlug,
+        targetKind: target.kind,
         priorState: "not_following",
         unfollowedName: null,
         dryRun,
@@ -167,14 +208,15 @@ export async function unfollowProfile(
       return {
         success: true as const,
         profileUrl: input.profileUrl,
-        publicId,
+        publicId: targetSlug,
+        targetKind: target.kind,
         priorState: "unknown",
         unfollowedName: null,
         dryRun,
       };
     }
 
-    // Profile is currently being followed.  Clicking the Following button
+    // The page is currently being followed.  Clicking the Following button
     // opens a confirmation dialog on most LinkedIn variants; on some, it
     // unfollows immediately.  Retry the interaction to tolerate transient
     // dialog-render delays.
@@ -198,7 +240,7 @@ export async function unfollowProfile(
 
       if (!clicked) {
         throw new Error(
-          `Failed to click Following button for "${publicId}".`,
+          `Failed to click Following button for "${targetSlug}".`,
         );
       }
 
@@ -251,7 +293,7 @@ export async function unfollowProfile(
       })()`);
 
       throw new Error(
-        `Unfollow confirmation did not appear for "${publicId}". ` +
+        `Unfollow confirmation did not appear for "${targetSlug}". ` +
           "LinkedIn's DOM may have changed or the page did not fully load.",
       );
     }, 3);
@@ -273,7 +315,8 @@ export async function unfollowProfile(
     return {
       success: true as const,
       profileUrl: input.profileUrl,
-      publicId,
+      publicId: targetSlug,
+      targetKind: target.kind,
       priorState: "following",
       unfollowedName: confirmedName.length > 0 ? confirmedName : null,
       dryRun,

--- a/packages/core/src/testing/e2e-helpers.ts
+++ b/packages/core/src/testing/e2e-helpers.ts
@@ -296,6 +296,27 @@ export function getE2EProfileUrl(): string {
 }
 
 /**
+ * Read the `LHREMOTE_E2E_COMPANY_URL` environment variable.
+ *
+ * Returns a LinkedIn company URL used for company-page E2E tests
+ * (unfollow-profile against `/company/{slug}/`).  The URL should point
+ * to an organization that the test account either follows or does not
+ * follow — both states exercise the company-page detection path.
+ *
+ * Pair with `unfollow-profile.e2e.test.ts` to confirm the empirical
+ * premise of ADR-007's 2026-04-29 amendment: that the same readiness
+ * selector and Follow/Following aria-label detection works on company
+ * pages as on member profiles.
+ *
+ * @throws if `LHREMOTE_E2E_COMPANY_URL` is not set or is empty.
+ */
+export function getE2ECompanyUrl(): string {
+  const url = process.env.LHREMOTE_E2E_COMPANY_URL;
+  if (!url) throw new Error("LHREMOTE_E2E_COMPANY_URL must be set");
+  return url;
+}
+
+/**
  * Connect to the launcher, list accounts, and return the first account ID.
  *
  * Fails the test if no accounts are configured in LinkedHelper.

--- a/packages/core/src/testing/index.ts
+++ b/packages/core/src/testing/index.ts
@@ -6,6 +6,7 @@ export {
   describeE2E,
   forceStopInstance,
   getE2ECommentUrn,
+  getE2ECompanyUrl,
   getE2EPersonId,
   getE2EPostUrl,
   getE2EProfileUrl,

--- a/packages/e2e/src/unfollow-profile.e2e.test.ts
+++ b/packages/e2e/src/unfollow-profile.e2e.test.ts
@@ -5,6 +5,7 @@ import { afterAll, beforeAll, expect, it } from "vitest";
 import {
   describeE2E,
   forceStopInstance,
+  getE2ECompanyUrl,
   getE2EProfileUrl,
   installErrorDetection,
   launchApp,
@@ -116,6 +117,7 @@ describeE2E("unfollow-profile operation", () => {
       expect(parsed.success).toBe(true);
       expect(parsed.profileUrl).toBe(profileUrl);
       expect(parsed.dryRun).toBe(true);
+      expect(parsed.targetKind).toBe("profile");
       expect(parsed.publicId.length).toBeGreaterThan(0);
       expect(["following", "not_following", "unknown"]).toContain(parsed.priorState);
 
@@ -126,6 +128,72 @@ describeE2E("unfollow-profile operation", () => {
         expect((parsed.unfollowedName ?? "").length).toBeGreaterThan(0);
       } else {
         // When not following or unknown, no click/name extraction happens.
+        expect(parsed.unfollowedName).toBeNull();
+      }
+    },
+    180_000,
+  );
+
+  it(
+    "unfollow-profile dryRun detects follow state on a /company/ URL without mutating",
+    async () => {
+      // ADR-007 (2026-04-29 amendment) extends the readiness selector and
+      // Following/Follow aria-label detection from member profiles to
+      // company pages.  This E2E test is the empirical verification that
+      // the analytic premise holds against rendered company-page DOM.
+      // Set LHREMOTE_E2E_COMPANY_URL to any LinkedIn organization URL
+      // (e.g. https://www.linkedin.com/company/mirohq/) to enable.
+      const companyUrl = getE2ECompanyUrl();
+
+      const { server, getHandler } = createMockServer();
+      registerUnfollowProfile(server);
+      const handler = getHandler("unfollow-profile");
+
+      const result = (await handler({
+        profileUrl: companyUrl,
+        cdpPort,
+        dryRun: true,
+      })) as {
+        isError?: boolean;
+        content: { type: string; text: string }[];
+      };
+
+      expect(
+        result.isError,
+        `MCP tool error: ${result.content[0]?.text ?? "no content"}`,
+      ).toBeFalsy();
+      expect(result.content).toHaveLength(1);
+
+      const parsed = JSON.parse(
+        (result.content[0] as { text: string }).text,
+      ) as UnfollowProfileOutput;
+
+      expect(parsed.success).toBe(true);
+      expect(parsed.profileUrl).toBe(companyUrl);
+      expect(parsed.dryRun).toBe(true);
+      expect(parsed.targetKind).toBe("company");
+      expect(parsed.publicId.length).toBeGreaterThan(0);
+      // ADR-007's amended premise (2026-04-29) is that the readiness
+      // selector and Following/Follow aria-label detection work on
+      // company pages.  "unknown" fires only when neither button is
+      // visible — i.e., the premise is violated.  Fail fast with an
+      // explicit message so the regression surfaces clearly instead of
+      // hiding behind a permissive `toContain` set.  Diagnostic capture
+      // in navigate-to-company-{ts}-{slug}.{json,png} is the evidence
+      // path; inspect those artifacts before relaxing this assertion.
+      expect(
+        parsed.priorState,
+        `Detection returned "unknown" on company page ${companyUrl} — ` +
+          `ADR-007's amended premise (Follow/Following toggle works on ` +
+          `company pages) was violated.  Inspect the diagnostic capture ` +
+          `under \${os.tmpdir()}/lhremote-diagnostics/navigate-to-company-*.{json,png}.`,
+      ).not.toBe("unknown");
+      expect(["following", "not_following"]).toContain(parsed.priorState);
+
+      if (parsed.priorState === "following") {
+        expect(parsed.unfollowedName).not.toBeNull();
+        expect((parsed.unfollowedName ?? "").length).toBeGreaterThan(0);
+      } else {
         expect(parsed.unfollowedName).toBeNull();
       }
     },

--- a/packages/mcp/src/tools/unfollow-profile.ts
+++ b/packages/mcp/src/tools/unfollow-profile.ts
@@ -10,13 +10,13 @@ import { cdpConnectionSchema, mcpCatchAll, mcpSuccess } from "../helpers.js";
 export function registerUnfollowProfile(server: McpServer): void {
   server.tool(
     "unfollow-profile",
-    "Unfollow a LinkedIn profile by navigating to its profile page and clicking the Following → Unfollow toggle. Prefer this over `unfollow-from-feed` for bulk feed-hygiene workflows: feed-based tools are limited to one action per feed fetch because the feed DOM refreshes after each hide/unfollow, invalidating other indexes. Works regardless of whether the author is currently in the home feed. Returns the detected prior follow state so bulk workflows can distinguish actual unfollows from no-op calls on already-unfollowed or private profiles.",
+    "Unfollow a LinkedIn member profile or organization page by navigating to it and clicking the Following → Unfollow toggle. Accepts both profile URLs (https://www.linkedin.com/in/{publicId}/) and company URLs (https://www.linkedin.com/company/{slug}/) — LinkedIn renders the same Follow/Following toggle on both surfaces. Prefer this over `unfollow-from-feed` for bulk feed-hygiene workflows: feed-based tools are limited to one action per feed fetch because the feed DOM refreshes after each hide/unfollow, invalidating other indexes; this tool works regardless of whether the author is currently in the home feed. For org-level feed-volume escalation, use this as the unfollow substitute since LinkedIn does not expose a Mute action on company pages. Returns the detected prior follow state and target kind (profile vs company) so bulk workflows can distinguish actual unfollows from no-op calls on already-unfollowed targets and from inaccessible targets (private/blocked profiles, restricted/unavailable companies).",
     {
       profileUrl: z
         .string()
         .url()
         .describe(
-          "LinkedIn profile URL (e.g. https://www.linkedin.com/in/{publicId}/)",
+          "LinkedIn profile URL (e.g. https://www.linkedin.com/in/{publicId}/) or company URL (e.g. https://www.linkedin.com/company/{slug}/)",
         ),
       dryRun: z
         .boolean()
@@ -38,7 +38,7 @@ export function registerUnfollowProfile(server: McpServer): void {
         });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
-        return mcpCatchAll(error, "Failed to unfollow profile");
+        return mcpCatchAll(error, "Failed to unfollow target");
       }
     },
   );


### PR DESCRIPTION
## Summary

- Extends `unfollow-profile` to accept LinkedIn `/company/{slug}/` URLs alongside `/in/{publicId}/` profile URLs.
- Unblocks org-level feed-hygiene workflows (LinkedIn does not expose a Mute action on company pages, so unfollow is the only escalation path).
- Reuses the existing aria-label-anchored Following/Follow detection — LinkedIn renders the same toggle on both surfaces.

## Work Item

Closes #757

## Changes

- **Core (`navigate-to-profile.ts`)**: Adds `LINKEDIN_COMPANY_RE`, `FollowableTarget` discriminated union, `extractFollowableTarget()`, `buildCompanyUrl()`, and `navigateToCompany()` as siblings of the existing profile-only API. Refactors diagnostic capture into a shared `captureNavigationLoadFailure(Inner)` helper that kind-tags the artifact filename (`navigate-to-{profile,company}-{timestamp}-{slug}.{json,png}`) and the console.warn caller label.
- **Core (`unfollow-profile.ts`)**: Uses `extractFollowableTarget` and dispatches navigation to `navigateToProfile` or `navigateToCompany` based on target kind. Adds `targetKind: "profile" | "company"` to `UnfollowProfileOutput` so callers can discriminate without re-parsing the URL. The `publicId` field is reused for both kinds and documented accordingly.
- **MCP / CLI**: Tool description, command description, and argument descriptions updated to mention both URL forms. CLI handler messaging adapts based on `targetKind` ("Profile"/"Company", "profile page"/"company page"). `priorState=unknown` message uses kind-specific access reason — "private/blocked profile" vs "restricted/unavailable company".
- **URIError safety**: `extractPublicId` and `extractFollowableTarget` both wrap `decodeURIComponent` in try/catch so malformed percent-encoding (e.g. `%ZZ`) returns the standard validation error instead of leaking `URIError` to callers.
- **ADR-007**: Amended (2026-04-29) to record the company-page extension of `PROFILE_READY_SELECTOR` and the kind-tagged diagnostic filename.

`extractPublicId` remains profile-only — it is consumed by `hide-feed-author-profile` and `visit-profile`, which target features LinkedIn exposes only on member profiles (Mute, VisitAndExtract).

## Test Plan

- [x] 30+ new unit tests in `navigate-to-profile.test.ts` covering `LINKEDIN_COMPANY_RE`, `extractFollowableTarget` (positive/negative cases, percent-encoding, locale subdomains, http scheme, query/fragment, host injection, URIError on malformed encoding), `buildCompanyUrl` (round-trip with extractor), and `captureCompanyLoadFailure` (env gate, kind-tagged filename).
- [x] 5 new unit tests in `unfollow-profile.test.ts` covering company URL routing (profile vs company dispatch), Following → Unfollow dialog flow, "unknown" follow-state on company URLs, synchronous-unfollow fallback, and rejection of company URLs with no slug.
- [x] Symmetric `expect(navigateToCompany).not.toHaveBeenCalled()` on profile-URL test path.
- [x] All 1644 core tests pass; lint clean across all packages; tsc clean.
- [ ] **E2E verification (REQUIRED before merge)**: ADR-007's 2026-04-29 amendment relies on the empirical premise that the same readiness selector and Follow/Following aria-label detection works on company pages as on member profiles. Verify locally with LinkedHelper installed:

  ```sh
  export LHREMOTE_E2E_COMPANY_URL=https://www.linkedin.com/company/<slug>/
  pnpm --filter @lhremote/e2e test:e2e:file unfollow-profile
  ```

  The new test (`unfollow-profile dryRun detects follow state on a /company/ URL without mutating`) exercises the company-page navigation, readiness wait, and follow-state detection. If `priorState` returns `"unknown"`, ADR-007's amended premise is violated and the readiness selector or detection selectors need to be extended for company-page DOM (diagnostic capture in `navigate-to-company-{ts}-{slug}.{json,png}` is the evidence path).

## Discoveries

None — scope was tightly contained to `unfollow-profile`. `hide-feed-author-profile` and `visit-profile` retain `extractPublicId` because LinkedIn's Mute and VisitAndExtract are profile-only features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)