### PR TITLE
(fix) core: parse public typeahead as a top-level array

### DIFF
--- a/packages/core/src/operations/resolve-linkedin-entity.test.ts
+++ b/packages/core/src/operations/resolve-linkedin-entity.test.ts
@@ -58,16 +58,14 @@ describe("resolveLinkedInEntity", () => {
 
       const mockResponse = {
         ok: true,
-        json: vi.fn().mockResolvedValue({
-          elements: [
-            {
-              hitInfo: {
-                id: "1234",
-                displayName: "Acme Corp",
-              },
-            },
-          ],
-        }),
+        json: vi.fn().mockResolvedValue([
+          {
+            id: "1234",
+            type: "COMPANY",
+            displayName: "Acme Corp",
+            trackingId: "abc==",
+          },
+        ]),
       };
       vi.spyOn(globalThis, "fetch").mockResolvedValue(
         mockResponse as unknown as Response,
@@ -85,12 +83,12 @@ describe("resolveLinkedInEntity", () => {
       ]);
     });
 
-    it("falls back to Voyager when public endpoint returns no elements", async () => {
+    it("falls back to Voyager when public endpoint returns an empty array", async () => {
       setupVoyagerMocks();
 
       vi.spyOn(globalThis, "fetch").mockResolvedValue({
         ok: true,
-        json: vi.fn().mockResolvedValue({ elements: [] }),
+        json: vi.fn().mockResolvedValue([]),
       } as unknown as Response);
 
       mockClient.evaluate.mockResolvedValue({
@@ -137,7 +135,7 @@ describe("resolveLinkedInEntity", () => {
 
       vi.spyOn(globalThis, "fetch").mockResolvedValue({
         ok: true,
-        json: vi.fn().mockResolvedValue({ elements: [] }),
+        json: vi.fn().mockResolvedValue([]),
       } as unknown as Response);
 
       await expect(
@@ -154,9 +152,9 @@ describe("resolveLinkedInEntity", () => {
 
       vi.spyOn(globalThis, "fetch").mockResolvedValue({
         ok: true,
-        json: vi.fn().mockResolvedValue({
-          elements: [{ hitInfo: { id: "42", displayName: "Match Corp" } }],
-        }),
+        json: vi.fn().mockResolvedValue([
+          { id: "42", type: "COMPANY", displayName: "Match Corp" },
+        ]),
       } as unknown as Response);
 
       const result = await resolveLinkedInEntity({
@@ -233,11 +231,9 @@ describe("resolveLinkedInEntity", () => {
 
       const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({
         ok: true,
-        json: vi.fn().mockResolvedValue({
-          elements: [
-            { hitInfo: { id: "101", locationName: "San Francisco" } },
-          ],
-        }),
+        json: vi.fn().mockResolvedValue([
+          { id: "101", type: "GEO", displayName: "San Francisco" },
+        ]),
       } as unknown as Response);
 
       await resolveLinkedInEntity({
@@ -254,13 +250,15 @@ describe("resolveLinkedInEntity", () => {
     it("limits public results to 10", async () => {
       vi.mocked(resolveInstancePort).mockResolvedValue(9222);
 
-      const elements = Array.from({ length: 15 }, (_, i) => ({
-        hitInfo: { id: String(i), displayName: `Company ${String(i)}` },
+      const entries = Array.from({ length: 15 }, (_, i) => ({
+        id: String(i),
+        type: "COMPANY",
+        displayName: `Company ${String(i)}`,
       }));
 
       vi.spyOn(globalThis, "fetch").mockResolvedValue({
         ok: true,
-        json: vi.fn().mockResolvedValue({ elements }),
+        json: vi.fn().mockResolvedValue(entries),
       } as unknown as Response);
 
       const result = await resolveLinkedInEntity({
@@ -272,18 +270,16 @@ describe("resolveLinkedInEntity", () => {
       expect(result.matches).toHaveLength(10);
     });
 
-    it("filters out elements without hitInfo.id", async () => {
+    it("filters out entries without id", async () => {
       vi.mocked(resolveInstancePort).mockResolvedValue(9222);
 
       vi.spyOn(globalThis, "fetch").mockResolvedValue({
         ok: true,
-        json: vi.fn().mockResolvedValue({
-          elements: [
-            { hitInfo: { id: "1", displayName: "Valid" } },
-            { hitInfo: { displayName: "No ID" } },
-            { hitInfo: { id: "3", companyName: "Also Valid" } },
-          ],
-        }),
+        json: vi.fn().mockResolvedValue([
+          { id: "1", type: "COMPANY", displayName: "Valid" },
+          { type: "COMPANY", displayName: "No ID" },
+          { id: "3", type: "COMPANY", displayName: "Also Valid" },
+        ]),
       } as unknown as Response);
 
       const result = await resolveLinkedInEntity({
@@ -295,6 +291,42 @@ describe("resolveLinkedInEntity", () => {
       expect(result.matches).toHaveLength(2);
       expect(result.matches[0]?.id).toBe("1");
       expect(result.matches[1]?.id).toBe("3");
+    });
+
+    it("returns empty matches when public response is not an array (defensive)", async () => {
+      // Defends against the original bug: when the parser previously
+      // expected an object {elements: [...]}, an array response would
+      // silently produce []. Now an unexpected non-array response is
+      // explicitly handled by the Array.isArray gate.
+      setupVoyagerMocks();
+
+      vi.spyOn(globalThis, "fetch").mockResolvedValue({
+        ok: true,
+        json: vi.fn().mockResolvedValue({ elements: [] }),
+      } as unknown as Response);
+
+      mockClient.evaluate.mockResolvedValue({
+        data: {
+          elements: [
+            {
+              targetUrn: "urn:li:organization:5555",
+              title: { text: "Voyager Match" },
+            },
+          ],
+        },
+      });
+
+      const result = await resolveLinkedInEntity({
+        query: "test",
+        entityType: "COMPANY",
+        cdpPort: 9222,
+      });
+
+      // Non-array response treated as empty → falls back to Voyager
+      expect(result.strategy).toBe("voyager");
+      expect(result.matches).toEqual([
+        { id: "5555", name: "Voyager Match", type: "COMPANY" },
+      ]);
     });
   });
 

--- a/packages/core/src/operations/resolve-linkedin-entity.test.ts
+++ b/packages/core/src/operations/resolve-linkedin-entity.test.ts
@@ -293,11 +293,12 @@ describe("resolveLinkedInEntity", () => {
       expect(result.matches[1]?.id).toBe("3");
     });
 
-    it("returns empty matches when public response is not an array (defensive)", async () => {
+    it("falls back to Voyager when public response is not an array (defensive)", async () => {
       // Defends against the original bug: when the parser previously
       // expected an object {elements: [...]}, an array response would
       // silently produce []. Now an unexpected non-array response is
-      // explicitly handled by the Array.isArray gate.
+      // explicitly handled by the Array.isArray gate inside the parser
+      // (parser returns []), which then engages the Voyager fallback.
       setupVoyagerMocks();
 
       vi.spyOn(globalThis, "fetch").mockResolvedValue({

--- a/packages/core/src/operations/resolve-linkedin-entity.ts
+++ b/packages/core/src/operations/resolve-linkedin-entity.ts
@@ -82,17 +82,19 @@ async function tryPublicTypeahead(
   }
 }
 
-/** Shape of the public typeahead API response. */
-interface PublicTypeaheadResponse {
-  elements?: Array<{
-    hitInfo?: {
-      id?: string;
-      displayName?: string;
-      companyName?: string;
-      locationName?: string;
-    };
-  }>;
-}
+/**
+ * Shape of the public typeahead API response.
+ *
+ * The endpoint returns a top-level JSON array (not an object with an
+ * `elements` field). Each entry has a flat `{id, type, displayName,
+ * trackingId}` shape.
+ */
+type PublicTypeaheadResponse = Array<{
+  id?: string;
+  type?: string;
+  displayName?: string;
+  trackingId?: string;
+}>;
 
 /**
  * Parse the public typeahead response into normalised matches.
@@ -101,19 +103,13 @@ function parsePublicTypeaheadResponse(
   data: PublicTypeaheadResponse,
   entityType: EntityType,
 ): EntityMatch[] {
-  if (!data.elements) return [];
+  if (!Array.isArray(data)) return [];
 
-  return data.elements
-    .filter((el): el is typeof el & { hitInfo: { id: string } } =>
-      el.hitInfo?.id !== undefined,
-    )
+  return data
+    .filter((el): el is typeof el & { id: string } => el.id !== undefined)
     .map((el) => ({
-      id: el.hitInfo.id,
-      name:
-        el.hitInfo?.displayName ??
-        el.hitInfo?.companyName ??
-        el.hitInfo?.locationName ??
-        "",
+      id: el.id,
+      name: el.displayName ?? "",
       type: entityType,
     }))
     .slice(0, 10);

--- a/packages/core/src/operations/resolve-linkedin-entity.ts
+++ b/packages/core/src/operations/resolve-linkedin-entity.ts
@@ -75,7 +75,7 @@ async function tryPublicTypeahead(
     });
     if (!response.ok) return undefined;
 
-    const data = (await response.json()) as PublicTypeaheadResponse;
+    const data: unknown = await response.json();
     return parsePublicTypeaheadResponse(data, entityType);
   } catch {
     return undefined;
@@ -83,30 +83,38 @@ async function tryPublicTypeahead(
 }
 
 /**
- * Shape of the public typeahead API response.
+ * Shape of one entry in the public typeahead API response.
  *
  * The endpoint returns a top-level JSON array (not an object with an
  * `elements` field). Each entry has a flat `{id, type, displayName,
  * trackingId}` shape.
  */
-type PublicTypeaheadResponse = Array<{
+interface PublicTypeaheadEntry {
   id?: string;
   type?: string;
   displayName?: string;
   trackingId?: string;
-}>;
+}
 
 /**
  * Parse the public typeahead response into normalised matches.
+ *
+ * Accepts `unknown` and validates the array shape at runtime: the
+ * upstream `response.json()` cannot be statically typed, and the
+ * endpoint has shifted shape historically (the original bug in #763
+ * was a parser written against an older `{elements: [...]}` shape).
+ * Defensive validation here keeps the contract honest.
  */
 function parsePublicTypeaheadResponse(
-  data: PublicTypeaheadResponse,
+  data: unknown,
   entityType: EntityType,
 ): EntityMatch[] {
   if (!Array.isArray(data)) return [];
 
-  return data
-    .filter((el): el is typeof el & { id: string } => el.id !== undefined)
+  return (data as PublicTypeaheadEntry[])
+    .filter((el): el is PublicTypeaheadEntry & { id: string } =>
+      typeof el?.id === "string",
+    )
     .map((el) => ({
       id: el.id,
       name: el.displayName ?? "",


### PR DESCRIPTION
## Summary

- Public typeahead at `/jobs-guest/api/typeaheadHits` returns a top-level array `[{id, type, displayName, trackingId}, …]`, but `parsePublicTypeaheadResponse` expected `{elements: [{hitInfo: {id, displayName, …}}]}`. `data.elements` was always undefined → parser always returned `[]` → original silent-failure reported in #763.
- PR #764 turned that silent empty-matches case into a Voyager-fallback engagement (architecturally correct), but couldn't actually fix the user-facing bug because the public path itself was never producing matches for COMPANY queries. Voyager's `hitsV2` separately 404s, so users saw an explicit error instead of empty results, but resolution still failed.
- This PR fixes the parser to handle the actual array shape. The empty-public → Voyager fallback from #764 is preserved (still useful for `SCHOOL` and genuine empty cases).

## Verification

E2E validation against live LinkedIn (LH instance with `linkedin.com/feed/` open) using `resolveLinkedInEntity` directly with the four queries from the original bug report:

| Query | Strategy | Matches | Canonical id |
|-------|----------|---------|--------------|
| Mistral AI | public | 10 | `94273421` |
| Hugging Face | public | 3 | `11193683` |
| Anthropic | public | 10 | `74126343` |
| Cursor | public | 10 | `105614038` |

All four resolve via the public path with no Voyager fallback needed.

Unit tests updated to use the actual array shape (20/20 pass; +1 defensive test for the non-array case that engages Voyager fallback). Full `pnpm lint` and `pnpm test` pass on macOS.

## Test plan

- [x] `pnpm --filter @lhremote/core test -- resolve-linkedin-entity` passes (20/20)
- [x] `pnpm lint` passes
- [x] `pnpm test` passes (full suite)
- [x] Live `resolveLinkedInEntity` calls succeed for all four #763 queries via public strategy
- [ ] E2E `profile-and-utility.e2e.test.ts > resolve-linkedin-entity > resolves a COMPANY entity` — still depends on #766 (test design predates the new contract); validated above directly

Closes #763