### PR TITLE
(fix) core: update reactions-modal readiness selectors per ADR-007

### DIFF
--- a/packages/core/src/cdp/wait-for-reactions-modal.test.ts
+++ b/packages/core/src/cdp/wait-for-reactions-modal.test.ts
@@ -74,7 +74,7 @@ describe("waitForReactionsModal", () => {
     expect(evaluate).toHaveBeenCalledTimes(3);
   });
 
-  it("polls with the dialog + engager-link readiness predicate", async () => {
+  it("polls with the resolver fallback chain (validated canonical wrappers + tab-anchor walk)", async () => {
     const evaluate = vi.fn().mockResolvedValueOnce(true);
     const client = {
       evaluate,
@@ -84,11 +84,41 @@ describe("waitForReactionsModal", () => {
     await waitForReactionsModal(client);
 
     const script = String(evaluate.mock.calls[0]?.[0] ?? "");
-    // Stage 1: ARIA dialog wrapper must exist.
-    expect(script).toContain('[role="dialog"]');
-    // Stage 2: at least one engager profile link inside the dialog
-    // must have hydrated.
+    // Resolver helper signature must appear (shared with the scrape /
+    // scroll / total scripts in get-post-engagers.ts).
+    expect(script).toContain("__getReactionsModal");
+    // Stage 1 wrappers — sequential, ordered.  The selector list is
+    // emitted as a JSON array literal so the resolver can iterate and
+    // return on first match (preserving documented precedence).  The
+    // assertions below use the JSON-source form (backslash-escaped
+    // quotes) because that is the literal text the resolver script
+    // contains; the JS engine resolves the escapes at evaluation time
+    // back to `aria-modal="true"` etc.
+    expect(script).toContain('"dialog"');
+    expect(script).toContain('"[aria-modal=\\"true\\"]"');
+    expect(script).toContain('"[role=\\"dialog\\"]"');
+    // Sequential per-selector iteration — not a single comma-joined
+    // `querySelector`, which would return the first match in document
+    // order rather than the first match in selector-precedence order.
+    expect(script).toContain("for (let i = 0;");
+    expect(script).toContain("wrapperSelectors[i]");
+    // Per-selector iteration over ALL matches (not just the first
+    // match) — without this, an unrelated <dialog> / [aria-modal] /
+    // [role=dialog] earlier in the DOM would shadow the engager modal
+    // and the predicate would poll until timeout while the real
+    // modal is open.
+    expect(script).toContain("querySelectorAll");
+    expect(script).toContain("for (let j = 0;");
+    // Per-candidate validation — only accept a candidate if it
+    // contains the "All reactions" tab OR an engager link.  The
+    // predicate's "is this actually the engager modal?" gate.
+    expect(script).toContain('aria-label$=" All reactions"');
     expect(script).toContain('a[href*="/in/"]');
+    // Stage 2 fallback — tab-anchor walk reached only when no
+    // canonical wrapper validated.  The tab aria-label stayed stable
+    // across the 2026-05 refresh; the ancestor walk locates the modal
+    // wrapper that no longer carries any of the canonical roles.
+    expect(script).toContain("ancestor.parentElement");
   });
 
   it("throws the reactions-modal timeout error when readiness predicate never matches before the deadline", async () => {
@@ -124,6 +154,11 @@ describe("waitForReactionsModal", () => {
           bodyTextSnippet: "",
           reactionsButtonAriaLabels: [],
           reactionsCountText: null,
+          htmlDialogCount: 0,
+          ariaModalCount: 0,
+          hasReactionsTab: false,
+          reactionsTabAncestorChain: [],
+          resolvedModalAncestorTag: null,
         };
       }
       return false;
@@ -176,6 +211,14 @@ describe("captureReactionsModalFailure", () => {
         bodyTextSnippet: "Reactions\n",
         reactionsButtonAriaLabels: ["React Like to post by Alice"],
         reactionsCountText: "42 reactions",
+        htmlDialogCount: 0,
+        ariaModalCount: 1,
+        hasReactionsTab: true,
+        reactionsTabAncestorChain: [
+          "div role=tablist inLinks=0",
+          "div .artdeco-modal__content inLinks=24",
+        ],
+        resolvedModalAncestorTag: "div",
       }),
       send: vi.fn().mockResolvedValue({ data: "aGVsbG8=" }),
     } as unknown as CDPClient;
@@ -221,9 +264,7 @@ describe("captureReactionsModalFailure", () => {
     await captureReactionsModalFailure(client);
 
     const script = String(vi.mocked(client.evaluate).mock.calls[0]?.[0] ?? "");
-    // All seven probe-shape fields the issue body specifies must be
-    // collected — the JSON the operator inspects is shaped by this
-    // script alone.
+    // Original probe-shape fields (#773 Phase 1 issue body baseline).
     expect(script).toContain("href");
     expect(script).toContain("dialogCount");
     expect(script).toContain("dialogHasInLinks");
@@ -231,10 +272,19 @@ describe("captureReactionsModalFailure", () => {
     expect(script).toContain("bodyTextSnippet");
     expect(script).toContain("reactionsButtonAriaLabels");
     expect(script).toContain("reactionsCountText");
-    // Selectors the predicate uses must appear verbatim in the probe
-    // so the diagnostic and the predicate stay aligned.
+    // Phase 2 expansion — wrapper-shape probes that distinguish
+    // "modal not opened" from "modal opened with non-canonical wrapper".
+    expect(script).toContain("htmlDialogCount");
+    expect(script).toContain("ariaModalCount");
+    expect(script).toContain("hasReactionsTab");
+    expect(script).toContain("reactionsTabAncestorChain");
+    expect(script).toContain("resolvedModalAncestorTag");
+    // Selectors the predicate / resolver use must appear verbatim in
+    // the probe so the diagnostic and the resolution rule stay aligned.
     expect(script).toContain('[role="dialog"]');
     expect(script).toContain('a[href*="/in/"]');
+    // Resolver helper signature — probe re-uses RESOLVE_REACTIONS_MODAL_SCRIPT.
+    expect(script).toContain("__getReactionsModal");
     // FIND_REACTIONS_SCRIPT regex shape — the probe re-uses it so a
     // future update there is reflected in diagnostics without a
     // separate change.
@@ -331,6 +381,11 @@ describe("captureReactionsModalFailure", () => {
         bodyTextSnippet: "",
         reactionsButtonAriaLabels: [],
         reactionsCountText: null,
+        htmlDialogCount: 0,
+        ariaModalCount: 0,
+        hasReactionsTab: false,
+        reactionsTabAncestorChain: [],
+        resolvedModalAncestorTag: null,
       }),
       send: vi.fn().mockRejectedValue(new Error("captureScreenshot failed")),
     } as unknown as CDPClient;

--- a/packages/core/src/cdp/wait-for-reactions-modal.test.ts
+++ b/packages/core/src/cdp/wait-for-reactions-modal.test.ts
@@ -1,0 +1,442 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { CDPClient } from "./client.js";
+
+// Register the fs-promises mock BEFORE importing the module under test.
+// `wait-for-reactions-modal.ts` imports `node:fs/promises` at module
+// load; relying on Vitest's vi.mock hoisting to cover this is brittle
+// under ESM transforms.  Dynamic-import after the mock guarantees the
+// mocked version is the one the module sees.
+vi.mock("node:fs/promises", () => ({
+  // mkdtemp returns the path of the freshly-created directory.  In
+  // production it has a random suffix; in tests we return a stable
+  // shape so assertions can match it.
+  mkdtemp: vi.fn(async (prefix: string) => `${prefix}TESTABCDEF`),
+  writeFile: vi.fn().mockResolvedValue(undefined),
+  // lstat/chmod back the post-mkdtemp security check that
+  // `wait-for-post-load.ts` exports as `ensureSecureDiagnosticDir` and
+  // this module reuses.  Default mock returns a fresh-and-secure
+  // directory shape so tests that don't care about the security path
+  // continue to pass; tests that exercise the security path override
+  // this in scope.
+  lstat: vi.fn().mockResolvedValue({
+    isSymbolicLink: () => false,
+    isDirectory: () => true,
+    mode: 0o700,
+  }),
+  chmod: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Mock the delay helper so polling iterations don't burn wall-clock
+// time; the unit tests assert behavior of the deadline-driven loop, not
+// of the actual delay primitive.
+vi.mock("../utils/delay.js", () => ({
+  delay: vi.fn().mockResolvedValue(undefined),
+}));
+
+const { captureReactionsModalFailure, waitForReactionsModal } = await import(
+  "./wait-for-reactions-modal.js"
+);
+
+describe("waitForReactionsModal", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns immediately when readiness predicate matches on first poll", async () => {
+    const evaluate = vi.fn().mockResolvedValueOnce(true);
+    const client = {
+      evaluate,
+      send: vi.fn(),
+    } as unknown as CDPClient;
+
+    await waitForReactionsModal(client);
+
+    expect(evaluate).toHaveBeenCalledTimes(1);
+  });
+
+  it("polls until readiness predicate matches", async () => {
+    const evaluate = vi
+      .fn()
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+    const client = {
+      evaluate,
+      send: vi.fn(),
+    } as unknown as CDPClient;
+
+    await waitForReactionsModal(client);
+
+    expect(evaluate).toHaveBeenCalledTimes(3);
+  });
+
+  it("polls with the dialog + engager-link readiness predicate", async () => {
+    const evaluate = vi.fn().mockResolvedValueOnce(true);
+    const client = {
+      evaluate,
+      send: vi.fn(),
+    } as unknown as CDPClient;
+
+    await waitForReactionsModal(client);
+
+    const script = String(evaluate.mock.calls[0]?.[0] ?? "");
+    // Stage 1: ARIA dialog wrapper must exist.
+    expect(script).toContain('[role="dialog"]');
+    // Stage 2: at least one engager profile link inside the dialog
+    // must have hydrated.
+    expect(script).toContain('a[href*="/in/"]');
+  });
+
+  it("throws the reactions-modal timeout error when readiness predicate never matches before the deadline", async () => {
+    const evaluate = vi.fn().mockResolvedValue(false);
+    const client = {
+      evaluate,
+      send: vi.fn(),
+    } as unknown as CDPClient;
+
+    // Tiny timeout: with `delay` mocked to resolve immediately, the loop
+    // exits within microseconds because `Date.now()` advances naturally
+    // between iterations.
+    await expect(waitForReactionsModal(client, 1)).rejects.toThrow(
+      "Timed out waiting for reactions modal to appear",
+    );
+  });
+
+  it("on timeout, attempts diagnostic capture before re-throwing (gated on LHREMOTE_CAPTURE_DIAGNOSTICS)", async () => {
+    const originalEnv = process.env.LHREMOTE_CAPTURE_DIAGNOSTICS;
+    process.env.LHREMOTE_CAPTURE_DIAGNOSTICS = "1";
+
+    // Readiness probe (`evaluate(<readiness predicate>)`) always returns
+    // false; diagnostic probe (`evaluate(<diagnostics object>)`) returns
+    // a probe-shaped object.  We disambiguate by inspecting the script
+    // text — the diagnostic script contains "dialogCount".
+    const evaluate = vi.fn(async (script: string) => {
+      if (script.includes("dialogCount")) {
+        return {
+          href: "https://www.linkedin.com/feed/update/urn:li:activity:1/",
+          dialogCount: 0,
+          dialogHasInLinks: false,
+          dialogChildElementCount: 0,
+          bodyTextSnippet: "",
+          reactionsButtonAriaLabels: [],
+          reactionsCountText: null,
+        };
+      }
+      return false;
+    });
+    const send = vi.fn().mockResolvedValue({ data: "aGVsbG8=" });
+    const client = { evaluate, send } as unknown as CDPClient;
+
+    try {
+      await expect(waitForReactionsModal(client, 1)).rejects.toThrow(
+        "Timed out waiting for reactions modal to appear",
+      );
+      // The diagnostic probe runs at least once before the timeout
+      // re-throws (env=1), and `Page.captureScreenshot` is requested.
+      expect(send).toHaveBeenCalledWith("Page.captureScreenshot", {
+        format: "png",
+        captureBeyondViewport: true,
+      });
+    } finally {
+      if (originalEnv === undefined) {
+        delete process.env.LHREMOTE_CAPTURE_DIAGNOSTICS;
+      } else {
+        process.env.LHREMOTE_CAPTURE_DIAGNOSTICS = originalEnv;
+      }
+    }
+  });
+});
+
+describe("captureReactionsModalFailure", () => {
+  const originalEnv = process.env.LHREMOTE_CAPTURE_DIAGNOSTICS;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    if (originalEnv === undefined) {
+      delete process.env.LHREMOTE_CAPTURE_DIAGNOSTICS;
+    } else {
+      process.env.LHREMOTE_CAPTURE_DIAGNOSTICS = originalEnv;
+    }
+  });
+
+  function makeClient(): CDPClient {
+    return {
+      evaluate: vi.fn().mockResolvedValue({
+        href: "https://www.linkedin.com/feed/update/urn:li:activity:1/",
+        dialogCount: 1,
+        dialogHasInLinks: false,
+        dialogChildElementCount: 4,
+        bodyTextSnippet: "Reactions\n",
+        reactionsButtonAriaLabels: ["React Like to post by Alice"],
+        reactionsCountText: "42 reactions",
+      }),
+      send: vi.fn().mockResolvedValue({ data: "aGVsbG8=" }),
+    } as unknown as CDPClient;
+  }
+
+  it("is a no-op when LHREMOTE_CAPTURE_DIAGNOSTICS is unset", async () => {
+    delete process.env.LHREMOTE_CAPTURE_DIAGNOSTICS;
+    const client = makeClient();
+
+    await captureReactionsModalFailure(client);
+
+    expect(client.evaluate).not.toHaveBeenCalled();
+    expect(client.send).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op when LHREMOTE_CAPTURE_DIAGNOSTICS is any truthy-but-not-"1" value', async () => {
+    process.env.LHREMOTE_CAPTURE_DIAGNOSTICS = "true";
+    const client = makeClient();
+
+    await captureReactionsModalFailure(client);
+
+    expect(client.evaluate).not.toHaveBeenCalled();
+    expect(client.send).not.toHaveBeenCalled();
+  });
+
+  it("captures DOM probes and screenshot when LHREMOTE_CAPTURE_DIAGNOSTICS=1", async () => {
+    process.env.LHREMOTE_CAPTURE_DIAGNOSTICS = "1";
+    const client = makeClient();
+
+    await captureReactionsModalFailure(client);
+
+    expect(client.evaluate).toHaveBeenCalledTimes(1);
+    expect(client.send).toHaveBeenCalledWith("Page.captureScreenshot", {
+      format: "png",
+      captureBeyondViewport: true,
+    });
+  });
+
+  it("probe script collects all documented fields", async () => {
+    process.env.LHREMOTE_CAPTURE_DIAGNOSTICS = "1";
+    const client = makeClient();
+
+    await captureReactionsModalFailure(client);
+
+    const script = String(vi.mocked(client.evaluate).mock.calls[0]?.[0] ?? "");
+    // All seven probe-shape fields the issue body specifies must be
+    // collected — the JSON the operator inspects is shaped by this
+    // script alone.
+    expect(script).toContain("href");
+    expect(script).toContain("dialogCount");
+    expect(script).toContain("dialogHasInLinks");
+    expect(script).toContain("dialogChildElementCount");
+    expect(script).toContain("bodyTextSnippet");
+    expect(script).toContain("reactionsButtonAriaLabels");
+    expect(script).toContain("reactionsCountText");
+    // Selectors the predicate uses must appear verbatim in the probe
+    // so the diagnostic and the predicate stay aligned.
+    expect(script).toContain('[role="dialog"]');
+    expect(script).toContain('a[href*="/in/"]');
+    // FIND_REACTIONS_SCRIPT regex shape — the probe re-uses it so a
+    // future update there is reflected in diagnostics without a
+    // separate change.
+    expect(script).toContain("reactions?");
+  });
+
+  it("swallows capture-side errors rather than masking the caller's timeout", async () => {
+    process.env.LHREMOTE_CAPTURE_DIAGNOSTICS = "1";
+    const client = {
+      evaluate: vi.fn().mockRejectedValue(new Error("evaluate failed")),
+      send: vi.fn(),
+    } as unknown as CDPClient;
+
+    await expect(captureReactionsModalFailure(client)).resolves.toBeUndefined();
+  });
+
+  it("writes diagnostics with the wait-for-reactions-modal prefix and .json/.png extensions", async () => {
+    process.env.LHREMOTE_CAPTURE_DIAGNOSTICS = "1";
+    const client = makeClient();
+    const { writeFile } = await import("node:fs/promises");
+    const writeFileMock = vi.mocked(writeFile);
+    writeFileMock.mockClear();
+
+    await captureReactionsModalFailure(client);
+
+    expect(writeFileMock.mock.calls.length).toBeGreaterThanOrEqual(1);
+    for (const call of writeFileMock.mock.calls) {
+      const filePath = String(call[0]);
+      const lastSep = Math.max(filePath.lastIndexOf("/"), filePath.lastIndexOf("\\"));
+      const baseDir = lastSep >= 0 ? filePath.slice(0, lastSep) : "";
+      const filename = lastSep >= 0 ? filePath.slice(lastSep + 1) : filePath;
+
+      // Basename must contain no path separator.
+      expect(filename).not.toMatch(/[/\\]/);
+      // Filename: wait-for-reactions-modal-{ISO}.{json|png}.  mkdtemp
+      // adds randomness at the directory level, so the filename itself
+      // no longer needs a random suffix.
+      expect(filename).toMatch(
+        /^wait-for-reactions-modal-[\w.-]+\.(json|png)$/,
+      );
+      // Path: ${tmpdir()}/lhremote-diagnostics-XXXXXX/{filename} — the
+      // mkdtemp mock pads with a deterministic suffix in tests.  Use
+      // [/\\] for the separator so the regex matches both POSIX and
+      // Windows path shapes (CI runs on windows-latest too).
+      expect(baseDir).toMatch(/lhremote-diagnostics-[A-Za-z0-9]+$/);
+    }
+  });
+
+  it("uses mkdtemp so concurrent timeouts in the same millisecond produce distinct directories", async () => {
+    process.env.LHREMOTE_CAPTURE_DIAGNOSTICS = "1";
+    const { writeFile, mkdtemp } = await import("node:fs/promises");
+    const writeFileMock = vi.mocked(writeFile);
+    const mkdtempMock = vi.mocked(mkdtemp);
+    writeFileMock.mockClear();
+    mkdtempMock.mockClear();
+
+    let invocation = 0;
+    mkdtempMock.mockImplementation(
+      async (prefix) => `${prefix}TEST${(++invocation).toString().padStart(6, "0")}`,
+    );
+
+    const fixedNow = Date.UTC(2026, 0, 1, 0, 0, 0, 0);
+    const nowSpy = vi.spyOn(Date, "now").mockReturnValue(fixedNow);
+    const isoSpy = vi.spyOn(Date.prototype, "toISOString").mockReturnValue(
+      new Date(fixedNow).toISOString(),
+    );
+
+    try {
+      await captureReactionsModalFailure(makeClient());
+      await captureReactionsModalFailure(makeClient());
+
+      const jsonCalls = writeFileMock.mock.calls.filter((c) =>
+        String(c[0]).endsWith(".json"),
+      );
+      expect(jsonCalls.length).toBeGreaterThanOrEqual(2);
+      const paths = jsonCalls.map((c) => String(c[0]));
+      const uniquePaths = new Set(paths);
+      expect(uniquePaths.size).toBe(paths.length);
+    } finally {
+      isoSpy.mockRestore();
+      nowSpy.mockRestore();
+    }
+  });
+
+  it("only mentions .png in the completion warning when the screenshot was actually written", async () => {
+    process.env.LHREMOTE_CAPTURE_DIAGNOSTICS = "1";
+
+    const client = {
+      evaluate: vi.fn().mockResolvedValue({
+        href: "https://www.linkedin.com/feed/update/urn:li:activity:1/",
+        dialogCount: 0,
+        dialogHasInLinks: false,
+        dialogChildElementCount: 0,
+        bodyTextSnippet: "",
+        reactionsButtonAriaLabels: [],
+        reactionsCountText: null,
+      }),
+      send: vi.fn().mockRejectedValue(new Error("captureScreenshot failed")),
+    } as unknown as CDPClient;
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    try {
+      await captureReactionsModalFailure(client);
+
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      const message = String(warnSpy.mock.calls[0]?.[0] ?? "");
+      expect(message).toContain(".json");
+      expect(message).not.toMatch(/\.\{json,png\}|\.png/);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("refuses to write into a pre-existing diagnostics path that is a symlink", async () => {
+    process.env.LHREMOTE_CAPTURE_DIAGNOSTICS = "1";
+    const { lstat, writeFile } = await import("node:fs/promises");
+    const lstatMock = vi.mocked(lstat);
+    const writeFileMock = vi.mocked(writeFile);
+    writeFileMock.mockClear();
+
+    lstatMock.mockResolvedValueOnce({
+      isSymbolicLink: () => true,
+      isDirectory: () => false,
+      mode: 0o777,
+    } as Awaited<ReturnType<typeof lstat>>);
+
+    const client = {
+      evaluate: vi.fn(),
+      send: vi.fn(),
+    } as unknown as CDPClient;
+
+    await captureReactionsModalFailure(client);
+
+    expect(client.evaluate).not.toHaveBeenCalled();
+    expect(client.send).not.toHaveBeenCalled();
+    expect(writeFileMock).not.toHaveBeenCalled();
+  });
+
+  it("writes JSON with mode 0o600 and creates baseDir via mkdtemp", async () => {
+    process.env.LHREMOTE_CAPTURE_DIAGNOSTICS = "1";
+    const client = makeClient();
+    const { writeFile, mkdtemp } = await import("node:fs/promises");
+    const writeFileMock = vi.mocked(writeFile);
+    const mkdtempMock = vi.mocked(mkdtemp);
+    writeFileMock.mockClear();
+    mkdtempMock.mockClear();
+
+    await captureReactionsModalFailure(client);
+
+    expect(mkdtempMock).toHaveBeenCalledWith(
+      expect.stringMatching(/lhremote-diagnostics-$/),
+    );
+
+    const jsonCall = writeFileMock.mock.calls.find((c) =>
+      String(c[0]).endsWith(".json"),
+    );
+    expect(jsonCall).toBeDefined();
+    expect(jsonCall?.[2]).toMatchObject({ mode: 0o600 });
+  });
+
+  it("late rejection from capture body does not surface as UnhandledPromiseRejection (timer-wins race)", async () => {
+    process.env.LHREMOTE_CAPTURE_DIAGNOSTICS = "1";
+
+    const unhandled: unknown[] = [];
+    const handler = (reason: unknown): void => {
+      unhandled.push(reason);
+    };
+    process.on("unhandledRejection", handler);
+
+    // Force the timer to win the race by making setTimeout fire on the
+    // microtask queue (before the inner evaluate's setImmediate-scheduled
+    // rejection lands).
+    const timeoutSpy = vi
+      .spyOn(globalThis, "setTimeout")
+      .mockImplementation(((cb: () => void) => {
+        Promise.resolve().then(cb);
+        return 0 as unknown as NodeJS.Timeout;
+      }) as typeof setTimeout);
+
+    try {
+      const client = {
+        evaluate: vi.fn(
+          () =>
+            new Promise<unknown>((_, reject) => {
+              setImmediate(() =>
+                reject(new Error("simulated late CDP rejection")),
+              );
+            }),
+        ),
+        send: vi.fn(),
+      } as unknown as CDPClient;
+
+      await captureReactionsModalFailure(client);
+
+      // Allow the late rejection to settle.
+      await new Promise<void>((r) => setImmediate(r));
+      await new Promise<void>((r) => setImmediate(r));
+
+      expect(unhandled).toHaveLength(0);
+    } finally {
+      timeoutSpy.mockRestore();
+      process.off("unhandledRejection", handler);
+    }
+  });
+});

--- a/packages/core/src/cdp/wait-for-reactions-modal.ts
+++ b/packages/core/src/cdp/wait-for-reactions-modal.ts
@@ -1,0 +1,298 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { mkdtemp, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { delay } from "../utils/delay.js";
+import type { CDPClient } from "./client.js";
+import { ensureSecureDiagnosticDir } from "./wait-for-post-load.js";
+
+// ----------------------------------------------------------------------------
+// Selectors used by both the readiness predicate ({@link waitForReactionsModal})
+// and the diagnostic probe ({@link captureReactionsModalFailure}).
+// Centralizing them keeps the two aligned: a future timeout's "which-of-three-
+// is-missing" signal stays accurate by definition.
+// ----------------------------------------------------------------------------
+
+/**
+ * Reactions modal wrapper — the standard ARIA dialog LinkedIn opens after
+ * the user clicks the reactions count beneath a post.  This selector has
+ * been stable across LinkedIn UI revisions; the probe still reports
+ * `dialogCount` so a future change away from `[role="dialog"]` lands as
+ * a precise diagnostic signal rather than a generic timeout.
+ */
+const REACTIONS_MODAL_SELECTOR = '[role="dialog"]';
+
+/**
+ * Engager profile link inside the modal — each engager entry contains an
+ * `<a href="/in/{slug}">` linking to that person's profile.  Used both
+ * by the readiness predicate (presence ⇒ engager rows hydrated) and by
+ * the diagnostic probe (`dialogHasInLinks`).
+ */
+const REACTIONS_MODAL_ENGAGER_LINK_SELECTOR = 'a[href*="/in/"]';
+
+/**
+ * Poll the DOM until the reactions modal has loaded with at least one
+ * profile link visible.
+ *
+ * Issue #773 Phase 1: this helper was lifted from `get-post-engagers.ts`
+ * (where it lived as a local function) to a shared module so the same
+ * diagnostic-capture pattern that pinned the post-detail regression in
+ * #762 / #771 (PR #770 / PR #772) can apply here.  The lifted predicate
+ * is unchanged — Phase 2 will update it per diagnostic data captured
+ * on the next E2E timeout.
+ *
+ * On timeout, if `LHREMOTE_CAPTURE_DIAGNOSTICS=1`, a best-effort
+ * diagnostic capture is written to a per-invocation
+ * `${os.tmpdir()}/lhremote-diagnostics-XXXXXX/` directory before the
+ * error propagates; see {@link captureReactionsModalFailure}.  Opt-in
+ * because the LinkedIn engager modal can include personal data
+ * (engager names, profile slugs, headlines).
+ *
+ * @param client    - Connected CDP client targeting a LinkedIn page.
+ * @param timeoutMs - Polling deadline in milliseconds (default: 10s).
+ *
+ * @throws If the modal predicate does not match before the deadline.
+ */
+export async function waitForReactionsModal(
+  client: CDPClient,
+  timeoutMs = 10_000,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const ready = await client.evaluate<boolean>(`(() => {
+      const modal = document.querySelector('${REACTIONS_MODAL_SELECTOR}');
+      if (!modal) return false;
+      return modal.querySelectorAll('${REACTIONS_MODAL_ENGAGER_LINK_SELECTOR}').length > 0;
+    })()`);
+    if (ready) return;
+    await delay(500);
+  }
+  // captureReactionsModalFailure self-gates on LHREMOTE_CAPTURE_DIAGNOSTICS
+  // and swallows its own errors, so the original timeout always propagates
+  // unchanged regardless of capture-side outcome.
+  await captureReactionsModalFailure(client);
+  throw new Error(
+    "Timed out waiting for reactions modal to appear",
+  );
+}
+
+/**
+ * Cap on the wall-clock time the diagnostic capture is awaited before
+ * the caller's timeout is re-thrown.  Without this, a misbehaving CDP
+ * connection could prolong error propagation by up to `CDPClient.send`'s
+ * own timeout per call (`Runtime.evaluate` + `Page.captureScreenshot`).
+ */
+const DIAGNOSTIC_CAPTURE_TIMEOUT_MS = 10_000;
+
+/**
+ * Mutable cancellation state shared between the outer wrapper and the
+ * inner capture body.  The wrapper flips `timedOut` when the bound timer
+ * wins the race; the inner body checks between each async step and
+ * returns early, giving up any remaining writes so the process can exit
+ * promptly.
+ */
+interface CaptureCancellationState {
+  timedOut: boolean;
+}
+
+/**
+ * Best-effort diagnostic capture when {@link waitForReactionsModal}
+ * times out waiting for the reactions modal DOM.  Each invocation
+ * creates a fresh `${os.tmpdir()}/lhremote-diagnostics-XXXXXX/`
+ * directory via `mkdtemp` (atomic; refuses to follow any pre-existing
+ * symlink at the prefix) and writes
+ * `wait-for-reactions-modal-{timestamp}.json` (URL, dialog probes,
+ * reactions-button candidates, body-text snippet) and a sibling `.png`
+ * (full-page `Page.captureScreenshot` with `captureBeyondViewport: true`,
+ * when the screenshot succeeds) inside it, so callers can classify the
+ * failure — wrong click target, modal never opened, or modal opened
+ * but engager-link selectors stale.  Per-invocation directories
+ * prevent concurrent timeouts from clobbering each other's artifacts
+ * AND close the TOCTOU window a shared parent directory would
+ * otherwise leave open.  The trailing `console.warn` reports only the
+ * artifacts that were actually written; the `.png` is best-effort and
+ * may be absent.
+ *
+ * **Opt-in only.** Self-gated on `LHREMOTE_CAPTURE_DIAGNOSTICS=1` —
+ * no-op otherwise.  Default-off in production (CLI, MCP server)
+ * because the artifacts can contain personal data from the LinkedIn
+ * engager list.  E2E tests activate it via `vitest.e2e.config.ts`
+ * `env` so every run produces diagnostics without touching the
+ * codebase.
+ *
+ * The diagnostics directory is created with mode `0o700` and files
+ * with mode `0o600` (POSIX; no-op on Windows) so that personal data
+ * in a shared `os.tmpdir()` is not exposed to other local users.
+ *
+ * The capture is cooperatively cancellable and bounded by
+ * {@link DIAGNOSTIC_CAPTURE_TIMEOUT_MS}: the outer wrapper stops
+ * awaiting at the cap, and the inner body checks a shared cancellation
+ * flag between each step and returns early when it flips — so
+ * remaining CDP calls and disk writes are skipped rather than merely
+ * un-awaited.  In rare cases the in-flight async step started before
+ * the cap may still complete in the background; the process is not
+ * held alive by this function beyond the cap plus any such single
+ * in-flight step.
+ *
+ * Any capture-side failure is swallowed so the original timeout
+ * always propagates unchanged.
+ *
+ * Probe set: `{ href, dialogCount, dialogHasInLinks,
+ * dialogChildElementCount, bodyTextSnippet, reactionsButtonAriaLabels,
+ * reactionsCountText }` — distinguishes:
+ *  1. "click never opened a dialog" (`dialogCount === 0`)
+ *  2. "dialog opened but engager-link selectors stale"
+ *     (`dialogCount > 0 && !dialogHasInLinks`)
+ *  3. "wrong button was clicked" (`reactionsButtonAriaLabels` reveals
+ *     which aria-labels exist on visible reaction-related buttons,
+ *     and `reactionsCountText` reports what the
+ *     `FIND_REACTIONS_SCRIPT` regex would currently match)
+ *
+ * Mirrors the diagnostic-capture pattern documented in ADR-007 for
+ * `navigateToProfile` and `waitForPostLoad` — same env var, same
+ * artifact structure, same cancellation discipline,
+ * {@link ensureSecureDiagnosticDir} reused from `wait-for-post-load.ts`.
+ *
+ * @internal Exported for unit testing only; not part of the public API.
+ */
+export async function captureReactionsModalFailure(
+  client: CDPClient,
+): Promise<void> {
+  if (process.env.LHREMOTE_CAPTURE_DIAGNOSTICS !== "1") return;
+  const state: CaptureCancellationState = { timedOut: false };
+  let bound: NodeJS.Timeout | undefined;
+  try {
+    await Promise.race([
+      // Attach a no-op catch to the inner promise so a late rejection
+      // (after the timer wins the race) does not escape as an
+      // UnhandledPromiseRejection — capture-side errors must always be
+      // swallowed to keep the caller's timeout propagating unchanged.
+      captureReactionsModalFailureInner(client, state).catch(() => undefined),
+      new Promise<void>((resolve) => {
+        bound = setTimeout(() => {
+          state.timedOut = true;
+          resolve();
+        }, DIAGNOSTIC_CAPTURE_TIMEOUT_MS);
+      }),
+    ]);
+  } catch {
+    // Capture itself failed; do not mask the caller's timeout.
+  } finally {
+    if (bound !== undefined) clearTimeout(bound);
+  }
+}
+
+async function captureReactionsModalFailureInner(
+  client: CDPClient,
+  state: CaptureCancellationState,
+): Promise<void> {
+  const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+  // mkdtemp is the atomic fresh-directory primitive: it generates a
+  // random suffix and creates the directory in one syscall, refusing
+  // to follow any pre-existing symlink at the prefix.  See
+  // wait-for-post-load.ts capturePostLoadFailureInner for the full
+  // TOCTOU rationale — ensureSecureDiagnosticDir is centralized
+  // there; this site reuses it.
+  const baseDir = await mkdtemp(join(tmpdir(), "lhremote-diagnostics-"));
+  if (state.timedOut) return;
+  if (!(await ensureSecureDiagnosticDir(baseDir))) return;
+  if (state.timedOut) return;
+  const prefix = join(baseDir, `wait-for-reactions-modal-${timestamp}`);
+
+  const info = await client.evaluate<{
+    href: string;
+    dialogCount: number;
+    dialogHasInLinks: boolean;
+    dialogChildElementCount: number;
+    bodyTextSnippet: string;
+    reactionsButtonAriaLabels: string[];
+    reactionsCountText: string | null;
+  }>(`(() => {
+    const dialogs = document.querySelectorAll('${REACTIONS_MODAL_SELECTOR}');
+    const firstDialog = dialogs[0] || null;
+    const dialogHasInLinks = firstDialog
+      ? firstDialog.querySelectorAll('${REACTIONS_MODAL_ENGAGER_LINK_SELECTOR}').length > 0
+      : false;
+    const dialogChildElementCount = firstDialog ? firstDialog.childElementCount : 0;
+
+    // Capture aria-labels of visible buttons whose label hints at
+    // reactions / engagement — distinguishes "clicked the wrong button"
+    // (e.g. clicked a generic "Like" toggle instead of the reactions
+    // count summary) from "right button, modal selectors stale".  Cap
+    // length and count to keep the artifact bounded.
+    const reactionsButtonAriaLabels = Array.prototype.slice
+      .call(document.querySelectorAll('button[aria-label]'))
+      .map(function (el) { return (el.getAttribute('aria-label') || '').trim(); })
+      .filter(function (label) {
+        return /reaction|like|engager|comment/i.test(label) && label.length < 200;
+      })
+      .slice(0, 30);
+
+    // Capture the text the FIND_REACTIONS_SCRIPT regex would currently
+    // match — pins what the click target looks like at timeout time so
+    // Phase 2 can decide whether the regex itself needs updating.
+    const reactionsCountElements = Array.prototype.slice
+      .call(document.querySelectorAll('button, [role="button"], span, a'))
+      .filter(function (el) {
+        const t = (el.textContent || '').trim();
+        return /^\\d[\\d,]*\\s+reactions?$/i.test(t) && el.offsetHeight > 0;
+      });
+    const reactionsCountText = reactionsCountElements[0]
+      ? (reactionsCountElements[0].textContent || '').trim()
+      : null;
+
+    return {
+      href: location.href,
+      dialogCount: dialogs.length,
+      dialogHasInLinks: dialogHasInLinks,
+      dialogChildElementCount: dialogChildElementCount,
+      bodyTextSnippet: (document.body ? document.body.innerText : "").slice(0, 800),
+      reactionsButtonAriaLabels: reactionsButtonAriaLabels,
+      reactionsCountText: reactionsCountText,
+    };
+  })()`);
+  if (state.timedOut) return;
+
+  // 0o600: owner-only rw.  POSIX-only; no-op on Windows.
+  await writeFile(`${prefix}.json`, JSON.stringify(info, null, 2), {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  if (state.timedOut) {
+    // Cap fired after JSON landed but before screenshot.  Surface the
+    // path NOW — the per-invocation mkdtemp directory is the only
+    // place these artifacts live, so an early return without a warn
+    // would leave operators unable to find them.
+    console.warn(
+      `[waitForReactionsModal] timeout diagnostics partial: ${prefix}.json (screenshot skipped — capture cap reached)`,
+    );
+    return;
+  }
+
+  let wroteScreenshot = false;
+  try {
+    const screenshot = (await client.send("Page.captureScreenshot", {
+      format: "png",
+      captureBeyondViewport: true,
+    })) as { data?: string };
+    if (!state.timedOut && screenshot.data) {
+      await writeFile(`${prefix}.png`, Buffer.from(screenshot.data, "base64"), {
+        mode: 0o600,
+      });
+      wroteScreenshot = true;
+    }
+  } catch {
+    // Screenshot is best-effort; info.json is the primary artifact.
+  }
+
+  // Unconditional warn — even if `state.timedOut` flipped during the
+  // screenshot, we still have at least the JSON at the randomized
+  // path, and the operator needs the path to find anything at all.
+  // Mention `.png` only when actually written.
+  const artifacts = wroteScreenshot ? "{json,png}" : "json";
+  console.warn(
+    `[waitForReactionsModal] timeout diagnostics written: ${prefix}.${artifacts}`,
+  );
+}

--- a/packages/core/src/cdp/wait-for-reactions-modal.ts
+++ b/packages/core/src/cdp/wait-for-reactions-modal.ts
@@ -9,39 +9,147 @@ import type { CDPClient } from "./client.js";
 import { ensureSecureDiagnosticDir } from "./wait-for-post-load.js";
 
 // ----------------------------------------------------------------------------
-// Selectors used by both the readiness predicate ({@link waitForReactionsModal})
-// and the diagnostic probe ({@link captureReactionsModalFailure}).
-// Centralizing them keeps the two aligned: a future timeout's "which-of-three-
-// is-missing" signal stays accurate by definition.
+// Selectors used by the readiness predicate, the diagnostic probe, and the
+// modal resolver shared with `get-post-engagers.ts` (scrape / scroll / total).
+// Centralizing them keeps the call sites aligned: a future regression in
+// "which selector matches the engager modal" lands as a precise diagnostic
+// signal rather than a generic timeout.
 // ----------------------------------------------------------------------------
 
 /**
- * Reactions modal wrapper — the standard ARIA dialog LinkedIn opens after
- * the user clicks the reactions count beneath a post.  This selector has
- * been stable across LinkedIn UI revisions; the probe still reports
- * `dialogCount` so a future change away from `[role="dialog"]` lands as
- * a precise diagnostic signal rather than a generic timeout.
+ * Reactions modal wrapper — ordered fallback chain.  LinkedIn's 2026-05
+ * markup refresh removed the `[role="dialog"]` ARIA wrapper from the
+ * engager modal (Phase 1 diagnostic capture, JSON `dialogCount: 0`
+ * while the modal IS visible in `bodyTextSnippet` — see #773).
+ *
+ * Tried sequentially by the resolver, in this order — first match wins:
+ *   1. `dialog`               — HTML5 native dialog
+ *   2. `[aria-modal="true"]`  — ARIA standard for modal regions
+ *   3. `[role="dialog"]`      — defensive retention (legacy markup)
+ *
+ * `querySelector` with a comma-joined selector list returns the first
+ * match in **document order**, not in the order the selectors are
+ * listed.  That breaks the precedence claim above when multiple
+ * candidate wrappers coexist on the page (e.g. engager modal +
+ * unrelated dialog).  An array iterated by the resolver enforces real
+ * precedence.  Used by the readiness predicate
+ * ({@link waitForReactionsModal}) and shared via
+ * {@link RESOLVE_REACTIONS_MODAL_SCRIPT} with the diagnostic probe and
+ * the scrape / scroll / total scripts in `get-post-engagers.ts`.
  */
-const REACTIONS_MODAL_SELECTOR = '[role="dialog"]';
+const REACTIONS_MODAL_WRAPPER_SELECTORS: readonly string[] = [
+  "dialog",
+  '[aria-modal="true"]',
+  '[role="dialog"]',
+];
+
+/**
+ * Tab-anchor fallback selector — the "All reactions" filter button
+ * that sits at the top of the open engager modal.  Used when none of
+ * the canonical wrappers match: walk up from the tab to find the
+ * modal-like ancestor that contains the engager links.  The button
+ * aria-label has stayed stable across the 2026-05 refresh
+ * (`reactionsButtonAriaLabels` in the diagnostic JSON includes
+ * "24 All reactions") even though the wrapper element shape shifted.
+ */
+const REACTIONS_TAB_FALLBACK_SELECTOR =
+  'button[aria-label$=" All reactions"]';
 
 /**
  * Engager profile link inside the modal — each engager entry contains an
  * `<a href="/in/{slug}">` linking to that person's profile.  Used both
- * by the readiness predicate (presence ⇒ engager rows hydrated) and by
- * the diagnostic probe (`dialogHasInLinks`).
+ * by the readiness predicate (presence ⇒ engager rows hydrated), the
+ * modal resolver (anchor-walk termination signal), and the diagnostic
+ * probe (`dialogHasInLinks`).
  */
 const REACTIONS_MODAL_ENGAGER_LINK_SELECTOR = 'a[href*="/in/"]';
+
+/**
+ * Maximum ancestor depth the tab-anchor fallback walks up from the
+ * "All reactions" button.  12 is generous: it crosses the modal
+ * wrapper plus typical layout chrome (toolbar, root-of-modal,
+ * portal-host) without risking a runaway walk into `<body>` if the
+ * page structure changes.
+ */
+const REACTIONS_MODAL_ANCESTOR_WALK_DEPTH = 12;
+
+/**
+ * In-page JavaScript that resolves the engager modal element via the
+ * fallback chain (canonical wrappers → tab-anchor walk).  Defines a
+ * function `__getReactionsModal()` that returns either the resolved
+ * `Element` or `null`.  Prepended to every consumer that needs the
+ * resolved modal — the readiness predicate ({@link waitForReactionsModal}),
+ * the diagnostic probe ({@link captureReactionsModalFailure}), and the
+ * scrape / scroll / total scripts in `get-post-engagers.ts` — so all
+ * call sites share a single resolution rule.  String form (not a
+ * function) because each call site composes a separate
+ * `Runtime.evaluate` script.
+ *
+ * Exported for reuse from `get-post-engagers.ts`.
+ */
+export const RESOLVE_REACTIONS_MODAL_SCRIPT = `
+function __getReactionsModal() {
+  // Stage 1: try the canonical wrapper selectors in precedence order.
+  // For each selector, iterate ALL matches and validate each one —
+  // accept only candidates that contain the "All reactions" filter
+  // tab OR at least one engager profile link.  Without this gate, an
+  // unrelated \`<dialog>\` / \`[aria-modal="true"]\` / \`[role="dialog"]\`
+  // rendered earlier in the DOM (cookie banner, unrelated overlay)
+  // would shadow the actual engager modal — Stage 1 would return the
+  // wrong element, Stage 2 would never run, and the predicate would
+  // poll until timeout while the real modal is open.  Per #773 Phase 1
+  // diagnostics, LinkedIn dropped \`[role="dialog"]\` from the engager
+  // modal in 2026-05; the broader list lets future restorations take
+  // effect without a code change.
+  const wrapperSelectors = ${JSON.stringify(REACTIONS_MODAL_WRAPPER_SELECTORS)};
+  for (let i = 0; i < wrapperSelectors.length; i++) {
+    const candidates = document.querySelectorAll(wrapperSelectors[i]);
+    for (let j = 0; j < candidates.length; j++) {
+      const c = candidates[j];
+      if (
+        c.querySelector('${REACTIONS_TAB_FALLBACK_SELECTOR}') ||
+        c.querySelector('${REACTIONS_MODAL_ENGAGER_LINK_SELECTOR}')
+      ) {
+        return c;
+      }
+    }
+  }
+  // Stage 2: walk up from the "All reactions" filter tab to find the
+  // modal-like ancestor.  Reached when no canonical wrapper holds the
+  // engager modal — either none exists (LinkedIn's 2026-05 state per
+  // Phase 1 diagnostics: zero matching dialog wrappers) or the
+  // wrapper is some other shape entirely.  The tab aria-label stayed
+  // stable across the refresh; its closest ancestor that holds
+  // engager links IS the modal.  Bounded depth so a
+  // missing-engager-links page doesn't infinite-loop.
+  const tab = document.querySelector('${REACTIONS_TAB_FALLBACK_SELECTOR}');
+  if (!tab || tab.offsetHeight === 0) return null;
+  let ancestor = tab.parentElement;
+  let depth = 0;
+  while (ancestor && depth < ${REACTIONS_MODAL_ANCESTOR_WALK_DEPTH}) {
+    if (ancestor.querySelectorAll('${REACTIONS_MODAL_ENGAGER_LINK_SELECTOR}').length > 0) {
+      return ancestor;
+    }
+    ancestor = ancestor.parentElement;
+    depth++;
+  }
+  return null;
+}
+`;
 
 /**
  * Poll the DOM until the reactions modal has loaded with at least one
  * profile link visible.
  *
- * Issue #773 Phase 1: this helper was lifted from `get-post-engagers.ts`
- * (where it lived as a local function) to a shared module so the same
- * diagnostic-capture pattern that pinned the post-detail regression in
- * #762 / #771 (PR #770 / PR #772) can apply here.  The lifted predicate
- * is unchanged — Phase 2 will update it per diagnostic data captured
- * on the next E2E timeout.
+ * Issue #773: the engager modal's `[role="dialog"]` wrapper disappeared
+ * with LinkedIn's 2026-05 markup refresh (Phase 1 diagnostic capture
+ * confirmed `dialogCount: 0` while the modal IS visually open — see
+ * `reactionsButtonAriaLabels` and `bodyTextSnippet`).  This predicate
+ * resolves the modal via {@link RESOLVE_REACTIONS_MODAL_SCRIPT}'s
+ * fallback chain: canonical wrappers (`<dialog>` / `[aria-modal="true"]`
+ * / `[role="dialog"]`) first, then a tab-anchor walk from the "All
+ * reactions" filter button — whose aria-label stayed stable.  Engager
+ * links inside the resolved element gate the predicate.
  *
  * On timeout, if `LHREMOTE_CAPTURE_DIAGNOSTICS=1`, a best-effort
  * diagnostic capture is written to a per-invocation
@@ -62,7 +170,8 @@ export async function waitForReactionsModal(
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     const ready = await client.evaluate<boolean>(`(() => {
-      const modal = document.querySelector('${REACTIONS_MODAL_SELECTOR}');
+      ${RESOLVE_REACTIONS_MODAL_SCRIPT}
+      const modal = __getReactionsModal();
       if (!modal) return false;
       return modal.querySelectorAll('${REACTIONS_MODAL_ENGAGER_LINK_SELECTOR}').length > 0;
     })()`);
@@ -141,14 +250,27 @@ interface CaptureCancellationState {
  *
  * Probe set: `{ href, dialogCount, dialogHasInLinks,
  * dialogChildElementCount, bodyTextSnippet, reactionsButtonAriaLabels,
- * reactionsCountText }` — distinguishes:
- *  1. "click never opened a dialog" (`dialogCount === 0`)
+ * reactionsCountText, htmlDialogCount, ariaModalCount, hasReactionsTab,
+ * reactionsTabAncestorChain, resolvedModalAncestorTag }` —
+ * distinguishes:
+ *  1. "click never opened a dialog" (`dialogCount === 0` AND
+ *     `htmlDialogCount === 0` AND `ariaModalCount === 0` AND
+ *     `hasReactionsTab === false`)
  *  2. "dialog opened but engager-link selectors stale"
  *     (`dialogCount > 0 && !dialogHasInLinks`)
  *  3. "wrong button was clicked" (`reactionsButtonAriaLabels` reveals
  *     which aria-labels exist on visible reaction-related buttons,
  *     and `reactionsCountText` reports what the
  *     `FIND_REACTIONS_SCRIPT` regex would currently match)
+ *  4. "modal opens but uses non-canonical wrapper" — at least one of
+ *     `htmlDialogCount` / `ariaModalCount` / `hasReactionsTab` is
+ *     non-zero/true; `reactionsTabAncestorChain` reveals which
+ *     ancestor tag/role/aria-modal/class shape the modal wrapper
+ *     actually has, so the resolver fallback chain in
+ *     {@link RESOLVE_REACTIONS_MODAL_SCRIPT} can target it directly
+ *  5. "resolver fallback walk found a candidate but engager links
+ *     missing" — `resolvedModalAncestorTag` non-null but the predicate
+ *     still failed; rare hydration race vs. actual selector miss
  *
  * Mirrors the diagnostic-capture pattern documented in ADR-007 for
  * `navigateToProfile` and `waitForPostLoad` — same env var, same
@@ -209,21 +331,82 @@ async function captureReactionsModalFailureInner(
     bodyTextSnippet: string;
     reactionsButtonAriaLabels: string[];
     reactionsCountText: string | null;
+    htmlDialogCount: number;
+    ariaModalCount: number;
+    hasReactionsTab: boolean;
+    reactionsTabAncestorChain: string[];
+    resolvedModalAncestorTag: string | null;
   }>(`(() => {
-    const dialogs = document.querySelectorAll('${REACTIONS_MODAL_SELECTOR}');
-    const firstDialog = dialogs[0] || null;
-    const dialogHasInLinks = firstDialog
-      ? firstDialog.querySelectorAll('${REACTIONS_MODAL_ENGAGER_LINK_SELECTOR}').length > 0
+    ${RESOLVE_REACTIONS_MODAL_SCRIPT}
+    // Legacy dialog probe — preserved for continuity with the original
+    // diagnostic shape; \`dialogCount === 0\` is the signal that pinned
+    // #773 in Phase 1.
+    const legacyDialogs = document.querySelectorAll('[role="dialog"]');
+    const firstLegacyDialog = legacyDialogs[0] || null;
+    const dialogHasInLinks = firstLegacyDialog
+      ? firstLegacyDialog.querySelectorAll('${REACTIONS_MODAL_ENGAGER_LINK_SELECTOR}').length > 0
       : false;
-    const dialogChildElementCount = firstDialog ? firstDialog.childElementCount : 0;
+    const dialogChildElementCount = firstLegacyDialog ? firstLegacyDialog.childElementCount : 0;
+
+    // New wrapper-shape probes — distinguish "modal not opened at all"
+    // from "modal opened but uses a different wrapper element".  If any
+    // of these are non-zero / true while \`dialogCount === 0\`, the
+    // resolver fallback in RESOLVE_REACTIONS_MODAL_SCRIPT must adapt.
+    const htmlDialogCount = document.querySelectorAll('dialog').length;
+    const ariaModalCount = document.querySelectorAll('[aria-modal="true"]').length;
+    const reactionsTab = document.querySelector('${REACTIONS_TAB_FALLBACK_SELECTOR}');
+    const hasReactionsTab = reactionsTab !== null && reactionsTab.offsetHeight > 0;
+
+    // Walk up from the "All reactions" tab and capture each ancestor's
+    // shape (tag, role, aria-modal, aria-labelledby presence, class
+    // first-token) up to the same depth the resolver walks.  Lets a
+    // future regression target the wrapper element directly without
+    // another round of probe extension.
+    const reactionsTabAncestorChain = [];
+    if (reactionsTab) {
+      let ancestor = reactionsTab.parentElement;
+      let depth = 0;
+      while (ancestor && depth < ${REACTIONS_MODAL_ANCESTOR_WALK_DEPTH}) {
+        const tag = (ancestor.tagName || '').toLowerCase();
+        const role = ancestor.getAttribute('role') || '';
+        const ariaModal = ancestor.getAttribute('aria-modal') || '';
+        const ariaLabelledBy = ancestor.getAttribute('aria-labelledby') ? 'yes' : '';
+        // First class token only — bounds artifact size; full classlist
+        // would balloon for utility-CSS-heavy pages.
+        const classToken = ((ancestor.className && typeof ancestor.className === 'string')
+          ? ancestor.className.trim().split(/\\s+/)[0]
+          : '') || '';
+        const inLinks = ancestor.querySelectorAll('${REACTIONS_MODAL_ENGAGER_LINK_SELECTOR}').length;
+        reactionsTabAncestorChain.push(
+          tag + (role ? ' role=' + role : '') +
+          (ariaModal ? ' aria-modal=' + ariaModal : '') +
+          (ariaLabelledBy ? ' aria-labelledby=yes' : '') +
+          (classToken ? ' .' + classToken : '') +
+          ' inLinks=' + inLinks
+        );
+        ancestor = ancestor.parentElement;
+        depth++;
+      }
+    }
+
+    // Did the resolver land?  Reports the resolved element's tag for
+    // the "fallback found a candidate but predicate still failed" case.
+    const resolvedModal = __getReactionsModal();
+    const resolvedModalAncestorTag = resolvedModal
+      ? (resolvedModal.tagName || '').toLowerCase()
+      : null;
 
     // Capture aria-labels of visible buttons whose label hints at
     // reactions / engagement — distinguishes "clicked the wrong button"
     // (e.g. clicked a generic "Like" toggle instead of the reactions
-    // count summary) from "right button, modal selectors stale".  Cap
-    // length and count to keep the artifact bounded.
+    // count summary) from "right button, modal selectors stale".
+    // \`offsetHeight > 0\` filters out hidden/offscreen buttons (matches
+    // the "visible" promise in the comment AND mirrors the visibility
+    // check in the FIND_REACTIONS_SCRIPT below).  Cap length and count
+    // to keep the artifact bounded.
     const reactionsButtonAriaLabels = Array.prototype.slice
       .call(document.querySelectorAll('button[aria-label]'))
+      .filter(function (el) { return el.offsetHeight > 0; })
       .map(function (el) { return (el.getAttribute('aria-label') || '').trim(); })
       .filter(function (label) {
         return /reaction|like|engager|comment/i.test(label) && label.length < 200;
@@ -245,12 +428,17 @@ async function captureReactionsModalFailureInner(
 
     return {
       href: location.href,
-      dialogCount: dialogs.length,
+      dialogCount: legacyDialogs.length,
       dialogHasInLinks: dialogHasInLinks,
       dialogChildElementCount: dialogChildElementCount,
       bodyTextSnippet: (document.body ? document.body.innerText : "").slice(0, 800),
       reactionsButtonAriaLabels: reactionsButtonAriaLabels,
       reactionsCountText: reactionsCountText,
+      htmlDialogCount: htmlDialogCount,
+      ariaModalCount: ariaModalCount,
+      hasReactionsTab: hasReactionsTab,
+      reactionsTabAncestorChain: reactionsTabAncestorChain,
+      resolvedModalAncestorTag: resolvedModalAncestorTag,
     };
   })()`);
   if (state.timedOut) return;

--- a/packages/core/src/operations/get-post-engagers.ts
+++ b/packages/core/src/operations/get-post-engagers.ts
@@ -6,9 +6,10 @@ import type { PostEngager } from "../types/post-analytics.js";
 import { CDPClient } from "../cdp/client.js";
 import { discoverTargets } from "../cdp/discovery.js";
 import { waitForPostLoad } from "../cdp/wait-for-post-load.js";
+import { waitForReactionsModal } from "../cdp/wait-for-reactions-modal.js";
 import type { ConnectionOptions } from "./types.js";
 import { extractPostUrn, resolvePostDetailUrl } from "./get-post-stats.js";
-import { delay, gaussianDelay, gaussianBetween, maybeHesitate, maybeBreak, simulateReadingTime } from "../utils/delay.js";
+import { gaussianDelay, gaussianBetween, maybeHesitate, maybeBreak, simulateReadingTime } from "../utils/delay.js";
 import { humanizedScrollTo, humanizedClick } from "../linkedin/dom-automation.js";
 import type { HumanizedMouse } from "../linkedin/humanized-mouse.js";
 import { navigateAwayIf } from "./navigate-away.js";
@@ -209,33 +210,6 @@ const GET_MODAL_TOTAL_SCRIPT = `(() => {
 
   return 0;
 })()`;
-
-// ---------------------------------------------------------------------------
-// Wait helpers
-// ---------------------------------------------------------------------------
-
-/**
- * Poll the DOM until the reactions modal has loaded with at least one
- * profile link visible.
- */
-async function waitForReactionsModal(
-  client: CDPClient,
-  timeoutMs = 10_000,
-): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    const ready = await client.evaluate<boolean>(`(() => {
-      const modal = document.querySelector('[role="dialog"]');
-      if (!modal) return false;
-      return modal.querySelectorAll('a[href*="/in/"]').length > 0;
-    })()`);
-    if (ready) return;
-    await delay(500);
-  }
-  throw new Error(
-    "Timed out waiting for reactions modal to appear",
-  );
-}
 
 // ---------------------------------------------------------------------------
 // Main operation

--- a/packages/core/src/operations/get-post-engagers.ts
+++ b/packages/core/src/operations/get-post-engagers.ts
@@ -6,7 +6,10 @@ import type { PostEngager } from "../types/post-analytics.js";
 import { CDPClient } from "../cdp/client.js";
 import { discoverTargets } from "../cdp/discovery.js";
 import { waitForPostLoad } from "../cdp/wait-for-post-load.js";
-import { waitForReactionsModal } from "../cdp/wait-for-reactions-modal.js";
+import {
+  RESOLVE_REACTIONS_MODAL_SCRIPT,
+  waitForReactionsModal,
+} from "../cdp/wait-for-reactions-modal.js";
 import type { ConnectionOptions } from "./types.js";
 import { extractPostUrn, resolvePostDetailUrl } from "./get-post-stats.js";
 import { gaussianDelay, gaussianBetween, maybeHesitate, maybeBreak, simulateReadingTime } from "../utils/delay.js";
@@ -85,13 +88,17 @@ const REACTIONS_SELECTOR = "[data-lhremote-reactions]";
 /**
  * JavaScript source that extracts engager data from the reactions modal.
  *
- * The modal (`[role="dialog"]`) contains a scrollable list of people who
- * reacted to the post.  Each entry has a profile link (`a[href*="/in/"]`),
- * name text, headline, and a small reaction-type icon overlay.
+ * The modal contains a scrollable list of people who reacted to the
+ * post.  Each entry has a profile link (`a[href*="/in/"]`), name text,
+ * headline, and a small reaction-type icon overlay.  The modal element
+ * is resolved via {@link RESOLVE_REACTIONS_MODAL_SCRIPT}'s fallback
+ * chain — see #773 for why `[role="dialog"]` alone is no longer
+ * sufficient as of LinkedIn's 2026-05 markup refresh.
  */
 const SCRAPE_ENGAGERS_SCRIPT = `(() => {
+  ${RESOLVE_REACTIONS_MODAL_SCRIPT}
   const engagers = [];
-  const modal = document.querySelector('[role="dialog"]');
+  const modal = __getReactionsModal();
   if (!modal) return engagers;
 
   const seen = new Set();
@@ -165,11 +172,14 @@ const SCRAPE_ENGAGERS_SCRIPT = `(() => {
  * Build a scroll-modal script with a randomised scroll distance.
  *
  * The distance varies between 350–650 px to avoid the detection signal
- * of a perfectly uniform modal scroll cadence.
+ * of a perfectly uniform modal scroll cadence.  The modal element is
+ * resolved via {@link RESOLVE_REACTIONS_MODAL_SCRIPT}'s fallback chain
+ * (see #773 / Phase 1 diagnostics — `[role="dialog"]` alone is stale).
  */
 function createScrollModalScript(distance: number): string {
   return `(() => {
-  const modal = document.querySelector('[role="dialog"]');
+  ${RESOLVE_REACTIONS_MODAL_SCRIPT}
+  const modal = __getReactionsModal();
   if (!modal) return false;
 
   const divs = modal.querySelectorAll('div');
@@ -196,9 +206,12 @@ function createScrollModalScript(distance: number): string {
 /**
  * JavaScript source that extracts the total reactions count from the
  * reactions modal header text (e.g. "42 Reactions" or "All (42)").
+ * Modal resolution shares {@link RESOLVE_REACTIONS_MODAL_SCRIPT}'s
+ * fallback chain with the predicate / scrape / scroll scripts.
  */
 const GET_MODAL_TOTAL_SCRIPT = `(() => {
-  const modal = document.querySelector('[role="dialog"]');
+  ${RESOLVE_REACTIONS_MODAL_SCRIPT}
+  const modal = __getReactionsModal();
   if (!modal) return 0;
 
   const text = modal.textContent || '';


### PR DESCRIPTION
## Summary

- Lift `waitForReactionsModal` from `get-post-engagers.ts` into a shared diagnostic-capable helper at `packages/core/src/cdp/wait-for-reactions-modal.ts`, mirroring PR #770's pattern for `waitForPostLoad`. Phase 1 ships diagnostic capture (env-gated `LHREMOTE_CAPTURE_DIAGNOSTICS=1`, mkdtemp atomic per-invocation directories, `ensureSecureDiagnosticDir` reused) so the next regression in this area produces classifiable JSON evidence.
- Phase 2 (this PR's second commit) fixes the readiness selectors per ADR-007: shared `__getReactionsModal()` resolver tries canonical wrappers (`<dialog>` / `[aria-modal="true"]` / `[role="dialog"]`) then falls back to a tab-anchor walk from the "All reactions" filter button (whose aria-label stayed stable across LinkedIn's 2026-05 markup refresh).

## Context

`get-post-engagers` was the last of three post operations still failing after PR #772 fixed the post-detail timeout (#762/#771). Phase 1 diagnostic capture pinned the cause: LinkedIn dropped `[role="dialog"]` from the engager modal in 2026-05, so the existing predicate (lifted unchanged in commit 1) timed out at 10s while the modal WAS visually open. Phase 2 (commit 2) replaces the structural-CSS selector with a fallback chain anchored on aria-labels per ADR-007.

## Changes

| Phase | Commit | What |
|-------|--------|------|
| 1 (refactor) | `7cf5ee4` | Lift `waitForReactionsModal` to shared module + add `captureReactionsModalFailure` (env-gated probe with 7-field diagnostic JSON, screenshot, mkdtemp + 0o600 mode + cancellation discipline) |
| 2 (fix) | `ecfe169` | Add shared `__getReactionsModal()` resolver, expand probe to 12 fields with wrapper-shape distinguishers, wire scrape/scroll/total scripts to use the resolver |

## Test plan

- [x] `pnpm test` — 1675/1675 pass
- [x] `pnpm lint` — clean
- [x] `pnpm build` — clean
- [x] `pnpm --filter @lhremote/e2e test:e2e:file get-post-engagers` — PASS (51s, 2 independent runs within 60ms of each other)
- [ ] Copilot review cycle to clean
- [ ] CI green on all platforms (ubuntu/macos/windows)

Closes #773

🤖 Generated with [Claude Code](https://claude.com/claude-code)