### PR TITLE
(fix) core: rewrite comment-DOM lookups for LinkedIn React/SDUI post-detail

### DIFF
--- a/packages/core/src/linkedin/selectors.ts
+++ b/packages/core/src/linkedin/selectors.ts
@@ -145,6 +145,72 @@ export const COMMENT_REACTION_TRIGGER =
 export const COMMENT_REACTIONS_MENU =
   'button[aria-label="Open reactions menu"]';
 
+// ── React-stack post detail (LinkedIn 2026-05 SDUI rewrite) ──────
+
+/**
+ * Selects ANY comment article on the post-detail page.
+ *
+ * **Stack note**: as of LinkedIn's React/SDUI post-detail rewrite (live by
+ * 2026-05), comments are no longer `<article class="comments-comment-entity">`.
+ * Each comment is a `<div componentkey="replaceableComment_<URN>">` rendered
+ * inside a `<div data-component-type="LazyColumn" data-testid="...commentList...FeedType_FEED_DETAIL">`
+ * container.  Three nested `<div>` elements share the same `componentkey`
+ * value (outer wrapper, mid wrapper, inner content row); the selector
+ * matches all three but `waitForElement` style usage is unaffected.
+ *
+ * Use with `waitForElement` to anchor on the comments section having
+ * hydrated at least one comment.  Pair with {@link commentArticleSelectorByUrn}
+ * to scope subsequent selectors to a specific comment.
+ *
+ * See `research/linkedin/post-detail-comment-dom-react-sdui-20260506.md` and
+ * lhremote issue #776.
+ */
+export const COMMENT_ARTICLE_ANY = '[componentkey^="replaceableComment_"]';
+
+/**
+ * Build a selector that scopes to a specific comment article by URN.
+ *
+ * @param urn  Comment URN in the React-stack format
+ *             (`urn:li:comment:(urn:li:activity:<postId>,<commentId>)`).
+ *             Use {@link normalizeCommentUrnForReactStack} if you have the
+ *             legacy format `urn:li:comment:(activity:N,M)`.
+ *
+ * Returns a selector that matches the three nested elements sharing the
+ * same `componentkey`.  For scoped queries (e.g. finding a button inside
+ * the comment) the scope works regardless of which level the descendant
+ * lives at.
+ */
+export function commentArticleSelectorByUrn(urn: string): string {
+  return `[componentkey="replaceableComment_${urn}"]`;
+}
+
+/**
+ * Convert a legacy comment URN (`urn:li:comment:(activity:N,M)`) to the
+ * React-stack format (`urn:li:comment:(urn:li:activity:N,M)`).
+ *
+ * The legacy format was emitted by `get-post` and consumed by
+ * `comment-on-post` / `react-to-comment` against the Ember stack.  After
+ * LinkedIn's SDUI rewrite, the inner `activity:` segment is fully URN-qualified
+ * (`urn:li:activity:`).  The DOM only matches the new format, so client
+ * input in either form is normalized here before DOM lookups.
+ *
+ * @returns the new-format URN if the input matches the legacy form;
+ *          otherwise returns the input unchanged (idempotent for new format
+ *          and inputs that don't match either pattern).
+ */
+export function normalizeCommentUrnForReactStack(urn: string): string {
+  // Legacy:  urn:li:comment:(activity:N,M)
+  // SDUI:    urn:li:comment:(urn:li:activity:N,M)
+  const legacy = /^urn:li:comment:\((\w+):(\d+),(\d+)\)$/.exec(urn);
+  if (legacy) {
+    const type = legacy[1];
+    const postId = legacy[2];
+    const commentId = legacy[3];
+    return `urn:li:comment:(urn:li:${type}:${postId},${commentId})`;
+  }
+  return urn;
+}
+
 // ── Mention autocomplete ─────────────────────────────────────────
 
 /**

--- a/packages/core/src/operations/comment-on-post.test.ts
+++ b/packages/core/src/operations/comment-on-post.test.ts
@@ -58,6 +58,10 @@ function createMockClient() {
     send: vi.fn().mockResolvedValue(undefined),
     navigate: vi.fn().mockResolvedValue({ frameId: "F1" }),
     waitForEvent: vi.fn().mockResolvedValue(undefined),
+    // Reply path stamps a `data-lhremote-reply` marker on the Reply
+    // <button> via Runtime.evaluate.  Default: report success so the
+    // operation uses the stamped-marker selector.
+    evaluate: vi.fn().mockResolvedValue(true),
   };
 }
 
@@ -330,13 +334,22 @@ describe("commentOnPost", () => {
     // Reply flow: waitForElement called for comment article, reply button, focused input, submit button
     expect(waitForElement).toHaveBeenCalledTimes(4);
 
-    // First call: wait for the target comment article
-    const firstSelector = vi.mocked(waitForElement).mock.calls[0]?.[1];
-    expect(firstSelector).toContain(`article[data-id="${parentUrn}"]`);
+    // SDUI stack: legacy `urn:li:comment:(activity:N,M)` is normalized to
+    // `urn:li:comment:(urn:li:activity:N,M)` for componentkey lookups.
+    // (See lhremote#776 and `normalizeCommentUrnForReactStack`.)
+    const normalizedParentUrn = "urn:li:comment:(urn:li:activity:123,999)";
+    const expectedComponentkey = `[componentkey="replaceableComment_${normalizedParentUrn}"]`;
 
-    // Second call: wait for reply button within the article
+    // First call: wait for the target comment article (componentkey-scoped)
+    const firstSelector = vi.mocked(waitForElement).mock.calls[0]?.[1];
+    expect(firstSelector).toContain(expectedComponentkey);
+
+    // Second call: wait for the Reply button within the comment.  In the
+    // SDUI stack the Reply button has no aria-label, so the operation
+    // stamps a `data-lhremote-reply` marker via Runtime.evaluate (mocked
+    // to return `true`) and waits on the marker selector.
     const secondSelector = vi.mocked(waitForElement).mock.calls[1]?.[1];
-    expect(secondSelector).toContain('button[aria-label^="Reply to "]');
+    expect(secondSelector).toContain('button[data-lhremote-reply="1"]');
 
     // Third call: wait for focused comment input (not the global one)
     const thirdSelector = vi.mocked(waitForElement).mock.calls[2]?.[1];
@@ -345,7 +358,7 @@ describe("commentOnPost", () => {
     // scrollTo called for the comment article (not the top-level input)
     expect(humanizedScrollTo).toHaveBeenCalledTimes(1);
     const scrollSelector = vi.mocked(humanizedScrollTo).mock.calls[0]?.[1];
-    expect(scrollSelector).toContain(`article[data-id="${parentUrn}"]`);
+    expect(scrollSelector).toContain(expectedComponentkey);
   });
 
   it("rejects invalid parentCommentUrn format", async () => {

--- a/packages/core/src/operations/comment-on-post.ts
+++ b/packages/core/src/operations/comment-on-post.ts
@@ -8,7 +8,13 @@ import { ActionBudgetRepository } from "../db/index.js";
 import { waitForElement, humanizedScrollTo, humanizedClick, typeText, typeTextWithMentions } from "../linkedin/dom-automation.js";
 import type { MentionEntry } from "../linkedin/dom-automation.js";
 import type { HumanizedMouse } from "../linkedin/humanized-mouse.js";
-import { COMMENT_INPUT, COMMENT_REPLY_BUTTON, COMMENT_SUBMIT_BUTTON } from "../linkedin/selectors.js";
+import {
+  commentArticleSelectorByUrn,
+  COMMENT_INPUT,
+  COMMENT_REPLY_BUTTON,
+  COMMENT_SUBMIT_BUTTON,
+  normalizeCommentUrnForReactStack,
+} from "../linkedin/selectors.js";
 import { resolveAccount } from "../services/account-resolution.js";
 import { BudgetExceededError } from "../services/errors.js";
 import { withDatabase } from "../services/instance-context.js";
@@ -19,8 +25,18 @@ import { buildCdpOptions, type ConnectionOptions } from "./types.js";
 const LINKEDIN_POST_URL_RE =
   /linkedin\.com\/(?:feed\/update\/urn:li:\w+:\d+|posts\/[^/]+)/;
 
-/** Pattern matching a LinkedIn comment URN (e.g. `urn:li:comment:(activity:123,456)`). */
-const COMMENT_URN_RE = /^urn:li:comment:\(\w+:\d+,\d+\)$/;
+/**
+ * Pattern matching a LinkedIn comment URN.
+ *
+ * Accepts BOTH formats:
+ * - Legacy Ember stack: `urn:li:comment:(activity:123,456)`
+ * - React/SDUI stack:   `urn:li:comment:(urn:li:activity:123,456)`
+ *
+ * `normalizeCommentUrnForReactStack` converts to the React-stack form
+ * before DOM lookups.  See lhremote#776 and
+ * `research/linkedin/post-detail-comment-dom-react-sdui-20260506.md`.
+ */
+const COMMENT_URN_RE = /^urn:li:comment:\((?:urn:li:)?\w+:\d+,\d+\)$/;
 
 /** Limit type ID for PostComment in the LinkedHelper budget system. */
 const POST_COMMENT_LIMIT_TYPE_ID = 19;
