### PR TITLE
(chore) release: bump version to 0.19.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "lhremote",
       "source": "./",
       "description": "LinkedHelper automation toolkit — MCP server and workflow guidance for Claude Code",
-      "version": "0.18.0",
+      "version": "0.19.0",
       "author": {
         "name": "Alexey Pelykh"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lhremote",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "LinkedHelper automation toolkit — MCP server and workflow guidance for Claude Code",
   "author": {
     "name": "Alexey Pelykh",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/alexey-pelykh/lhremote",
     "source": "github"
   },
-  "version": "0.18.0",
+  "version": "0.19.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "lhremote",
-      "version": "0.18.0",
+      "version": "0.19.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary

Bump plugin and server version fields to 0.19.0 for the upcoming release.

### Changes since v0.18.0

- **(fix)** `core,mcp,cli`: accept /company/ URLs in unfollow-profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)