### PR TITLE
(fix) core: update post-detail readiness selectors per ADR-007

### DIFF
--- a/packages/core/src/cdp/wait-for-post-load.test.ts
+++ b/packages/core/src/cdp/wait-for-post-load.test.ts
@@ -72,7 +72,7 @@ describe("waitForPostLoad", () => {
     expect(evaluate).toHaveBeenCalledTimes(3);
   });
 
-  it("polls with the documented readiness predicate (author link AND span[dir=\"ltr\"])", async () => {
+  it("polls with the three-stage layered readiness predicate (main-scoped author link, aria-label markers, span[dir=ltr] fallback)", async () => {
     const evaluate = vi.fn().mockResolvedValueOnce(true);
     const client = {
       evaluate,
@@ -82,8 +82,16 @@ describe("waitForPostLoad", () => {
     await waitForPostLoad(client);
 
     const script = String(evaluate.mock.calls[0]?.[0] ?? "");
-    expect(script).toContain('a[href*="/in/"]');
-    expect(script).toContain('a[href*="/company/"]');
+    // Stage 1: <main>-scoped author link (document-wide would match
+    // nav/sidebar chips that hydrate before the post body).
+    expect(script).toContain('main a[href*="/in/"]');
+    expect(script).toContain('main a[href*="/company/"]');
+    // Stage 2: aria-label-based interaction markers per ADR-007.
+    expect(script).toContain('aria-label^="React Like to "');
+    expect(script).toContain('aria-label^="Comment on"');
+    expect(script).toContain('aria-label^="Text editor for creating"');
+    // Stage 3: legacy span[dir="ltr"] fallback (defensive retention
+    // in case LinkedIn restores the markup).
     expect(script).toContain('span[dir="ltr"]');
   });
 
@@ -121,8 +129,12 @@ describe("waitForPostLoad", () => {
           mainFeedListItemsWithMenuButton: 0,
           mainFeedListItemsViableForPostScrape: 0,
           hasAuthorLink: false,
+          hasAuthorLinkInMain: false,
           hasLtrSpans: false,
           hasArticles: false,
+          hasReactLikeButton: false,
+          hasCommentOnButton: false,
+          hasTopLevelEditor: false,
           bodyTextSnippet: "",
         };
       }
@@ -177,8 +189,12 @@ describe("capturePostLoadFailure", () => {
         mainFeedListItemsWithMenuButton: 0,
         mainFeedListItemsViableForPostScrape: 0,
         hasAuthorLink: false,
+        hasAuthorLinkInMain: false,
         hasLtrSpans: true,
         hasArticles: false,
+        hasReactLikeButton: false,
+        hasCommentOnButton: false,
+        hasTopLevelEditor: false,
         bodyTextSnippet: "Post body text\n",
       }),
       send: vi.fn().mockResolvedValue({ data: "aGVsbG8=" }),
@@ -234,8 +250,21 @@ describe("capturePostLoadFailure", () => {
     expect(script).toContain("mainFeedListItemsViableForPostScrape");
     expect(script).toContain("offsetHeight >= 100");
     expect(script).toContain("hasAuthorLink");
+    // Post-#771: <main>-scoped author-link probe (separate from
+    // document-wide hasAuthorLink) so a future regression can
+    // distinguish "page failed entirely" from "page rendered
+    // sidebar/nav chips but not the post body".
+    expect(script).toContain("hasAuthorLinkInMain");
     expect(script).toContain("hasLtrSpans");
     expect(script).toContain("hasArticles");
+    // Post-#771: aria-label-based interactive markers per ADR-007 —
+    // exact selectors the new readiness predicate uses.
+    expect(script).toContain("hasReactLikeButton");
+    expect(script).toContain("hasCommentOnButton");
+    expect(script).toContain("hasTopLevelEditor");
+    expect(script).toContain('aria-label^="React Like to "');
+    expect(script).toContain('aria-label^="Comment on"');
+    expect(script).toContain('aria-label^="Text editor for creating"');
     expect(script).toContain("bodyTextSnippet");
   });
 
@@ -341,8 +370,12 @@ describe("capturePostLoadFailure", () => {
         mainFeedListItemsWithMenuButton: 0,
         mainFeedListItemsViableForPostScrape: 0,
         hasAuthorLink: false,
+        hasAuthorLinkInMain: false,
         hasLtrSpans: false,
         hasArticles: false,
+        hasReactLikeButton: false,
+        hasCommentOnButton: false,
+        hasTopLevelEditor: false,
         bodyTextSnippet: "",
       }),
       send: vi.fn().mockRejectedValue(new Error("captureScreenshot failed")),

--- a/packages/core/src/cdp/wait-for-post-load.ts
+++ b/packages/core/src/cdp/wait-for-post-load.ts
@@ -69,11 +69,12 @@ const POST_LTR_SPAN_FALLBACK_SELECTOR = 'span[dir="ltr"]';
  *  2. Any of {@link POST_INTERACTION_SELECTOR} suffices.
  *  3. Otherwise fall back to {@link POST_LTR_SPAN_FALLBACK_SELECTOR}.
  *
- * Issues #762 / #771: the original `span[dir="ltr"]`-only predicate stopped
- * matching after LinkedIn's 2026-05 post-detail markup refresh removed
- * `[data-testid="mainFeed"]`, `span[dir="ltr"]`, and `<article>`.  Phase 1
- * (PR #770) shipped diagnostic capture that pinned the regression; this
- * helper closes it.
+ * Issues #762 / #771: the original predicate required both an author link
+ * AND at least one `span[dir="ltr"]`; LinkedIn's 2026-05 post-detail markup
+ * refresh removed `[data-testid="mainFeed"]`, `span[dir="ltr"]`, and
+ * `<article>`, breaking the second gate (the author link still renders).
+ * Phase 1 (PR #770) shipped diagnostic capture that pinned the regression;
+ * this helper closes it.
  *
  * On timeout, if `LHREMOTE_CAPTURE_DIAGNOSTICS=1`, a best-effort diagnostic
  * capture is written to a per-invocation

--- a/packages/core/src/cdp/wait-for-post-load.ts
+++ b/packages/core/src/cdp/wait-for-post-load.ts
@@ -7,28 +7,79 @@ import { join } from "node:path";
 import { delay } from "../utils/delay.js";
 import type { CDPClient } from "./client.js";
 
+// ----------------------------------------------------------------------------
+// Selectors used by both the readiness predicate ({@link waitForPostLoad}) and
+// the diagnostic probe ({@link capturePostLoadFailure}).  Centralizing them
+// keeps the two aligned: the predicate's joined disjunction is exactly the
+// union of the three probes the diagnostic reports individually, so a future
+// timeout's "which-of-three-is-missing" signal stays accurate by definition.
+// ----------------------------------------------------------------------------
+
+/**
+ * `<main>`-scoped author link — anchor pointing to either a member profile
+ * (`/in/{slug}`) or a company page (`/company/{slug}`).  Phase 1 (PR #770)
+ * confirmed this anchor still renders post-2026-05 markup refresh; the
+ * `<main>` scope avoids matching nav / sidebar profile chips that hydrate
+ * before the post itself.
+ */
+const POST_READY_AUTHOR_LINK_SELECTOR =
+  'main a[href*="/in/"], main a[href*="/company/"]';
+
+/**
+ * Document-wide author-link selector — diagnostic-only.  Reported alongside
+ * {@link POST_READY_AUTHOR_LINK_SELECTOR} so a future regression can
+ * distinguish "page failed to render entirely" from "page rendered nav /
+ * sidebar chips but not the post body".
+ */
+const POST_AUTHOR_LINK_DOCUMENT_WIDE_SELECTOR =
+  'a[href*="/in/"], a[href*="/company/"]';
+
+// Post-detail interaction markers (per ADR-007 — aria-label-based markers
+// preferred over structural CSS / role selectors).  Each renders only after
+// the post has hydrated far enough for downstream extraction; any single
+// match satisfies the readiness predicate.  The diagnostic probe reports
+// each individually so a future timeout produces a precise
+// "which-of-three-is-missing" signal.
+const POST_REACT_LIKE_SELECTOR =
+  'main button[aria-label^="React Like to "]';
+const POST_COMMENT_ON_SELECTOR =
+  'main button[aria-label^="Comment on"]';
+const POST_EDITOR_SELECTOR =
+  'main [role="textbox"][aria-label^="Text editor for creating"]';
+
+/** Comma-separated disjunction of the three interaction markers. */
+const POST_INTERACTION_SELECTOR = [
+  POST_REACT_LIKE_SELECTOR,
+  POST_COMMENT_ON_SELECTOR,
+  POST_EDITOR_SELECTOR,
+].join(", ");
+
+/**
+ * Legacy `span[dir="ltr"]` fallback selector.  Phase 1 confirmed gone as of
+ * 2026-05-05 but kept defensively: costs nothing if missing, and provides a
+ * path back to the original signal if/when LinkedIn restores the markup.
+ */
+const POST_LTR_SPAN_FALLBACK_SELECTOR = 'span[dir="ltr"]';
+
 /**
  * Poll the DOM until a LinkedIn post detail page has rendered.
  *
- * The page is considered ready when an author link
- * (`a[href*="/in/"]` or `a[href*="/company/"]`) and at least one
- * `span[dir="ltr"]` are present.  These selectors mirror the in-page
- * scraping scripts that downstream extraction uses, so a positive
- * match indicates the DOM has the structural anchors those scripts
- * key off.
+ * Three-stage layered predicate (per ADR-007):
+ *  1. {@link POST_READY_AUTHOR_LINK_SELECTOR} must match — required.
+ *  2. Any of {@link POST_INTERACTION_SELECTOR} suffices.
+ *  3. Otherwise fall back to {@link POST_LTR_SPAN_FALLBACK_SELECTOR}.
  *
- * On timeout, if `LHREMOTE_CAPTURE_DIAGNOSTICS=1`, a best-effort
- * diagnostic capture is written to a per-invocation
- * `${os.tmpdir()}/lhremote-diagnostics-XXXXXX/` directory before the
- * error propagates; see {@link capturePostLoadFailure}.  The capture
- * is opt-in because LinkedIn post-detail pages can include personal
- * data.
+ * Issues #762 / #771: the original `span[dir="ltr"]`-only predicate stopped
+ * matching after LinkedIn's 2026-05 post-detail markup refresh removed
+ * `[data-testid="mainFeed"]`, `span[dir="ltr"]`, and `<article>`.  Phase 1
+ * (PR #770) shipped diagnostic capture that pinned the regression; this
+ * helper closes it.
  *
- * The structural-selector strategy mirrors the original implementation
- * verbatim — this helper exists primarily to remove duplication across
- * `get-post`, `get-post-engagers`, and `get-post-stats`, and to add the
- * diagnostic capture surface so the next selector regression produces
- * classifiable evidence (per ADR-007's pattern for `navigateToProfile`).
+ * On timeout, if `LHREMOTE_CAPTURE_DIAGNOSTICS=1`, a best-effort diagnostic
+ * capture is written to a per-invocation
+ * `${os.tmpdir()}/lhremote-diagnostics-XXXXXX/` directory before the error
+ * propagates; see {@link capturePostLoadFailure}.  Opt-in because LinkedIn
+ * post-detail pages can include personal data.
  *
  * @param client    - Connected CDP client targeting a LinkedIn page.
  * @param timeoutMs - Polling deadline in milliseconds (default: 15s).
@@ -42,10 +93,9 @@ export async function waitForPostLoad(
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     const ready = await client.evaluate<boolean>(`(() => {
-      const authorLink = document.querySelector('a[href*="/in/"], a[href*="/company/"]');
-      if (!authorLink) return false;
-      const ltrSpans = document.querySelectorAll('span[dir="ltr"]');
-      return ltrSpans.length > 0;
+      if (!document.querySelector('${POST_READY_AUTHOR_LINK_SELECTOR}')) return false;
+      if (document.querySelector('${POST_INTERACTION_SELECTOR}')) return true;
+      return document.querySelectorAll('${POST_LTR_SPAN_FALLBACK_SELECTOR}').length > 0;
     })()`);
     if (ready) return;
     await delay(500);
@@ -119,24 +169,31 @@ interface CaptureCancellationState {
  *
  * Probe set: `{ href, title, hasMain, hasMainFeed,
  * mainFeedListItemCount, mainFeedListItemsWithMenuButton,
- * mainFeedListItemsViableForPostScrape, hasAuthorLink, hasLtrSpans,
- * hasArticles, bodyTextSnippet }` — mirrors the container-selection
- * logic in `SCRAPE_POST_DETAIL_SCRIPT`: it scopes from `<main>`
- * (fallback) → `[data-testid="mainFeed"]` → `div[role="listitem"]`
- * inside that feed → per-item
- * `button[aria-label^="Open control menu for post"]` → items with
- * `offsetHeight >= 100` (the scraper skips smaller skeleton/hidden
- * items).  Each layer is probed separately so a future timeout
- * reproduces the exact selector-presence picture without re-running
- * the wait.  Counts (rather than booleans) for the listitem,
- * menu-button, and viable-item layers help Phase 2 distinguish
- * "wrapper renamed" from "no items rendered yet" from "items present
- * but skeleton-sized" — a healthy `mainFeed` with zero listitems is a
- * different failure mode than a missing `mainFeed`, and items with
- * menu buttons but `offsetHeight < 100` would be picked up by a
- * naive count yet rejected by the scraper.  The menu-button count is
- * scoped to listitems inside `mainFeed` (not document-wide) so it
- * can't be inflated by unrelated buttons elsewhere on the page.
+ * mainFeedListItemsViableForPostScrape, hasAuthorLink,
+ * hasAuthorLinkInMain, hasLtrSpans, hasArticles, hasReactLikeButton,
+ * hasCommentOnButton, hasTopLevelEditor, bodyTextSnippet }` —
+ * mirrors the container-selection logic in
+ * `SCRAPE_POST_DETAIL_SCRIPT`: it scopes from `<main>` (fallback) →
+ * `[data-testid="mainFeed"]` → `div[role="listitem"]` inside that
+ * feed → per-item `button[aria-label^="Open control menu for post"]`
+ * → items with `offsetHeight >= 100` (the scraper skips smaller
+ * skeleton/hidden items).  Each layer is probed separately so a
+ * future timeout reproduces the exact selector-presence picture
+ * without re-running the wait.  Counts (rather than booleans) for
+ * the listitem, menu-button, and viable-item layers help Phase 2
+ * distinguish "wrapper renamed" from "no items rendered yet" from
+ * "items present but skeleton-sized" — a healthy `mainFeed` with
+ * zero listitems is a different failure mode than a missing
+ * `mainFeed`, and items with menu buttons but `offsetHeight < 100`
+ * would be picked up by a naive count yet rejected by the scraper.
+ * The menu-button count is scoped to listitems inside `mainFeed`
+ * (not document-wide) so it can't be inflated by unrelated buttons
+ * elsewhere on the page.
+ *
+ * The post-#771 probes (`hasAuthorLinkInMain`, `hasReactLikeButton`,
+ * `hasCommentOnButton`, `hasTopLevelEditor`) shadow
+ * {@link waitForPostLoad}'s readiness selectors so a timeout pins
+ * exactly which post-anchored signal is missing.
  *
  * Mirrors the diagnostic-capture pattern documented in ADR-007 for
  * `navigateToProfile` — same env var, same artifact structure, same
@@ -206,8 +263,12 @@ async function capturePostLoadFailureInner(
     mainFeedListItemsWithMenuButton: number;
     mainFeedListItemsViableForPostScrape: number;
     hasAuthorLink: boolean;
+    hasAuthorLinkInMain: boolean;
     hasLtrSpans: boolean;
     hasArticles: boolean;
+    hasReactLikeButton: boolean;
+    hasCommentOnButton: boolean;
+    hasTopLevelEditor: boolean;
     bodyTextSnippet: string;
   }>(`(() => {
     const mainFeed = document.querySelector('[data-testid="mainFeed"]');
@@ -234,9 +295,13 @@ async function capturePostLoadFailureInner(
       mainFeedListItemCount: listItems.length,
       mainFeedListItemsWithMenuButton: itemsWithMenu.length,
       mainFeedListItemsViableForPostScrape: viableItems.length,
-      hasAuthorLink: document.querySelector('a[href*="/in/"], a[href*="/company/"]') !== null,
-      hasLtrSpans: document.querySelectorAll('span[dir="ltr"]').length > 0,
+      hasAuthorLink: document.querySelector('${POST_AUTHOR_LINK_DOCUMENT_WIDE_SELECTOR}') !== null,
+      hasAuthorLinkInMain: document.querySelector('${POST_READY_AUTHOR_LINK_SELECTOR}') !== null,
+      hasLtrSpans: document.querySelectorAll('${POST_LTR_SPAN_FALLBACK_SELECTOR}').length > 0,
       hasArticles: document.querySelectorAll('article').length > 0,
+      hasReactLikeButton: document.querySelector('${POST_REACT_LIKE_SELECTOR}') !== null,
+      hasCommentOnButton: document.querySelector('${POST_COMMENT_ON_SELECTOR}') !== null,
+      hasTopLevelEditor: document.querySelector('${POST_EDITOR_SELECTOR}') !== null,
       bodyTextSnippet: (document.body ? document.body.innerText : "").slice(0, 800),
     };
   })()`);


### PR DESCRIPTION
## Summary

- Replace `waitForPostLoad`'s `span[dir="ltr"]`-only readiness predicate (Phase 1 confirmed gone in LinkedIn's 2026-05 post-detail markup refresh) with a three-stage layered predicate: `<main>`-scoped author link → ADR-007-compliant aria-label interactive markers (React Like / Comment on / Text editor for creating) → defensive `span[dir="ltr"]` fallback
- Hoist selectors to module constants so the readiness predicate and the diagnostic probe share a single source of truth
- Extend the diagnostic probe with `hasAuthorLinkInMain`, `hasReactLikeButton`, `hasCommentOnButton`, `hasTopLevelEditor` so a future regression produces an immediately classifiable "which-of-three-is-missing" signal

This is **Phase 2** of #762 — Phase 1 (PR #770) shipped the diagnostic capture infrastructure that pinned the regression to those three removed anchors (`[data-testid="mainFeed"]`, `span[dir="ltr"]`, `<article>`). This PR closes both issues.

## Out of scope

- `SCRAPE_POST_DETAIL_SCRIPT` / `SCRAPE_COMMENTS_SCRIPT` / `SCRAPE_ENGAGERS_SCRIPT` deeper selector refactor — these scripts have graceful fallbacks (empty string / array tolerated by E2E shape assertions) and a deeper refactor needs fresh empirical evidence from a post-Phase-2 E2E run. Phase 3 territory.
- Locale-aware aria-label patterns — out of project posture per ADR-007 documented limitation ("Acceptable for now (LH default locale is English)")

## Test plan

- [x] `pnpm lint` clean
- [x] `pnpm test` green: 1659 core unit/integration tests + 486 mcp tests; 22/22 wait-for-post-load tests
- [ ] **Local pre-merge verification (per #771's literal scope)**: run `pnpm test:e2e` against the failing post URL set with `LHREMOTE_CAPTURE_DIAGNOSTICS=1`. If the predicate still times out, the new probe fields (`hasReactLikeButton`, `hasCommentOnButton`, `hasTopLevelEditor`, `hasAuthorLinkInMain`) immediately tell us which post-anchored signal is missing — feed that into a Phase 3 follow-up
- [ ] Confirm Copilot review

Closes #762
Closes #771

🤖 Generated with [Claude Code](https://claude.com/claude-code)