@@ -171,13 +187,35 @@ export async function commentOnPost(
 
     if (parentUrn) {
       // --- Reply to a specific comment ---
-      // Find the target comment article by its data-id attribute
-      const commentSelector = `article[data-id="${parentUrn}"]`;
+      // React/SDUI stack: each comment is a `<div componentkey="replaceableComment_<URN>">`,
+      // not the legacy `<article class="comments-comment-entity" data-id="<URN>">`.
+      // Normalize the URN to the SDUI form (legacy callers pass
+      // `urn:li:comment:(activity:N,M)`; SDUI uses
+      // `urn:li:comment:(urn:li:activity:N,M)`).  See lhremote#776.
+      const normalizedParentUrn = normalizeCommentUrnForReactStack(parentUrn);
+      const commentSelector = commentArticleSelectorByUrn(normalizedParentUrn);
       await waitForElement(client, commentSelector, undefined, mouse);
       await humanizedScrollTo(client, commentSelector, mouse);
 
-      // Click the Reply button within that comment
-      const replySelector = `${commentSelector} ${COMMENT_REPLY_BUTTON}`;
+      // The Reply button has no aria-label in the React/SDUI stack — it's
+      // identified only by its `textContent === "Reply"`.  Stamp a marker
+      // attribute via JS so we can use a CSS selector for the subsequent
+      // wait/click flow.  Falls back to the legacy `aria-label^="Reply to "`
+      // if the marker stamp couldn't find a Reply button (covers any
+      // residual Ember-stack pages or future re-skin).
+      const replyMarkerStamped = await client.evaluate<boolean>(`(() => {
+        const scope = document.querySelector(${JSON.stringify(commentSelector)});
+        if (!scope) return false;
+        const btn = Array.from(scope.querySelectorAll('button'))
+          .find(b => (b.textContent || '').trim() === 'Reply');
+        if (!btn) return false;
+        btn.setAttribute('data-lhremote-reply', '1');
+        return true;
+      })()`);
+
+      const replySelector = replyMarkerStamped
+        ? `${commentSelector} button[data-lhremote-reply="1"]`
+        : `${commentSelector} ${COMMENT_REPLY_BUTTON}`;
       await waitForElement(client, replySelector, undefined, mouse);
       await humanizedClick(client, replySelector, mouse);
       await gaussianDelay(550, 75, 400, 700);

--- a/packages/core/src/operations/react-to-comment.test.ts
+++ b/packages/core/src/operations/react-to-comment.test.ts
@@ -15,7 +15,7 @@ vi.mock("../linkedin/dom-automation.js", () => ({
   waitForElement: vi.fn(),
   waitForDOMStable: vi.fn().mockResolvedValue(undefined),
   hover: vi.fn(),
-  click: vi.fn(),
+  click: vi.fn().mockResolvedValue(undefined),
   humanizedHover: vi.fn(),
   humanizedClick: vi.fn(),
   humanizedScrollTo: vi.fn(),
@@ -30,6 +30,7 @@ vi.mock("../utils/delay.js", () => ({
 import { CDPClient } from "../cdp/client.js";
 import { discoverTargets } from "../cdp/discovery.js";
 import {
+  click,
   humanizedClick,
   humanizedHover,
   humanizedScrollTo,
@@ -40,12 +41,12 @@ import { reactToComment } from "./react-to-comment.js";
 
 const POST_URL = "https://www.linkedin.com/feed/update/urn:li:activity:7436698865522851840/";
 const COMMENT_URN = "urn:li:comment:(activity:7436698865522851840,7436707959465730049)";
-// The operation stamps a `data-comment-urn` marker onto the matching
-// article and uses that for subsequent scoped queries (see operation
-// implementation comment for rationale).  Tests assert against the
-// marker-based selector.
-const ARTICLE_SELECTOR = `article[data-comment-urn="${COMMENT_URN}"]`;
-const TRIGGER_SELECTOR = `${ARTICLE_SELECTOR} button:is([aria-label^="React Like to "], [aria-label^="Unreact "])`;
+// The operation normalizes `commentUrn` to the React/SDUI form
+// (`urn:li:comment:(urn:li:activity:N,M)`) and scopes selectors to a
+// `componentkey="replaceableComment_<URN>"` element.  Tests assert
+// against the normalized componentkey selector.  See lhremote#776.
+const NORMALIZED_COMMENT_URN = "urn:li:comment:(urn:li:activity:7436698865522851840,7436707959465730049)";
+const ARTICLE_SELECTOR = `[componentkey="replaceableComment_${NORMALIZED_COMMENT_URN}"]`;
 const MENU_SELECTOR = `${ARTICLE_SELECTOR} button[aria-label="Open reactions menu"]`;
 
 const mockClient = {
@@ -57,8 +58,23 @@ const mockClient = {
   waitForEvent: vi.fn().mockResolvedValue(undefined),
 };
 
-/** Default trigger aria-label (no reaction applied). */
-let nextTriggerLabel: string | null = null;
+/** Default reaction-state textContent (null → operation reads as not-reacted). */
+let nextReactionStateText: string | null = null;
+
+/**
+ * Helper: build the React/SDUI state-text for a given reaction type.
+ * Produces the doubled-word form the parser expects (e.g. "InsightfulInsightful").
+ * Pass `null` for the not-reacted state.
+ */
+function reactionStateText(name: string | null): string {
+  if (name === null) {
+    // "no reactionLike" — visible "Like" prompt is appended to the hidden
+    // a11y "no reaction" label.
+    return "Reaction button state: no reactionLike";
+  }
+  // "InsightfulInsightful" — hidden a11y label + visible button face.
+  return `Reaction button state: ${name}${name}`;
+}
 
 function setupMocks() {
   vi.mocked(CDPClient).mockImplementation(function () {
@@ -75,27 +91,38 @@ function setupMocks() {
   // Conditional evaluate mock — the operation calls evaluate for several
   // distinct purposes:
   //   (a) `location.pathname`     — navigateAwayIf decision
-  //   (b) JS-side comment-presence probe (load-more pagination loop)
-  //   (c) reading the trigger button's `aria-label`
+  //   (b) JS-side comment-presence probe (load-more pagination loop) —
+  //       SDUI stack uses `componentkey="replaceableComment_<URN>"`.
+  //   (c) reading the comment's reaction state via the `[role="button"]`
+  //       text content (`Reaction button state: <X>`).
   // Defaulting to a no-op pathname avoids navigateAwayIf side effects.
   // The presence probe defaults to `true` so the pagination loop exits
   // on its first iteration without clicking "Load more comments" — tests
   // that exercise pagination can override per-call.
-  // The trigger label is read from `nextTriggerLabel` (set per test).
-  nextTriggerLabel = null;
+  // The current reaction is set per test via `nextReactionStateText`
+  // (e.g. "Reaction button state: InsightfulInsightful" → Insightful;
+  //       "Reaction button state: no reactionLike" → not reacted).
+  nextReactionStateText = null;
   mockClient.evaluate.mockImplementation((script: unknown) => {
     if (typeof script === "string" && script.includes("location.pathname")) {
       return Promise.resolve("/feed/");
     }
+    // State-text read MUST be matched before the componentkey-presence
+    // check below — the state-detection script also contains
+    // `componentkey=` (in the JSON-stringified scope selector), so the
+    // order matters.
     if (
       typeof script === "string" &&
-      script.includes("article[data-id]") &&
-      script.includes("setAttribute('data-comment-urn'")
+      script.includes("Reaction button state:")
+    ) {
+      return Promise.resolve(nextReactionStateText);
+    }
+    if (
+      typeof script === "string" &&
+      script.includes("componentkey=") &&
+      script.includes("replaceableComment_")
     ) {
       return Promise.resolve(true);
-    }
-    if (typeof script === "string" && script.includes("getAttribute('aria-label')")) {
-      return Promise.resolve(nextTriggerLabel);
     }
     return Promise.resolve(null);
   });
@@ -214,9 +241,9 @@ describe("reactToComment", () => {
     });
   });
 
-  it('returns alreadyReacted when same reaction is active ("Unreact Like")', async () => {
+  it("returns alreadyReacted when same reaction is active (state-text 'LikeLike')", async () => {
     setupMocks();
-    nextTriggerLabel = "Unreact Like";
+    nextReactionStateText = reactionStateText("Like");
 
     const result = await reactToComment({
       postUrl: POST_URL,
@@ -229,29 +256,13 @@ describe("reactToComment", () => {
     expect(result.reactionType).toBe("like");
     expect(result.alreadyReacted).toBe(true);
     expect(humanizedHover).not.toHaveBeenCalled();
+    // No menu click happens — the no-op short-circuits before the popup.
+    expect(humanizedClick).not.toHaveBeenCalled();
   });
 
-  it('returns alreadyReacted with comment-context aria-label ("Unreact Like to X\'s comment")', async () => {
+  it("opens menu and clicks new reaction when switching from Celebrate → Like", async () => {
     setupMocks();
-    // Verifies the regex /^Unreact\s+(\w+)/i correctly handles the
-    // comment-context-preserving form by capturing only the first word.
-    nextTriggerLabel = "Unreact Like to Olly's comment";
-
-    const result = await reactToComment({
-      postUrl: POST_URL,
-      commentUrn: COMMENT_URN,
-      reactionType: "like",
-      cdpPort: 9222,
-    });
-
-    expect(result.success).toBe(true);
-    expect(result.alreadyReacted).toBe(true);
-    expect(humanizedHover).not.toHaveBeenCalled();
-  });
-
-  it("unreacts first then re-Likes via direct trigger when target is Like", async () => {
-    setupMocks();
-    nextTriggerLabel = "Unreact Celebrate";
+    nextReactionStateText = reactionStateText("Celebrate");
 
     const result = await reactToComment({
       postUrl: POST_URL,
@@ -263,17 +274,19 @@ describe("reactToComment", () => {
     expect(result.success).toBe(true);
     expect(result.reactionType).toBe("like");
     expect(result.alreadyReacted).toBe(false);
-    // For Like target: NO popup is needed — clicking the direct-Like
-    // trigger is the apply mechanism.  2 clicks: (1) trigger to unreact
-    // existing reaction, (2) trigger again to apply Like.
-    expect(humanizedClick).toHaveBeenCalledTimes(2);
-    expect(humanizedClick).toHaveBeenNthCalledWith(1, mockClient, TRIGGER_SELECTOR, undefined);
-    expect(humanizedClick).toHaveBeenNthCalledWith(2, mockClient, TRIGGER_SELECTOR, undefined);
+    expect(result.currentReaction).toBe("celebrate");
+    // SDUI stack: humanizedClick on menu (opens popup) → plain click on
+    // popup reaction (no mouse motion, popup stays open).  LinkedIn
+    // auto-replaces the existing reaction.
+    expect(humanizedClick).toHaveBeenCalledTimes(1);
+    expect(humanizedClick).toHaveBeenCalledWith(mockClient, MENU_SELECTOR, undefined);
+    expect(click).toHaveBeenCalledTimes(1);
+    expect(click).toHaveBeenCalledWith(mockClient, 'button[aria-label="Like"]');
   });
 
-  it("unreacts first then opens popup when target is non-Like", async () => {
+  it("opens menu and clicks new reaction when switching from Like → Celebrate", async () => {
     setupMocks();
-    nextTriggerLabel = "Unreact Like";
+    nextReactionStateText = reactionStateText("Like");
 
     const result = await reactToComment({
       postUrl: POST_URL,
@@ -285,20 +298,13 @@ describe("reactToComment", () => {
     expect(result.success).toBe(true);
     expect(result.reactionType).toBe("celebrate");
     expect(result.alreadyReacted).toBe(false);
-    // For non-Like target: 3 clicks: (1) trigger to unreact, (2) menu
-    // to open popup, (3) popup-reaction button.
-    expect(humanizedClick).toHaveBeenCalledTimes(3);
-    expect(humanizedClick).toHaveBeenNthCalledWith(1, mockClient, TRIGGER_SELECTOR, undefined);
-    expect(humanizedClick).toHaveBeenNthCalledWith(2, mockClient, MENU_SELECTOR, undefined);
-    expect(humanizedClick).toHaveBeenNthCalledWith(
-      3,
-      mockClient,
-      'button[aria-label^="React Celebrate to "]',
-      undefined,
-    );
+    expect(humanizedClick).toHaveBeenCalledTimes(1);
+    expect(humanizedClick).toHaveBeenCalledWith(mockClient, MENU_SELECTOR, undefined);
+    expect(click).toHaveBeenCalledTimes(1);
+    expect(click).toHaveBeenCalledWith(mockClient, 'button[aria-label="Celebrate"]');
   });
 
-  it("returns dryRun: true for Like target — no clicks at all", async () => {
+  it("returns dryRun for Like target — opens menu, validates popup, no reaction click", async () => {
     setupMocks();
 
     const result = await reactToComment({
@@ -313,11 +319,15 @@ describe("reactToComment", () => {
     expect(result.dryRun).toBe(true);
     expect(result.alreadyReacted).toBe(false);
     expect(result.currentReaction).toBeNull();
-    // For Like target with dryRun: NO popup involved, NO clicks at all.
-    expect(humanizedClick).not.toHaveBeenCalled();
+    // SDUI stack: every reaction (incl. Like) goes through the popup.
+    // Dry-run clicks the menu (validates the popup machinery) but skips
+    // clicking the reaction button.
+    expect(humanizedClick).toHaveBeenCalledTimes(1);
+    expect(humanizedClick).toHaveBeenCalledWith(mockClient, MENU_SELECTOR, undefined);
+    expect(click).not.toHaveBeenCalled();
   });
 
-  it("returns dryRun: true for non-Like target — clicks menu but skips reaction", async () => {
+  it("returns dryRun for non-Like target — opens menu but skips reaction click", async () => {
     setupMocks();
 
     const result = await reactToComment({
@@ -332,15 +342,14 @@ describe("reactToComment", () => {
     expect(result.dryRun).toBe(true);
     expect(result.alreadyReacted).toBe(false);
     expect(result.currentReaction).toBeNull();
-    // For non-Like target with dryRun: clicks menu to validate popup opens,
-    // but does NOT click the reaction button — exactly 1 click.
     expect(humanizedClick).toHaveBeenCalledTimes(1);
     expect(humanizedClick).toHaveBeenCalledWith(mockClient, MENU_SELECTOR, undefined);
+    expect(click).not.toHaveBeenCalled();
   });
 
   it("returns dryRun with currentReaction when a different reaction is active", async () => {
     setupMocks();
-    nextTriggerLabel = "Unreact Celebrate";
+    nextReactionStateText = reactionStateText("Celebrate");
 
     const result = await reactToComment({
       postUrl: POST_URL,
@@ -354,16 +363,16 @@ describe("reactToComment", () => {
     expect(result.dryRun).toBe(true);
     expect(result.alreadyReacted).toBe(false);
     expect(result.currentReaction).toBe("celebrate");
-    // Should NOT click trigger to unreact (dryRun preserves state),
-    // but DOES click menu to validate popup opens (non-Like target) —
-    // exactly 1 click (no unreact, no reaction button).
+    // Dry-run preserves state — clicks the menu (popup-validation) but
+    // does not click the reaction.  No "unreact first" step in the SDUI flow.
     expect(humanizedClick).toHaveBeenCalledTimes(1);
     expect(humanizedClick).toHaveBeenCalledWith(mockClient, MENU_SELECTOR, undefined);
+    expect(click).not.toHaveBeenCalled();
   });
 
   it("returns alreadyReacted with dryRun when same reaction is active", async () => {
     setupMocks();
-    nextTriggerLabel = "Unreact Like";
+    nextReactionStateText = reactionStateText("Like");
 
     const result = await reactToComment({
       postUrl: POST_URL,
@@ -402,10 +411,11 @@ describe("reactToComment", () => {
 
     // First waitForElement: anchor — any comment article (proves the
     // comments section has hydrated before we look for a specific URN).
+    // SDUI stack uses `componentkey^="replaceableComment_"` (lhremote#776).
     expect(waitForElement).toHaveBeenNthCalledWith(
       1,
       mockClient,
-      "article.comments-comment-entity",
+      '[componentkey^="replaceableComment_"]',
       undefined,
       undefined,
     );
@@ -419,11 +429,11 @@ describe("reactToComment", () => {
       undefined,
     );
 
-    // Third waitForElement: the comment-scoped reaction trigger
+    // Third waitForElement: the comment-scoped reactions menu opener
     expect(waitForElement).toHaveBeenNthCalledWith(
       3,
       mockClient,
-      TRIGGER_SELECTOR,
+      MENU_SELECTOR,
       undefined,
       undefined,
     );
@@ -445,7 +455,7 @@ describe("reactToComment", () => {
     );
   });
 
-  it("clicks the direct trigger (no popup) when target is Like", async () => {
+  it("opens the menu via humanizedClick and clicks Like via plain click in popup (SDUI: no direct trigger)", async () => {
     setupMocks();
 
     await reactToComment({
@@ -455,16 +465,18 @@ describe("reactToComment", () => {
       cdpPort: 9222,
     });
 
-    // Like target: just click the direct-Like trigger.  No menu.
+    // SDUI stack: every reaction goes through the popup, including Like.
+    // Sequence: humanizedClick on menu (opens click-anchored popup),
+    // then plain `click` on reaction button (no mouse motion — popup
+    // cannot close mid-motion).
     expect(humanizedClick).toHaveBeenCalledTimes(1);
-    expect(humanizedClick).toHaveBeenCalledWith(
-      mockClient,
-      TRIGGER_SELECTOR,
-      undefined,
-    );
+    expect(humanizedClick).toHaveBeenCalledWith(mockClient, MENU_SELECTOR, undefined);
+    expect(click).toHaveBeenCalledTimes(1);
+    expect(click).toHaveBeenCalledWith(mockClient, 'button[aria-label="Like"]');
+    expect(humanizedHover).not.toHaveBeenCalled();
   });
 
-  it("clicks Open-reactions-menu when target is non-Like", async () => {
+  it("clicks Open-reactions-menu when target is non-Like (popup is click-anchored)", async () => {
     setupMocks();
 
     await reactToComment({
@@ -474,15 +486,12 @@ describe("reactToComment", () => {
       cdpPort: 9222,
     });
 
-    // Non-Like target: click menu to open popup.
-    expect(humanizedClick).toHaveBeenCalledWith(
-      mockClient,
-      MENU_SELECTOR,
-      undefined,
-    );
+    // Non-Like target: same flow — humanizedClick opens, plain click selects.
+    expect(humanizedClick).toHaveBeenCalledWith(mockClient, MENU_SELECTOR, undefined);
+    expect(click).toHaveBeenCalledWith(mockClient, 'button[aria-label="Celebrate"]');
   });
 
-  it("wraps popup wait in retryInteraction (only fires for non-Like)", async () => {
+  it("wraps popup wait in retryInteraction (always — SDUI uses popup for every reaction)", async () => {
     setupMocks();
 
     await reactToComment({
@@ -494,11 +503,12 @@ describe("reactToComment", () => {
 
     expect(retryInteraction).toHaveBeenCalledWith(expect.any(Function), 3);
 
-    // Final waitForElement: the comment-level popup reaction button
-    // ("React {Type} to {Name}'s comment" prefix), with timeout, no mouse.
+    // Final waitForElement: the popup reaction button.  SDUI uses the
+    // bare aria-label format (`button[aria-label="<Type>"]`) — same as
+    // post-level reactions.
     expect(waitForElement).toHaveBeenLastCalledWith(
       mockClient,
-      'button[aria-label^="React Insightful to "]',
+      'button[aria-label="Insightful"]',
       { timeout: 10_000 },
     );
   });
@@ -513,11 +523,7 @@ describe("reactToComment", () => {
       cdpPort: 9222,
     });
 
-    expect(humanizedClick).toHaveBeenCalledWith(
-      mockClient,
-      'button[aria-label^="React Funny to "]',
-      undefined,
-    );
+    expect(click).toHaveBeenCalledWith(mockClient, 'button[aria-label="Funny"]');
   });
 
   it("disconnects the CDP client even when an error occurs", async () => {

--- a/packages/core/src/operations/react-to-comment.ts
+++ b/packages/core/src/operations/react-to-comment.ts
@@ -5,6 +5,7 @@ import { resolveInstancePort } from "../cdp/index.js";
 import { CDPClient } from "../cdp/client.js";
 import { discoverTargets } from "../cdp/discovery.js";
 import {
+  click,
   humanizedClick,
   humanizedScrollTo,
   retryInteraction,
@@ -13,8 +14,10 @@ import {
 } from "../linkedin/dom-automation.js";
 import type { HumanizedMouse } from "../linkedin/humanized-mouse.js";
 import {
-  COMMENT_REACTION_TRIGGER,
+  commentArticleSelectorByUrn,
+  COMMENT_ARTICLE_ANY,
   COMMENT_REACTIONS_MENU,
+  normalizeCommentUrnForReactStack,
 } from "../linkedin/selectors.js";
 import { gaussianDelay } from "../utils/delay.js";
 import { navigateAwayIf } from "./navigate-away.js";
@@ -25,8 +28,18 @@ import type { ConnectionOptions } from "./types.js";
 const LINKEDIN_POST_URL_RE =
   /linkedin\.com\/(?:feed\/update\/urn:li:\w+:\d+|posts\/[^/]+)/;
 
-/** Pattern matching a LinkedIn comment URN (e.g. `urn:li:comment:(activity:123,456)`). */
-const COMMENT_URN_RE = /^urn:li:comment:\(\w+:\d+,\d+\)$/;
+/**
+ * Pattern matching a LinkedIn comment URN.
+ *
+ * Accepts BOTH formats:
+ * - Legacy Ember stack: `urn:li:comment:(activity:123,456)`
+ * - React/SDUI stack:   `urn:li:comment:(urn:li:activity:123,456)`
+ *
+ * Code paths normalize to the React-stack form via
+ * `normalizeCommentUrnForReactStack` before DOM lookups.  See
+ * `research/linkedin/post-detail-comment-dom-react-sdui-20260506.md`.
+ */
+const COMMENT_URN_RE = /^urn:li:comment:\((?:urn:li:)?\w+:\d+,\d+\)$/;
 
 /**
  * JavaScript source that finds and clicks the "Load more comments" button
@@ -77,23 +90,26 @@ const MAX_LOAD_MORE_ATTEMPTS = 20;
 
 /**
  * Map from reaction type to its popup-button selector for the
- * comment-level reactions popup.
+ * comment-level reactions popup (LinkedIn React/SDUI stack).
  *
- * **Important**: comment-level popup buttons have aria-labels of the form
- * `"React {Type} to {Name}'s comment"` — distinct from the post-level
- * popup which uses bare `"React Like"` / `"Like"` / etc.  The post-level
- * REACTION_LIKE/CELEBRATE/etc. constants do NOT match here.
+ * **History**: Previously the comment-level popup used aria-labels like
+ * `"React Like to {Name}'s comment"` (Ember stack).  After the React/SDUI
+ * rewrite (verified 2026-05-06, see
+ * `research/linkedin/post-detail-comment-dom-react-sdui-20260506.md`)
+ * clicking `Open reactions menu` on a comment opens the SAME page-level
+ * popup that `react-to-post` uses, so the bare `aria-label="Like"` /
+ * `aria-label="Celebrate"` / etc. selectors apply directly.
  *
- * Discovered via E2E diagnostic capture against the LinkedHelper webview
- * (lhremote#754).  See `../research/linkedin/comment-reactions-dom-20260428.md`.
+ * Verified live via `comment-dom-spike.e2e.test.ts` reactions-popup probe
+ * (lhremote#776).
  */
 const COMMENT_POPUP_REACTION_SELECTORS: Readonly<Record<ReactionType, string>> = {
-  like: 'button[aria-label^="React Like to "]',
-  celebrate: 'button[aria-label^="React Celebrate to "]',
-  support: 'button[aria-label^="React Support to "]',
-  love: 'button[aria-label^="React Love to "]',
-  insightful: 'button[aria-label^="React Insightful to "]',
-  funny: 'button[aria-label^="React Funny to "]',
+  like: 'button[aria-label="Like"]',
+  celebrate: 'button[aria-label="Celebrate"]',
+  support: 'button[aria-label="Support"]',
+  love: 'button[aria-label="Love"]',
+  insightful: 'button[aria-label="Insightful"]',
+  funny: 'button[aria-label="Funny"]',
 };
 
 /** Map from display name (as it appears in aria-labels) to reaction type. */
@@ -107,39 +123,61 @@ const REACTION_NAME_MAP: Readonly<Partial<Record<string, ReactionType>>> = {
 };
 
 /**
- * Detect the current reaction state of a specific comment by inspecting
- * the comment-scoped reaction trigger button's `aria-label`.
+ * Detect the current reaction state of a specific comment by reading
+ * the React/SDUI state-display element inside the comment scope.
  *
- * The expected aria-label patterns on the post detail page (Ember stack):
+ * **Stack note**: The Ember stack exposed state via the trigger button's
+ * `aria-label` (e.g., `"Unreact Like"`).  The React/SDUI rewrite removed
+ * the direct-Like trigger entirely; reaction state now lives in an
+ * element with `role="button"` (observed as `<div role="button">` and
+ * a sibling `<p role="button">`, both bearing the same text — we match
+ * either via the role-based selector).  Its `textContent` follows
+ * `"Reaction button state: <X><X>"` — the leading `<X>` is the hidden
+ * a11y label, the trailing `<X>` is the visible button face.  When the
+ * comment is unreacted, the text reads `"Reaction button state: no reactionLike"`
+ * (the trailing `Like` is the prompt shown to invite the user to react).
  *
- * - Not reacted: `"React Like to {Name}'s comment"`
- * - Reacted:    `"Unreact Like"` or `"Unreact Like to {Name}'s comment"`
- *               (and equivalent for Celebrate / Support / Love / Insightful / Funny)
- *
- * Uses the same `^Unreact\s+(\w+)` regex as the post-level detector;
- * the `\w+` capture takes only the first word, so it correctly handles
- * both the bare `"Unreact Like"` form and the comment-context-preserving
- * `"Unreact Like to {Name}'s comment"` form.
+ * Verified via `comment-dom-spike.e2e.test.ts` inner-button probe
+ * (lhremote#776).
  *
  * @returns The current reaction type, or `null` if not reacted.
  */
 async function detectCommentReaction(
   client: CDPClient,
-  scopedTriggerSelector: string,
+  commentScopeSelector: string,
 ): Promise<ReactionType | null> {
-  const label = await client.evaluate<string | null>(
+  const text = await client.evaluate<string | null>(
     `(() => {
-      const el = document.querySelector(${JSON.stringify(scopedTriggerSelector)});
-      return el ? el.getAttribute('aria-label') : null;
+      const scope = document.querySelector(${JSON.stringify(commentScopeSelector)});
+      if (!scope) return null;
+      const stateEl = Array.from(scope.querySelectorAll('[role="button"]'))
+        .find(el => /Reaction button state:/.test(el.textContent || ''));
+      return stateEl ? (stateEl.textContent || '').trim() : null;
     })()`,
   );
 
-  if (!label) return null;
+  if (!text) return null;
 
-  // Reacted: "Unreact Like" / "Unreact Like to {Name}'s comment", etc.
-  const unreactMatch = /^Unreact\s+(\w+)/i.exec(label);
-  if (unreactMatch?.[1]) {
-    return REACTION_NAME_MAP[unreactMatch[1].toLowerCase()] ?? null;
+  const match = /Reaction button state:\s*(.+)$/.exec(text);
+  const rest = match?.[1]?.trim();
+  if (!rest) return null;
+
+  // "no reactionLike" → not reacted
+  if (/^no reaction/i.test(rest)) return null;
+
+  // "InsightfulInsightful" → "Insightful" (perfect repetition of the
+  // state name).  Detect by checking whether the string is two halves of
+  // the same word.
+  const half = rest.slice(0, Math.floor(rest.length / 2));
+  if (half && rest === half + half) {
+    return REACTION_NAME_MAP[half.toLowerCase()] ?? null;
+  }
+
+  // Fallback: take the first word (covers single-rendered forms).
+  const wordMatch = /^([A-Za-z]+)/.exec(rest);
+  const word = wordMatch?.[1];
+  if (word) {
+    return REACTION_NAME_MAP[word.toLowerCase()] ?? null;
   }
 
   return null;
@@ -278,42 +316,38 @@ export async function reactToComment(
 
     const mouse = input.mouse;
 
-    // Wait for the comments section to render at least one comment.
-    // Without this anchor, looking up a specific `article[data-id="..."]`
-    // races the comments-section's lazy hydration: the post body lands
-    // first, comments arrive later as a JS-fetched batch.  Mirrors the
-    // pattern that `comment-on-post.ts` benefits from implicitly via
-    // `waitForElement(COMMENT_INPUT)` (its reply test runs after a
-    // top-level comment-on-post test that already triggered hydration).
-    await waitForElement(client, "article.comments-comment-entity", undefined, mouse);
+    // Normalize URN to React-stack format (legacy callers pass
+    // `urn:li:comment:(activity:N,M)`; the SDUI DOM uses
+    // `urn:li:comment:(urn:li:activity:N,M)`).  Use the normalized URN
+    // for all DOM lookups; preserve `input.commentUrn` for output / error
+    // messages so callers see what they passed in.
+    const normalizedUrn = normalizeCommentUrnForReactStack(input.commentUrn);
 
-    // Locate the target comment article — it may not be in the initial
-    // batch on a post with many comments (LinkedIn shows ~3-5 by default
-    // and paginates the rest behind a "Load more comments" button).
-    // Click the load-more button repeatedly until the specific URN is
+    // Wait for the comments section to render at least one comment.
+    // Without this anchor, looking up a specific componentkey races the
+    // comments-section's lazy hydration: the post body lands first,
+    // comments arrive later as a JS-fetched batch.  Mirrors the pattern
+    // that `comment-on-post.ts` benefits from implicitly via
+    // `waitForElement(COMMENT_INPUT)`.
+    await waitForElement(client, COMMENT_ARTICLE_ANY, undefined, mouse);
+
+    // Locate the target comment — it may not be in the initial batch on
+    // a post with many comments (LinkedIn shows ~3-5 by default and
+    // paginates the rest behind a "Load more comments" button).  Click
+    // the load-more button repeatedly until the specific URN is
     // reachable, or until no more load-more buttons remain.
-    // CSS attribute selectors with parentheses and colons in the value
-    // (e.g., `article[data-id="urn:li:comment:(activity:N,M)"]`) are
-    // technically valid CSS3, but the LinkedIn Electron webview has
-    // intermittent issues matching them via `querySelector`.  We use
-    // JS-side equality (`getAttribute('data-id') === target`) for
-    // presence checks and CSS-attribute scoping; the latter is fine
-    // for `:scope` searches inside the article once the element is
-    // found, but for *finding* the article we use a `data-comment-urn`
-    // marker stamped onto the element so subsequent scoped queries
-    // ride a clean attribute selector.
-    const articleSelector = `article[data-comment-urn="${input.commentUrn}"]`;
+    //
+    // The React/SDUI stack identifies each comment by
+    // `componentkey="replaceableComment_<URN>"` (three nested elements
+    // share the same value — the selector matches all three, which is
+    // fine for descendant queries).  See
+    // `research/linkedin/post-detail-comment-dom-react-sdui-20260506.md`
+    // and lhremote#776.
+    const articleSelector = commentArticleSelectorByUrn(normalizedUrn);
     let articleFound = false;
     for (let attempt = 0; attempt <= MAX_LOAD_MORE_ATTEMPTS; attempt++) {
       const isPresent = await client.evaluate<boolean>(`(() => {
-        const target = ${JSON.stringify(input.commentUrn)};
-        const article = Array.from(document.querySelectorAll('article[data-id]'))
-          .find(a => a.getAttribute('data-id') === target);
-        if (!article) return false;
-        // Stamp a marker so subsequent CSS attribute selectors can find it
-        // without depending on parens/colons being parsed correctly.
-        article.setAttribute('data-comment-urn', target);
-        return true;
+        return document.querySelector(${JSON.stringify(articleSelector)}) !== null;
       })()`);
       if (isPresent) {
         articleFound = true;
@@ -336,17 +370,18 @@ export async function reactToComment(
     await waitForElement(client, articleSelector, undefined, mouse);
     await humanizedScrollTo(client, articleSelector, mouse);
 
-    // Two distinct comment-scoped buttons (see selectors.ts):
-    //   - triggerSelector: state-bearing direct-Like button, used for
-    //     reading current reaction and unreacting an existing one.
-    //   - menuSelector:    popup-opening button, hovered/clicked to
-    //     expand the 6-reaction picker.
-    const triggerSelector = `${articleSelector} ${COMMENT_REACTION_TRIGGER}`;
+    // React/SDUI stack: the comment exposes ONE reaction-related button
+    // (the menu opener) and a state-display element.  The legacy
+    // "state-bearing direct-Like trigger" is gone — every reaction now
+    // goes through the popup, and switching reactions is a single click
+    // on the new reaction in the popup (LinkedIn auto-replaces the
+    // existing one).  See lhremote#776 and
+    // `research/linkedin/post-detail-comment-dom-react-sdui-20260506.md`.
     const menuSelector = `${articleSelector} ${COMMENT_REACTIONS_MENU}`;
-    await waitForElement(client, triggerSelector, undefined, mouse);
+    await waitForElement(client, menuSelector, undefined, mouse);
 
-    // Detect existing reaction state from the trigger's aria-label
-    const currentReaction = await detectCommentReaction(client, triggerSelector);
+    // Detect existing reaction state from the role="button" state element.
+    const currentReaction = await detectCommentReaction(client, articleSelector);
 
     if (currentReaction === reactionType) {
       // Already reacted with the requested type — no-op
@@ -362,44 +397,40 @@ export async function reactToComment(
       };
     }
 
-    if (!dryRun && currentReaction !== null) {
-      // Reacted with a different type — click the state-bearing trigger
-      // to unreact first.  Clicking the trigger when its aria-label is
-      // "Unreact {Type} to ..." toggles the existing reaction off.
-      await humanizedClick(client, triggerSelector, mouse);
-      // Wait for DOM to settle after unreacting — the trigger element's
-      // aria-label changes back to "React Like to ...".
+    // Apply / switch reaction.  In the React/SDUI stack the popup is
+    // CLICK-anchored on the menu button (verified via spike — hover
+    // alone does not open it; humanizedClick does).  But the popup is
+    // also fragile: humanizedClick on the popup button takes ~500ms
+    // (viewport scroll + multi-step humanized mouse motion + pre-hover
+    // pause), and the popup closes mid-motion before the click lands —
+    // observed as "Element button[aria-label=\"Like\"] not found for click".
+    //
+    // Workaround: open the menu via humanizedClick (fine — single click,
+    // mouse stays put), then dispatch the reaction via the lightweight
+    // synchronous JS click() helper (one CDP roundtrip, no mouse motion).
+    //
+    // The popup buttons are PAGE-LEVEL (not scoped to the comment) —
+    // clicking the menu re-positions the same shared popup anchored on
+    // the comment.  Selectors come from COMMENT_POPUP_REACTION_SELECTORS
+    // (bare aria-label="<Type>").
+    const popupReactionSelector = COMMENT_POPUP_REACTION_SELECTORS[reactionType];
+    await retryInteraction(async () => {
+      await humanizedClick(client, menuSelector, mouse);
+      await gaussianDelay(800, 200, 500, 1_500);
+      await waitForElement(client, popupReactionSelector, { timeout: 10_000 });
+    }, 3);
+
+    if (!dryRun) {
+      await click(client, popupReactionSelector);
+      await gaussianDelay(550, 75, 400, 700);
+      // After applying, give the DOM time to settle (the state element
+      // text updates to reflect the new reaction).
       await waitForDOMStable(client, 300);
-    }
-
-    // Apply the new reaction.
-    //
-    // For the "like" reaction specifically, the state-bearing direct-Like
-    // button (COMMENT_REACTION_TRIGGER) IS the apply mechanism — clicking
-    // it when in unreacted state applies a Like.  No popup needed.
-    //
-    // For the 5 non-Like reactions, we must open the reactions popup
-    // (COMMENT_REACTIONS_MENU) via a CLICK (not hover, unlike post-level)
-    // and then click the popup button.  Comment-level popup buttons have
-    // aria-labels "React {Type} to {Name}'s comment" — distinct from the
-    // post-level bare "React {Type}" / "{Type}" pattern.
-    if (reactionType === "like") {
-      if (!dryRun) {
-        await humanizedClick(client, triggerSelector, mouse);
-        await gaussianDelay(550, 75, 400, 700);
-      }
     } else {
-      const popupReactionSelector = COMMENT_POPUP_REACTION_SELECTORS[reactionType];
-      await retryInteraction(async () => {
-        await humanizedClick(client, menuSelector, mouse);
-        await gaussianDelay(800, 200, 500, 1_500);
-        await waitForElement(client, popupReactionSelector, { timeout: 10_000 });
-      }, 3);
-
-      if (!dryRun) {
-        await humanizedClick(client, popupReactionSelector, mouse);
-        await gaussianDelay(550, 75, 400, 700);
-      }
+      // Dry-run: dismiss the popup we just opened so we leave the page
+      // visually clean.
+      await client.send("Input.dispatchKeyEvent", { type: "keyDown", key: "Escape", code: "Escape", windowsVirtualKeyCode: 27 });
+      await client.send("Input.dispatchKeyEvent", { type: "keyUp", key: "Escape", code: "Escape", windowsVirtualKeyCode: 27 });
     }
 
     await gaussianDelay(1_500, 500, 700, 3_500); // Post-action dwell

--- a/packages/e2e/src/comment-dom-spike.e2e.test.ts
+++ b/packages/e2e/src/comment-dom-spike.e2e.test.ts
@@ -1,0 +1,548 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+/**
+ * Spike: comment-DOM regression probe (#776)
+ *
+ * Probes the LinkedIn post detail page DOM to discover the new selector
+ * shape for comment articles after the regression observed in LH 2.113.61
+ * E2E runs (`Timed out waiting for element "article.comments-comment-entity"`
+ * and `article[data-id="urn:li:comment:..."]`).
+ *
+ * The historical contract (research/linkedin/post-detail-comment-dom-20260409.md)
+ * was:
+ *   <article class="comments-comment-entity"
+ *            data-id="urn:li:comment:(activity:<postId>,<commentId>)">
+ *
+ * This spike navigates to the test post URL and enumerates plausible new
+ * shapes:
+ *   - Any `article` element on the page (count + class + data-id sample)
+ *   - Elements with `data-id` containing `urn:li:comment` (any tag)
+ *   - Elements with class names containing `comment` (sample classes)
+ *   - Specific selector existence checks
+ *
+ * Output is logged as JSON; the spike intentionally has no hard
+ * assertions on selector content — it documents reality.
+ */
+
+import { afterAll, beforeAll, expect, it } from "vitest";
+import {
+  describeE2E,
+  forceStopInstance,
+  getE2EPostUrl,
+  launchApp,
+  quitApp,
+  resolveAccountId,
+  retryAsync,
+} from "@lhremote/core/testing";
+import {
+  type AppService,
+  CDPClient,
+  delay,
+  discoverInstancePort,
+  discoverTargets,
+  LauncherService,
+  startInstanceWithRecovery,
+} from "@lhremote/core";
+
+/** Navigate the LinkedIn target and wait for the load event. */
+async function navigateAndWait(client: CDPClient, url: string): Promise<void> {
+  await client.send("Page.enable");
+  try {
+    const loadPromise = client.waitForEvent("Page.loadEventFired", 30_000);
+    await client.navigate(url);
+    await loadPromise;
+  } finally {
+    await client.send("Page.disable").catch(() => {});
+  }
+}
+
+interface ProbeResult {
+  /** Total `<article>` elements on the page. */
+  totalArticles: number;
+  /** Up to 5 article snapshots with class + data-id + first 200 chars. */
+  articleSamples: Array<{
+    className: string;
+    dataId: string | null;
+    role: string | null;
+    htmlPreview: string;
+  }>;
+  /** Tags found with `data-id` containing `urn:li:comment`. */
+  commentDataIdElements: Array<{
+    tag: string;
+    className: string;
+    dataId: string;
+    role: string | null;
+  }>;
+  /** Tags found with class names containing the substring "comment". */
+  classNameContainsComment: Array<{
+    tag: string;
+    className: string;
+  }>;
+  /** Existence checks for the selectors lhremote relies on. */
+  selectorChecks: Record<string, number>;
+}
+
+describeE2E("comment-dom regression probe (#776)", () => {
+  let app: AppService;
+  let port: number;
+  let accountId: number;
+  let client: CDPClient;
+  let postUrl: string;
+
+  beforeAll(async () => {
+    postUrl = getE2EPostUrl();
+
+    const launched = await launchApp();
+    app = launched.app;
+    port = launched.port;
+
+    accountId = await resolveAccountId(port);
+
+    const launcher = new LauncherService(port);
+    await retryAsync(() => launcher.connect(), { retries: 3, delay: 1_000 });
+    await startInstanceWithRecovery(launcher, accountId, port);
+    launcher.disconnect();
+
+    const instancePort = await retryAsync(
+      async () => {
+        const p = await discoverInstancePort(port);
+        if (p === null) throw new Error("Instance CDP port not discovered yet");
+        return p;
+      },
+      { retries: 10, delay: 2_000 },
+    );
+
+    const liTarget = await retryAsync(
+      async () => {
+        const t = await discoverTargets(instancePort);
+        const li = t.find(
+          (tgt) => tgt.type === "page" && tgt.url?.includes("linkedin.com"),
+        );
+        if (!li) throw new Error("LinkedIn target not found yet");
+        return li;
+      },
+      { retries: 30, delay: 2_000 },
+    );
+
+    client = new CDPClient(instancePort);
+    await client.connect(liTarget.id);
+
+    await navigateAndWait(client, postUrl);
+    // Comments section is lazy-hydrated: wait long enough for it to mount.
+    await delay(15_000);
+  }, 180_000);
+
+  afterAll(async () => {
+    client?.disconnect();
+
+    const launcher = new LauncherService(port);
+    try {
+      await launcher.connect();
+      await forceStopInstance(launcher, accountId, port);
+    } catch {
+      // Best-effort cleanup
+    } finally {
+      launcher.disconnect();
+    }
+
+    await quitApp(app);
+  }, 60_000);
+
+  it("dumps article + comment DOM shape (#776)", async () => {
+    // Page-state probe: verify we actually navigated where we think we did,
+    // not into a login wall / interstitial.
+    const pageState = await client.evaluate<{
+      url: string;
+      title: string;
+      bodyChildCount: number;
+      bodyChildTags: string[];
+      hasLoginForm: boolean;
+      hasMain: boolean;
+      mainChildren: number;
+    }>(`(() => {
+      const body = document.body;
+      const childTags = Array.from(body.children).map(c => c.tagName + (c.id ? '#' + c.id : ''));
+      return {
+        url: location.href,
+        title: document.title,
+        bodyChildCount: body.children.length,
+        bodyChildTags: childTags.slice(0, 30),
+        hasLoginForm: !!document.querySelector('form[action*="login"], input[name="session_password"]'),
+        hasMain: !!document.querySelector('main'),
+        mainChildren: document.querySelector('main')?.children.length ?? 0,
+      };
+    })()`);
+    console.log("\n[#776] === page state ===\n" + JSON.stringify(pageState, null, 2));
+
+    const result = await client.evaluate<ProbeResult>(`(() => {
+      const allArticles = Array.from(document.querySelectorAll('article'));
+      const articleSamples = allArticles.slice(0, 5).map(el => ({
+        className: el.className || '',
+        dataId: el.getAttribute('data-id'),
+        role: el.getAttribute('role'),
+        htmlPreview: (el.outerHTML || '').slice(0, 200),
+      }));
+
+      const commentDataIdElements = Array
+        .from(document.querySelectorAll('[data-id]'))
+        .filter(el => {
+          const v = el.getAttribute('data-id') || '';
+          return v.indexOf('urn:li:comment') !== -1;
+        })
+        .slice(0, 10)
+        .map(el => ({
+          tag: el.tagName,
+          className: el.className || '',
+          dataId: el.getAttribute('data-id') || '',
+          role: el.getAttribute('role'),
+        }));
+
+      const classNameContainsComment = Array
+        .from(document.querySelectorAll('[class*="comment"]'))
+        .filter(el => {
+          const cls = el.className || '';
+          return /comment(s|-)/i.test(cls);
+        })
+        .slice(0, 30)
+        .map(el => ({ tag: el.tagName, className: el.className || '' }));
+
+      const selectorChecks = {
+        'article.comments-comment-entity':
+          document.querySelectorAll('article.comments-comment-entity').length,
+        'article[data-id^="urn:li:comment:"]':
+          document.querySelectorAll('article[data-id^="urn:li:comment:"]').length,
+        'article[data-id*="urn:li:comment"]':
+          document.querySelectorAll('article[data-id*="urn:li:comment"]').length,
+        '[data-id^="urn:li:comment:"]':
+          document.querySelectorAll('[data-id^="urn:li:comment:"]').length,
+        '[data-urn^="urn:li:comment"]':
+          document.querySelectorAll('[data-urn^="urn:li:comment"]').length,
+        'article[class*="comments-comment"]':
+          document.querySelectorAll('article[class*="comments-comment"]').length,
+        '[class*="comments-comment-entity"]':
+          document.querySelectorAll('[class*="comments-comment-entity"]').length,
+        'div[data-id*="urn:li:comment"]':
+          document.querySelectorAll('div[data-id*="urn:li:comment"]').length,
+        '.comments-comments-list':
+          document.querySelectorAll('.comments-comments-list').length,
+        '.feed-shared-update-v2':
+          document.querySelectorAll('.feed-shared-update-v2').length,
+        '[data-id*="urn:li:fsd_comment"]':
+          document.querySelectorAll('[data-id*="urn:li:fsd_comment"]').length,
+        'div[class*="UpdateV2"]':
+          document.querySelectorAll('div[class*="UpdateV2"]').length,
+        'div[class*="commentary"]':
+          document.querySelectorAll('div[class*="commentary"]').length,
+      };
+
+      return {
+        totalArticles: allArticles.length,
+        articleSamples,
+        commentDataIdElements,
+        classNameContainsComment,
+        selectorChecks,
+      };
+    })()`);
+
+    console.log("\n[#776] === post-detail comment-DOM probe ===\n" + JSON.stringify(result, null, 2));
+
+    // If we got 0 articles, dump more info: maybe LH webview redirected
+    // somewhere, page is empty, or we're behind a guard.  Log without failing
+    // so the diagnostic block is preserved when the spike is iterated.
+    if (result.totalArticles === 0) {
+      const broader = await client.evaluate<unknown>(`(() => ({
+        // First 2000 chars of body innerHTML so we can eyeball the page.
+        bodyHtmlSample: (document.body.innerHTML || '').slice(0, 2000),
+        // Anything resembling a comment URN anywhere in markup.
+        urnSample: ((document.body.innerHTML || '').match(/urn:li:[a-z_]+:[^\\s"'<>]{0,80}/g) || []).slice(0, 10),
+        // Distinct top-level data-* attributes we see.
+        dataAttrs: (() => {
+          const seen = new Set();
+          for (const el of document.querySelectorAll('*')) {
+            for (const a of el.attributes) {
+              if (a.name.startsWith('data-')) seen.add(a.name);
+              if (seen.size > 80) break;
+            }
+            if (seen.size > 80) break;
+          }
+          return Array.from(seen).slice(0, 80);
+        })(),
+      }))()`);
+      console.log("\n[#776] === broad page probe (zero-article fallback) ===\n" + JSON.stringify(broader, null, 2));
+    }
+
+    // Targeted hunt for comment containers: walk every element that has any
+    // attribute or attribute name containing a comment URN substring, and
+    // record the host element's tag + a sample of its attributes.  Then walk
+    // up 3 levels to identify likely outer "comment article" containers
+    // (often the parent that holds the whole comment block).
+    const commentHunt = await client.evaluate<unknown>(`(() => {
+      function collectAttrs(el) {
+        const out = {};
+        for (const a of el.attributes) out[a.name] = a.value.slice(0, 120);
+        return out;
+      }
+      function ancestorChain(el, depth) {
+        const chain = [];
+        let cur = el;
+        for (let i = 0; i <= depth && cur; i++) {
+          chain.push({
+            tag: cur.tagName,
+            id: cur.id || null,
+            classNames: (cur.className || '').toString().slice(0, 200),
+            dataComponentType: cur.getAttribute && cur.getAttribute('data-component-type'),
+            dataTestId: cur.getAttribute && cur.getAttribute('data-testid'),
+            dataExpanded: cur.getAttribute && cur.getAttribute('data-expanded'),
+          });
+          cur = cur.parentElement;
+        }
+        return chain;
+      }
+
+      // 1. Elements where ANY attribute value contains a comment URN.
+      const urnHosts = [];
+      const seen = new WeakSet();
+      for (const el of document.querySelectorAll('*')) {
+        if (urnHosts.length >= 8) break;
+        if (seen.has(el)) continue;
+        for (const a of el.attributes) {
+          if (a.value && a.value.indexOf('urn:li:comment') !== -1) {
+            seen.add(el);
+            urnHosts.push({
+              attr: a.name,
+              attrValuePreview: a.value.slice(0, 150),
+              tag: el.tagName,
+              classNames: (el.className || '').toString().slice(0, 200),
+              ancestorChain: ancestorChain(el, 5),
+            });
+            break;
+          }
+        }
+      }
+
+      // 2. Elements whose id is or starts with a comment URN.
+      const idHosts = Array.from(document.querySelectorAll('[id]'))
+        .filter(el => el.id.indexOf('urn:li:comment') !== -1)
+        .slice(0, 5)
+        .map(el => ({ tag: el.tagName, id: el.id, classNames: (el.className || '').toString().slice(0, 200) }));
+
+      // 3. Look at <main> and its descendants for the most-likely comment region.
+      const main = document.querySelector('main');
+      const mainChildSummary = main
+        ? Array.from(main.children).slice(0, 5).map(c => ({
+            tag: c.tagName,
+            classNames: (c.className || '').toString().slice(0, 200),
+            childCount: c.children.length,
+            dataComponentType: c.getAttribute('data-component-type'),
+          }))
+        : null;
+
+      // 4. Count the SDUI-shaped elements — new React stack uses these.
+      const sduiCounts = {
+        '[data-component-type]': document.querySelectorAll('[data-component-type]').length,
+        '[data-sdui-screen]': document.querySelectorAll('[data-sdui-screen]').length,
+        '[data-testid]': document.querySelectorAll('[data-testid]').length,
+        '[data-expanded]': document.querySelectorAll('[data-expanded]').length,
+        '[data-display-contents]': document.querySelectorAll('[data-display-contents]').length,
+      };
+
+      // 5. Distinct data-component-type values observed.
+      const componentTypes = (() => {
+        const set = new Set();
+        for (const el of document.querySelectorAll('[data-component-type]')) {
+          set.add(el.getAttribute('data-component-type'));
+          if (set.size > 40) break;
+        }
+        return Array.from(set);
+      })();
+
+      // 6. Distinct data-testid values that hint at comments.
+      const commentTestIds = (() => {
+        const set = new Set();
+        for (const el of document.querySelectorAll('[data-testid]')) {
+          const v = el.getAttribute('data-testid') || '';
+          if (/comment|reply/i.test(v)) set.add(v);
+          if (set.size > 30) break;
+        }
+        return Array.from(set);
+      })();
+
+      return {
+        urnHosts,
+        idHosts,
+        mainChildSummary,
+        sduiCounts,
+        componentTypes,
+        commentTestIds,
+      };
+    })()`);
+    console.log("\n[#776] === comment hunt ===\n" + JSON.stringify(commentHunt, null, 2));
+
+    // Inner-button probe: pick the first visible comment article (by
+    // componentkey), enumerate every <button> inside it, and dump the
+    // shape — tag, classNames, aria-label, type.  Goal: discover the
+    // new aria-label patterns for the comment's Reply / React Like /
+    // reactions menu buttons, since the legacy `aria-label^="Reply to "`
+    // and `aria-label^="React Like to "` selectors timeout against the
+    // SDUI comment DOM (lhremote#776 follow-up).
+    const buttonHunt = await client.evaluate<unknown>(`(() => {
+      // Pick the OUTERMOST componentkey wrapper for the first comment.
+      // Multiple nested elements share the same componentkey value;
+      // querySelectorAll returns them in document order (outermost first
+      // by structural position, but several inner wrappers also share
+      // the key — there is no positional guarantee that any single index
+      // is the outer one).  Use a max-descendants heuristic: the outer
+      // wrapper contains the most descendant elements.
+      const all = Array.from(document.querySelectorAll('[componentkey^="replaceableComment_"]'));
+      if (all.length === 0) return { error: 'no comment articles found' };
+
+      let outer = all[0];
+      let maxDescendants = outer.querySelectorAll('*').length;
+      for (const el of all) {
+        const n = el.querySelectorAll('*').length;
+        if (n > maxDescendants) {
+          outer = el;
+          maxDescendants = n;
+        }
+      }
+
+      const componentkey = outer.getAttribute('componentkey');
+
+      // Enumerate ALL buttons under this comment.
+      const buttons = Array.from(outer.querySelectorAll('button')).map(b => ({
+        tag: b.tagName,
+        type: b.getAttribute('type'),
+        ariaLabel: b.getAttribute('aria-label'),
+        ariaPressed: b.getAttribute('aria-pressed'),
+        ariaExpanded: b.getAttribute('aria-expanded'),
+        textContentTrimmed: (b.textContent || '').trim().slice(0, 60),
+        dataTestId: b.getAttribute('data-testid'),
+        classNamesPreview: (b.className || '').toString().slice(0, 80),
+      }));
+
+      // Also enumerate elements with role="button" that aren't <button>.
+      const roleButtons = Array.from(outer.querySelectorAll('[role="button"]'))
+        .filter(b => b.tagName !== 'BUTTON')
+        .map(b => ({
+          tag: b.tagName,
+          ariaLabel: b.getAttribute('aria-label'),
+          textContentTrimmed: (b.textContent || '').trim().slice(0, 60),
+          classNamesPreview: (b.className || '').toString().slice(0, 80),
+        }));
+
+      // Image/svg elements with aria-label or alt for action icons.
+      const labeledIcons = Array.from(outer.querySelectorAll('[aria-label]'))
+        .filter(el => el.tagName !== 'BUTTON' && el.getAttribute('role') !== 'button')
+        .slice(0, 10)
+        .map(el => ({
+          tag: el.tagName,
+          ariaLabel: el.getAttribute('aria-label'),
+          textContentTrimmed: (el.textContent || '').trim().slice(0, 60),
+        }));
+
+      return {
+        commentKey: componentkey,
+        descendantCount: maxDescendants,
+        buttonCount: buttons.length,
+        buttons: buttons.slice(0, 30),
+        roleButtonCount: roleButtons.length,
+        roleButtons: roleButtons.slice(0, 10),
+        labeledIcons,
+      };
+    })()`);
+    console.log("\n[#776] === inner-button hunt ===\n" + JSON.stringify(buttonHunt, null, 2));
+
+    // Reactions popup probe: click "Open reactions menu" on the first
+    // visible comment, dump the popup buttons, then press Escape to
+    // close.  Read-only with respect to the comment's reaction state —
+    // the popup must be opened to inspect, but Escape dismisses it
+    // without applying any reaction.
+    // First, confirm by hover (not click) — post-level react-to-post.ts
+    // uses humanizedHover to open the menu.  After hovering, scan the
+    // entire page for buttons with aria-label "Like" / "React Like" /
+    // "Celebrate" / etc. — these are the post-level popup buttons that
+    // the comment menu likely shares.
+    const reactionPopupProbe = await client.evaluate<unknown>(`(async () => {
+      const all = Array.from(document.querySelectorAll('[componentkey^="replaceableComment_"]'));
+      let outer = all[0];
+      let max = outer ? outer.querySelectorAll('*').length : 0;
+      for (const el of all) {
+        const n = el.querySelectorAll('*').length;
+        if (n > max) { outer = el; max = n; }
+      }
+      if (!outer) return { error: 'no comment found' };
+
+      const menuBtn = outer.querySelector('button[aria-label="Open reactions menu"]');
+      if (!menuBtn) return { error: 'no reactions menu button found in comment' };
+
+      const REACTION_NAMES = ['Like', 'Celebrate', 'Support', 'Love', 'Insightful', 'Funny'];
+      function findReactionButtons() {
+        return REACTION_NAMES.map(name => {
+          // Try multiple selectors per name and pick the first visible.
+          const selectors = [
+            'button[aria-label="' + name + '"]',
+            'button[aria-label="React ' + name + '"]',
+            'button[aria-label^="React ' + name + ' "]',
+            'button[aria-label^="' + name + ' "]',
+          ];
+          for (const sel of selectors) {
+            const els = document.querySelectorAll(sel);
+            for (const el of els) {
+              const r = el.getBoundingClientRect();
+              if (r.width > 0 && r.height > 0) {
+                return { name, selector: sel, ariaLabel: el.getAttribute('aria-label'), w: r.width, h: r.height };
+              }
+            }
+          }
+          return { name, selector: null };
+        });
+      }
+
+      const before = findReactionButtons();
+
+      // Try CLICK first.
+      menuBtn.click();
+      await new Promise(r => setTimeout(r, 800));
+      const afterClick = findReactionButtons();
+
+      // Try simulated mouse events for HOVER (move into the menu button).
+      const r = menuBtn.getBoundingClientRect();
+      const x = r.left + r.width / 2;
+      const y = r.top + r.height / 2;
+      menuBtn.dispatchEvent(new MouseEvent('mouseover', { bubbles: true, clientX: x, clientY: y }));
+      menuBtn.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true, clientX: x, clientY: y }));
+      menuBtn.dispatchEvent(new PointerEvent('pointerover', { bubbles: true, clientX: x, clientY: y }));
+      menuBtn.dispatchEvent(new PointerEvent('pointerenter', { bubbles: true, clientX: x, clientY: y }));
+      await new Promise(res => setTimeout(res, 1500));
+      const afterHover = findReactionButtons();
+
+      // Press Escape to close any popup.
+      document.body.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, keyCode: 27 }));
+      await new Promise(res => setTimeout(res, 500));
+
+      // Also scan the role="button" reaction-state element near this comment
+      // — see if clicking IT might work as an alternative entry point.
+      const stateEls = Array.from(outer.querySelectorAll('[role="button"]'))
+        .filter(el => /Reaction button state/.test(el.textContent || ''))
+        .map(el => ({
+          tag: el.tagName,
+          textPreview: (el.textContent || '').slice(0, 60),
+          ariaLabel: el.getAttribute('aria-label'),
+          ariaPressed: el.getAttribute('aria-pressed'),
+        }));
+
+      return {
+        before,
+        afterClick,
+        afterHover,
+        stateEls,
+      };
+    })()`, true);
+    console.log("\n[#776] === reactions popup probe ===\n" + JSON.stringify(reactionPopupProbe, null, 2));
+
+    // Soft assertion: don't fail the spike on the zero-articles case;
+    // the diagnostic logs above are the deliverable.
+    expect(typeof result.selectorChecks).toBe("object");
+  }, 90_000);
+});


### PR DESCRIPTION
## Summary

LinkedIn migrated the post-detail page (`/posts/...`) off the legacy Ember/BEM stack to a React + CSS Modules + SDUI rewrite (live by 2026-05-06). The legacy DOM contract that `react-to-comment` and `comment-on-post` (reply path) relied on no longer exists.

## Old contract → new contract

| Concern | Legacy (Ember/BEM) | React/SDUI (now) |
|---------|--------------------|------------------|
| Comment container | `<article class="comments-comment-entity" data-id="urn:li:comment:(...)">` | `<div componentkey="replaceableComment_<URN>">` (3 nested elements share the key) |
| List wrapper | `.comments-comments-list` | `<div data-component-type="LazyColumn" data-testid="...commentList...FeedType_FEED_DETAIL">` |
| URN format | `urn:li:comment:(activity:N,M)` | `urn:li:comment:(urn:li:activity:N,M)` |
| Direct Like trigger | `button[aria-label^="React Like to "]` | **gone** — every reaction goes through the popup |
| Reactions menu | `button[aria-label="Open reactions menu"]` | same ✓ |
| Reply button | `button[aria-label^="Reply to "]` | **no aria-label** — `textContent === "Reply"` |
| Reaction state | trigger button's `aria-label` (e.g., `"Unreact Like"`) | `<div role="button">` `textContent === "Reaction button state: <X><X>"` |
| Popup reaction buttons | `button[aria-label^="React Like to "]` | bare `button[aria-label="Like"]` (same as post-level) |

## Changes

### `linkedin/selectors.ts`

- New `COMMENT_ARTICLE_ANY = '[componentkey^="replaceableComment_"]'` — anchor for "comments hydrated".
- New `commentArticleSelectorByUrn(urn)` builder.
- New `normalizeCommentUrnForReactStack(urn)` — accepts both URN forms, converts legacy → SDUI for DOM lookups (idempotent for new format).

### `operations/react-to-comment.ts`

- Drops the direct-Like trigger code path entirely. Every reaction (incl. Like) now: (1) clicks the menu opener, (2) waits for the popup, (3) clicks the target reaction.
- Switching between reactions is a single click on the new reaction in the popup (LinkedIn auto-replaces).
- Replaces aria-label-based state detection with a `textContent` parser on the `role="button"` state element (handles the doubled-word form `"InsightfulInsightful"` → `Insightful`, and `"no reactionLike"` → `null`).
- Updates `COMMENT_POPUP_REACTION_SELECTORS` to use bare aria-labels (`"Like"`, `"Celebrate"`, etc.) — same selectors `react-to-post` already uses, since the comment menu opens the shared popup.
- Dry-run path now opens the menu (validates the popup machinery), presses `Escape` to dismiss, and skips the reaction click.

### `operations/comment-on-post.ts` (reply path)

- Switches the comment-article selector from `article[data-id="..."]` to `componentkey`-scoped, with URN normalization.
- Locates the Reply button by stamping a `data-lhremote-reply` marker via `Runtime.evaluate` (`textContent === "Reply"`), then waits/clicks the marker selector — falls back to the legacy aria-label form.
- Relaxes `COMMENT_URN_RE` to accept both URN formats: `/^urn:li:comment:\((?:urn:li:)?\w+:\d+,\d+\)$/`.

### `e2e/src/comment-dom-spike.e2e.test.ts` (new)

Permanent regression-detector that probes article/componentkey shape, reactions popup contents, and inner-button structure. Logs structured JSON for each section. Re-run with:

```bash
pnpm --filter @lhremote/e2e test:e2e:file comment-dom-spike
```

## Test plan

- [x] `pnpm lint` — clean
- [x] `pnpm test` — all unit tests pass (1675 total, 47 in react-to-comment + comment-on-post)
- [ ] `pnpm --filter @lhremote/e2e test:e2e:file engagement` — verify post-DOM-rewrite E2E (CI doesn't run E2E; verify locally before merge)
- [ ] CI green

## Discovery

Full DOM contract + spike output: `research/linkedin/post-detail-comment-dom-react-sdui-20260506.md` (companion PR in `lhremote/research`). Supersedes `post-detail-comment-dom-20260409.md`.

## Dependencies

Independent of #777 (LH 2.113.61 mws.call regression) — both branched from main.

Closes #776

🤖 Generated with [Claude Code](https://claude.com/claude-code)