### PR TITLE
(fix) core: fall back to Voyager when public typeahead returns empty

### DIFF
--- a/packages/core/src/operations/resolve-linkedin-entity.test.ts
+++ b/packages/core/src/operations/resolve-linkedin-entity.test.ts
@@ -85,22 +85,63 @@ describe("resolveLinkedInEntity", () => {
       ]);
     });
 
-    it("returns empty matches when public endpoint returns no elements", async () => {
-      vi.mocked(resolveInstancePort).mockResolvedValue(9222);
+    it("falls back to Voyager when public endpoint returns no elements", async () => {
+      setupVoyagerMocks();
 
       vi.spyOn(globalThis, "fetch").mockResolvedValue({
         ok: true,
         json: vi.fn().mockResolvedValue({ elements: [] }),
       } as unknown as Response);
 
+      mockClient.evaluate.mockResolvedValue({
+        data: {
+          elements: [
+            {
+              targetUrn: "urn:li:organization:9999",
+              title: { text: "Mistral AI" },
+            },
+          ],
+        },
+      });
+
       const result = await resolveLinkedInEntity({
-        query: "NonexistentCorp",
+        query: "Mistral AI",
+        entityType: "COMPANY",
+        cdpPort: 9222,
+      });
+
+      expect(result.strategy).toBe("voyager");
+      expect(result.matches).toEqual([
+        { id: "9999", name: "Mistral AI", type: "COMPANY" },
+      ]);
+    });
+
+    it("does not call Voyager when public endpoint returns matches", async () => {
+      setupVoyagerMocks();
+
+      vi.spyOn(globalThis, "fetch").mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({
+          elements: [{ hitInfo: { id: "42", displayName: "Match Corp" } }],
+        }),
+      } as unknown as Response);
+
+      const result = await resolveLinkedInEntity({
+        query: "Match",
         entityType: "COMPANY",
         cdpPort: 9222,
       });
 
       expect(result.strategy).toBe("public");
-      expect(result.matches).toEqual([]);
+      expect(result.matches).toEqual([
+        { id: "42", name: "Match Corp", type: "COMPANY" },
+      ]);
+      // Confirm no Voyager-side work happens at all when public has matches:
+      // not just the API call, but also CDP target discovery and client
+      // instantiation. Locks in the early-return contract.
+      expect(mockClient.evaluate).not.toHaveBeenCalled();
+      expect(discoverTargets).not.toHaveBeenCalled();
+      expect(CDPClient).not.toHaveBeenCalled();
     });
 
     it("falls back to Voyager when public endpoint fails", async () => {

--- a/packages/core/src/operations/resolve-linkedin-entity.test.ts
+++ b/packages/core/src/operations/resolve-linkedin-entity.test.ts
@@ -116,6 +116,39 @@ describe("resolveLinkedInEntity", () => {
       ]);
     });
 
+    it("surfaces a helpful error when public is empty but no LinkedIn page is open", async () => {
+      // The empty-public → Voyager fallback now surfaces the same
+      // session-required error that SCHOOL queries would, instead of
+      // silently returning {matches: [], strategy: "public"}.
+      vi.mocked(resolveInstancePort).mockResolvedValue(9222);
+      vi.mocked(CDPClient).mockImplementation(function () {
+        return mockClient as unknown as CDPClient;
+      });
+      vi.mocked(discoverTargets).mockResolvedValue([
+        {
+          id: "target-1",
+          type: "page",
+          title: "Other",
+          url: "https://example.com",
+          description: "",
+          devtoolsFrontendUrl: "",
+        },
+      ]);
+
+      vi.spyOn(globalThis, "fetch").mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({ elements: [] }),
+      } as unknown as Response);
+
+      await expect(
+        resolveLinkedInEntity({
+          query: "Mistral AI",
+          entityType: "COMPANY",
+          cdpPort: 9222,
+        }),
+      ).rejects.toThrow("No LinkedIn page found");
+    });
+
     it("does not call Voyager when public endpoint returns matches", async () => {
       setupVoyagerMocks();
 

--- a/packages/core/src/operations/resolve-linkedin-entity.ts
+++ b/packages/core/src/operations/resolve-linkedin-entity.ts
@@ -287,17 +287,21 @@ export async function resolveLinkedInEntity(
     return { matches, strategy: "voyager" };
   }
 
-  // Try public endpoint first — only fall back to Voyager if the request
-  // itself failed (undefined), not when it succeeded with zero matches.
+  // Try public endpoint first. Fall back to Voyager when the request
+  // failed (undefined) OR succeeded with zero matches: the public
+  // typeahead endpoint has been observed to return empty for
+  // well-known COMPANY entities, and the same code path serves GEO.
+  // The authenticated Voyager path is more reliable when LinkedHelper
+  // has an active session.
   const publicMatches = await tryPublicTypeahead(
     input.query,
     input.entityType,
   );
-  if (publicMatches !== undefined) {
+  if (publicMatches !== undefined && publicMatches.length > 0) {
     return { matches: publicMatches, strategy: "public" };
   }
 
-  // Public endpoint failed — fallback to Voyager
+  // Public endpoint failed or returned zero — fallback to Voyager
   const voyagerMatches = await tryVoyagerTypeahead(
     input.query,
     input.entityType,


### PR DESCRIPTION
## Summary

- Tightens the fallback condition in `resolveLinkedInEntity` so that an HTTP-200 response with `elements: []` from the public typeahead endpoint also triggers Voyager fallback (previously, only `undefined` from network/parse failure did).
- Inverts the test that codified the bug; adds a complementary test that asserts the public happy path performs no Voyager-side work.

## Why

The public `jobs-guest/api/typeaheadHits` endpoint has been observed to return empty for well-known LinkedIn companies (Mistral AI, Hugging Face, Anthropic, Cursor). The documented behavior is "falls back to CDP-based Voyager... when public fails", but the code only treated `undefined` (request failure) as failure — a successful HTTP 200 with zero elements was returned as the final answer, never trying Voyager. Result: empty `matches[]` for any major company on the public path.

The Voyager path is already wired and proven for SCHOOL; the same code path serves COMPANY/GEO when LinkedHelper has an active LinkedIn session.

## Trade-offs

- For queries that are genuinely empty in both endpoints, callers now incur an extra Voyager round-trip (~1 CDP eval, < 100ms). The `strategy: \"voyager\"` field already discloses which path returned the result.
- For queries with no LinkedIn page open in LinkedHelper, an empty public response now surfaces an informative error (\"ensure LinkedHelper is running with an active LinkedIn session\") instead of a silently-empty result. Consistent with the existing SCHOOL behavior.

## Test plan

- [x] `pnpm --filter @lhremote/core test -- resolve-linkedin-entity` — 18/18 pass
- [x] `pnpm test` — 10/10 packages green
- [x] `pnpm lint` — clean

Closes #763