### PR TITLE
(fix) ci: pass LHREMOTE_E2E_PROFILE_URL and COMPANY_URL through turbo

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -11,7 +11,13 @@
     },
     "test:e2e": {
       "dependsOn": ["build", "^test:e2e"],
-      "passThroughEnv": ["LHREMOTE_E2E_PERSON_ID", "LHREMOTE_E2E_POST_URL", "LHREMOTE_E2E_COMMENT_URN"],
+      "passThroughEnv": [
+        "LHREMOTE_E2E_PERSON_ID",
+        "LHREMOTE_E2E_POST_URL",
+        "LHREMOTE_E2E_COMMENT_URN",
+        "LHREMOTE_E2E_PROFILE_URL",
+        "LHREMOTE_E2E_COMPANY_URL"
+      ],
       "cache": false
     },
     "lint": {


### PR DESCRIPTION
## Summary

- Add `LHREMOTE_E2E_PROFILE_URL` and `LHREMOTE_E2E_COMPANY_URL` to `turbo.json` `passThroughEnv` for the `test:e2e` task.
- Without them, turbo strips both vars before each package's `vitest run`, even when they are exported in the calling shell.

Three E2E tests (`unfollow-profile` dryRun ×2 and `hide-feed-author-profile` dryRun) were failing with `*_URL must be set` despite the env being set — this fixes them. Audit via `grep "process.env.LHREMOTE_E2E_"` confirms the 5-var inventory matches `e2e-helpers.ts`. `LHREMOTE_CAPTURE_DIAGNOSTICS` is set inside `vitest.e2e.config.ts` and does not need passthrough.

Closes #779

## Test plan
- [x] Identified root cause via `grep` of `process.env.LHREMOTE_E2E_*` consumers
- [x] Identified mismatch with `turbo.json` `passThroughEnv`
- [ ] After merge: re-run the three previously-failing tests with vars exported and confirm they pass