### PR TITLE
(fix) mcp,cli: pass effective bound to repo.search for query-profiles pagination

### DIFF
--- a/packages/cli/src/handlers/query-profiles.test.ts
+++ b/packages/cli/src/handlers/query-profiles.test.ts
@@ -248,7 +248,7 @@ describe("handleQueryProfiles", () => {
     expect(stderrSpy).toHaveBeenCalledWith("database locked\n");
   });
 
-  it("passes only filter parameters to repository (no limit/offset)", async () => {
+  it("passes effective bound (offset + limit) to repository so merged slice has enough records", async () => {
     vi.spyOn(process.stdout, "write").mockReturnValue(true);
 
     mockDiscovery();
@@ -269,6 +269,7 @@ describe("handleQueryProfiles", () => {
     expect(searchFn).toHaveBeenCalledWith({
       query: "Jane",
       company: "Acme",
+      limit: 15,
     });
   });
 
@@ -291,7 +292,50 @@ describe("handleQueryProfiles", () => {
     expect(searchFn).toHaveBeenCalledWith({
       company: "Acme",
       includeHistory: true,
+      limit: 20,
     });
+  });
+
+  it("returns the offset slice when offset > 0 against a single database (regression for #761)", async () => {
+    const stdoutSpy = vi
+      .spyOn(process.stdout, "write")
+      .mockReturnValue(true);
+
+    mockDiscovery();
+    mockDb();
+
+    // Simulate a single-DB search with 82 matching records globally
+    // and the repository returning rows [0, offset+limit) up to its limit.
+    const total = 82;
+    const allRows = Array.from({ length: total }, (_, i) => ({
+      id: i + 1,
+      firstName: `Person${i + 1}`,
+      lastName: null,
+      headline: null,
+      company: null,
+      title: null,
+    }));
+    const searchFn = vi.fn().mockImplementation((opts: { limit?: number }) => ({
+      profiles: allRows.slice(0, opts.limit ?? 20),
+      total,
+    }));
+    vi.mocked(ProfileRepository).mockImplementation(function () {
+      return { search: searchFn } as unknown as ProfileRepository;
+    });
+
+    await handleQueryProfiles({ offset: 20, limit: 20, json: true });
+
+    const output = stdoutSpy.mock.calls
+      .map((call) => String(call[0]))
+      .join("");
+    const parsed = JSON.parse(output);
+    expect(parsed.total).toBe(total);
+    expect(parsed.profiles).toHaveLength(20);
+    expect(parsed.profiles[0].id).toBe(21);
+    expect(parsed.profiles[19].id).toBe(40);
+    expect(searchFn).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 40 }),
+    );
   });
 
   it("applies limit/offset to merged results across databases", async () => {

--- a/packages/cli/src/handlers/query-profiles.ts
+++ b/packages/cli/src/handlers/query-profiles.ts
@@ -27,6 +27,10 @@ export async function handleQueryProfiles(options: {
     return;
   }
 
+  // Each DB must return enough rows so that the merged slice
+  // [offset, offset + limit) is fully covered.
+  const perDbLimit = offset + limit;
+
   // Aggregate results from all databases
   const allProfiles: ProfileSearchResult["profiles"] = [];
   let totalCount = 0;
@@ -39,6 +43,7 @@ export async function handleQueryProfiles(options: {
         ...(query !== undefined && { query }),
         ...(company !== undefined && { company }),
         ...(includeHistory !== undefined && { includeHistory }),
+        limit: perDbLimit,
       });
       allProfiles.push(...result.profiles);
       totalCount += result.total;

--- a/packages/mcp/src/tools/query-profiles.test.ts
+++ b/packages/mcp/src/tools/query-profiles.test.ts
@@ -108,7 +108,7 @@ describe("registerQueryProfiles", () => {
     expect(response.offset).toBe(0);
   });
 
-  it("passes only filter parameters to repository (no limit/offset)", async () => {
+  it("passes effective bound (offset + limit) to repository so merged slice has enough records", async () => {
     const { server, getHandler } = createMockServer();
     registerQueryProfiles(server);
     vi.mocked(discoverAllDatabases).mockReturnValue(
@@ -127,7 +127,50 @@ describe("registerQueryProfiles", () => {
     expect(searchFn).toHaveBeenCalledWith({
       query: "Jane",
       company: "Acme",
+      limit: 15,
     });
+  });
+
+  it("returns the offset slice when offset > 0 against a single database (regression for #761)", async () => {
+    const { server, getHandler } = createMockServer();
+    registerQueryProfiles(server);
+    vi.mocked(discoverAllDatabases).mockReturnValue(
+      new Map([[1, "/path/to/db"]]),
+    );
+    mockDb();
+
+    // Simulate a single-DB search with 82 matching records globally
+    // and the repository returning rows [0, offset+limit) up to its limit.
+    const total = 82;
+    const allRows = Array.from({ length: total }, (_, i) => ({
+      id: i + 1,
+      firstName: `Person${i + 1}`,
+      lastName: null,
+      headline: null,
+      company: null,
+      title: null,
+    }));
+    const searchFn = vi.fn().mockImplementation((opts: { limit?: number }) => ({
+      profiles: allRows.slice(0, opts.limit ?? 20),
+      total,
+    }));
+    vi.mocked(ProfileRepository).mockImplementation(function () {
+      return { search: searchFn } as unknown as ProfileRepository;
+    });
+
+    const handler = getHandler("query-profiles");
+    const result = await handler({ offset: 20, limit: 20 });
+
+    const response = JSON.parse(
+      (result as { content: [{ text: string }] }).content[0].text,
+    );
+    expect(response.total).toBe(total);
+    expect(response.profiles).toHaveLength(20);
+    expect(response.profiles[0].id).toBe(21);
+    expect(response.profiles[19].id).toBe(40);
+    expect(searchFn).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 40 }),
+    );
   });
 
   it("passes includeHistory to repository when specified", async () => {
@@ -149,6 +192,7 @@ describe("registerQueryProfiles", () => {
     expect(searchFn).toHaveBeenCalledWith({
       company: "Acme",
       includeHistory: true,
+      limit: 20,
     });
   });
 

--- a/packages/mcp/src/tools/query-profiles.ts
+++ b/packages/mcp/src/tools/query-profiles.ts
@@ -50,6 +50,12 @@ export function registerQueryProfiles(server: McpServer): void {
         return mcpError("No LinkedHelper databases found.");
       }
 
+      const effectiveOffset = offset ?? 0;
+      const effectiveLimit = limit ?? 20;
+      // Each DB must return enough rows so that the merged slice
+      // [effectiveOffset, effectiveOffset + effectiveLimit) is fully covered.
+      const perDbLimit = effectiveOffset + effectiveLimit;
+
       // Aggregate results from all databases
       const allProfiles: ProfileSearchResult["profiles"] = [];
       let totalCount = 0;
@@ -62,6 +68,7 @@ export function registerQueryProfiles(server: McpServer): void {
             ...(query !== undefined && { query }),
             ...(company !== undefined && { company }),
             ...(includeHistory !== undefined && { includeHistory }),
+            limit: perDbLimit,
           });
           allProfiles.push(...result.profiles);
           totalCount += result.total;
@@ -72,8 +79,6 @@ export function registerQueryProfiles(server: McpServer): void {
         }
       }
 
-      const effectiveOffset = offset ?? 0;
-      const effectiveLimit = limit ?? 20;
       const paginatedProfiles = allProfiles.slice(
         effectiveOffset,
         effectiveOffset + effectiveLimit,


### PR DESCRIPTION
## Summary

- Each LinkedHelper workspace has its own SQLite database, so `query-profiles` aggregates results across all DBs and slices the merged array client-side.
- Commit `e2631ad` removed `limit`/`offset` from the per-DB `repo.search()` call, but `ProfileSearchOptions.limit` silently defaults to `20` — so each DB returned at most 20 records, and any `offset >= 20` produced an empty slice while `total` remained correct (computed via `COUNT(*) OVER()` window in SQL).
- Fix: pass `limit: offset + limit` to each DB so the merged array contains enough rows to satisfy the requested global window. Both MCP and CLI handlers fixed in lockstep.

## Test plan

- [x] Inverted the two tests that codified the bug (`"passes only filter parameters to repository (no limit/offset)"`) in MCP and CLI test files; they now assert the effective bound is passed.
- [x] Added a single-DB regression test in both layers mirroring the issue reproduction (82 records, `offset=20, limit=20` → expect ids 21..40).
- [x] `pnpm --filter @lhremote/mcp test` — 486 tests pass (74 files).
- [x] `pnpm --filter @lhremote/cli test` — 553 tests pass (71 files).
- [x] `pnpm --filter @lhremote/core test` — 1644 tests pass (121 files).
- [x] `pnpm lint` — clean.
- [x] Mutation-test: removing the fix line causes the regression test to fail with `expected length 20, received 0` — exactly the #761 symptom.
- [ ] Manual repro from issue is unblocked once merged: `query-profiles({query: "Engineering Director", offset: 20, limit: 20})` returns the next 20 of 82 instead of `[]`.

Closes #761

🤖 Generated with [Claude Code](https://claude.com/claude-code)