### PR TITLE
(feat) core: add waitForLoggedInState gate and IncorrectContentStateError retry

### DIFF
--- a/packages/cli/src/handlers/collect-people.ts
+++ b/packages/cli/src/handlers/collect-people.ts
@@ -6,6 +6,7 @@ import {
   CollectionError,
   collectPeople,
   errorMessage,
+  withLoggedInStateRetryAtPort,
 } from "@lhremote/core";
 
 /** Handle the {@link https://github.com/alexey-pelykh/lhremote#collect-people | collect-people} CLI command. */
@@ -24,7 +25,12 @@ export async function handleCollectPeople(
   },
 ): Promise<void> {
   try {
-    const result = await collectPeople({
+    const result = await withLoggedInStateRetryAtPort(
+      options.cdpPort,
+      options.cdpHost ?? "127.0.0.1",
+      options.allowRemote ?? false,
+      () =>
+        collectPeople({
       campaignId,
       sourceUrl,
       ...(options.limit !== undefined && { limit: options.limit }),
@@ -34,7 +40,8 @@ export async function handleCollectPeople(
       cdpPort: options.cdpPort,
       ...(options.cdpHost !== undefined && { cdpHost: options.cdpHost }),
       ...(options.allowRemote !== undefined && { allowRemote: options.allowRemote }),
-    });
+      }),
+    );
 
     if (options.json) {
       process.stdout.write(JSON.stringify(result, null, 2) + "\n");

--- a/packages/cli/src/handlers/comment-on-post.ts
+++ b/packages/cli/src/handlers/comment-on-post.ts
@@ -7,6 +7,7 @@ import {
   commentOnPost,
   type CommentOnPostOutput,
   type MentionEntry,
+  withLoggedInStateRetryAtPort,
 } from "@lhremote/core";
 
 /** Handle the {@link https://github.com/alexey-pelykh/lhremote#comment-on-post | comment-on-post} CLI command. */
@@ -63,7 +64,12 @@ export async function handleCommentOnPost(options: {
 
   let result: CommentOnPostOutput;
   try {
-    result = await commentOnPost({
+    result = await withLoggedInStateRetryAtPort(
+      options.cdpPort,
+      options.cdpHost ?? "127.0.0.1",
+      options.allowRemote ?? false,
+      () =>
+        commentOnPost({
       postUrl: options.url,
       text: options.text,
       parentCommentUrn: options.parentCommentUrn,
@@ -73,7 +79,8 @@ export async function handleCommentOnPost(options: {
       allowRemote: options.allowRemote,
       accountId: options.accountId,
       dryRun: options.dryRun,
-    });
+      }),
+    );
   } catch (error) {
     if (error instanceof BudgetExceededError) {
       process.stderr.write(`${error.message}\n`);

--- a/packages/cli/src/handlers/dismiss-feed-post.ts
+++ b/packages/cli/src/handlers/dismiss-feed-post.ts
@@ -5,6 +5,7 @@ import {
   errorMessage,
   dismissFeedPost,
   type DismissFeedPostOutput,
+  withLoggedInStateRetryAtPort,
 } from "@lhremote/core";
 
 /** Handle the {@link https://github.com/alexey-pelykh/lhremote#dismiss-feed-post | dismiss-feed-post} CLI command. */
@@ -20,13 +21,19 @@ export async function handleDismissFeedPost(
 ): Promise<void> {
   let result: DismissFeedPostOutput;
   try {
-    result = await dismissFeedPost({
+    result = await withLoggedInStateRetryAtPort(
+      options.cdpPort,
+      options.cdpHost ?? "127.0.0.1",
+      options.allowRemote ?? false,
+      () =>
+        dismissFeedPost({
       feedIndex,
       cdpPort: options.cdpPort,
       cdpHost: options.cdpHost,
       allowRemote: options.allowRemote,
       dryRun: options.dryRun,
-    });
+      }),
+    );
   } catch (error) {
     const message = errorMessage(error);
     process.stderr.write(`${message}\n`);

--- a/packages/cli/src/handlers/endorse-skills.ts
+++ b/packages/cli/src/handlers/endorse-skills.ts
@@ -7,6 +7,7 @@ import {
   type EphemeralActionResult,
   CampaignExecutionError,
   CampaignTimeoutError,
+  withLoggedInStateRetryAtPort,
 } from "@lhremote/core";
 
 /** Handle the {@link https://github.com/alexey-pelykh/lhremote#endorse-skills | endorse-skills} CLI command. */
@@ -34,7 +35,12 @@ export async function handleEndorseSkills(options: {
 
   let result: EphemeralActionResult;
   try {
-    result = await endorseSkills({
+    result = await withLoggedInStateRetryAtPort(
+      options.cdpPort,
+      options.cdpHost ?? "127.0.0.1",
+      options.allowRemote ?? false,
+      () =>
+        endorseSkills({
       personId: options.personId,
       url: options.url,
       skillNames: options.skillNames,
@@ -46,7 +52,8 @@ export async function handleEndorseSkills(options: {
       cdpHost: options.cdpHost,
       allowRemote: options.allowRemote,
       accountId: options.accountId,
-    });
+      }),
+    );
   } catch (error) {
     if (error instanceof CampaignExecutionError || error instanceof CampaignTimeoutError) {
       process.stderr.write(`${error.message}\n`);

--- a/packages/cli/src/handlers/follow-person.ts
+++ b/packages/cli/src/handlers/follow-person.ts
@@ -7,6 +7,7 @@ import {
   type EphemeralActionResult,
   CampaignExecutionError,
   CampaignTimeoutError,
+  withLoggedInStateRetryAtPort,
 } from "@lhremote/core";
 
 /** Handle the {@link https://github.com/alexey-pelykh/lhremote#follow-person | follow-person} CLI command. */
@@ -34,7 +35,12 @@ export async function handleFollowPerson(options: {
 
   let result: EphemeralActionResult;
   try {
-    result = await followPerson({
+    result = await withLoggedInStateRetryAtPort(
+      options.cdpPort,
+      options.cdpHost ?? "127.0.0.1",
+      options.allowRemote ?? false,
+      () =>
+        followPerson({
       personId: options.personId,
       url: options.url,
       mode: options.mode,
@@ -45,7 +51,8 @@ export async function handleFollowPerson(options: {
       cdpHost: options.cdpHost,
       allowRemote: options.allowRemote,
       accountId: options.accountId,
-    });
+      }),
+    );
   } catch (error) {
     if (error instanceof CampaignExecutionError || error instanceof CampaignTimeoutError) {
       process.stderr.write(`${error.message}\n`);

--- a/packages/cli/src/handlers/get-feed.ts
+++ b/packages/cli/src/handlers/get-feed.ts
@@ -5,6 +5,7 @@ import {
   errorMessage,
   getFeed,
   type GetFeedOutput,
+  withLoggedInStateRetryAtPort,
 } from "@lhremote/core";
 
 /** Handle the {@link https://github.com/alexey-pelykh/lhremote#get-feed | get-feed} CLI command. */
@@ -20,13 +21,19 @@ export async function handleGetFeed(
 ): Promise<void> {
   let result: GetFeedOutput;
   try {
-    result = await getFeed({
+    result = await withLoggedInStateRetryAtPort(
+      options.cdpPort,
+      options.cdpHost ?? "127.0.0.1",
+      options.allowRemote ?? false,
+      () =>
+        getFeed({
       count: options.count,
       cursor: options.cursor,
       cdpPort: options.cdpPort,
       cdpHost: options.cdpHost,
       allowRemote: options.allowRemote,
-    });
+      }),
+    );
   } catch (error) {
     const message = errorMessage(error);
     process.stderr.write(`${message}\n`);

--- a/packages/cli/src/handlers/hide-feed-author-profile.ts
+++ b/packages/cli/src/handlers/hide-feed-author-profile.ts
@@ -5,6 +5,7 @@ import {
   errorMessage,
   hideFeedAuthorProfile,
   type HideFeedAuthorProfileOutput,
+  withLoggedInStateRetryAtPort,
 } from "@lhremote/core";
 
 /** Handle the {@link https://github.com/alexey-pelykh/lhremote#hide-feed-author-profile | hide-feed-author-profile} CLI command. */
@@ -20,13 +21,19 @@ export async function handleHideFeedAuthorProfile(
 ): Promise<void> {
   let result: HideFeedAuthorProfileOutput;
   try {
-    result = await hideFeedAuthorProfile({
+    result = await withLoggedInStateRetryAtPort(
+      options.cdpPort,
+      options.cdpHost ?? "127.0.0.1",
+      options.allowRemote ?? false,
+      () =>
+        hideFeedAuthorProfile({
       profileUrl,
       cdpPort: options.cdpPort,
       cdpHost: options.cdpHost,
       allowRemote: options.allowRemote,
       dryRun: options.dryRun,
-    });
+      }),
+    );
   } catch (error) {
     const message = errorMessage(error);
     process.stderr.write(`${message}\n`);

--- a/packages/cli/src/handlers/hide-feed-author.ts
+++ b/packages/cli/src/handlers/hide-feed-author.ts
@@ -5,6 +5,7 @@ import {
   errorMessage,
   hideFeedAuthor,
   type HideFeedAuthorOutput,
+  withLoggedInStateRetryAtPort,
 } from "@lhremote/core";
 
 /** Handle the {@link https://github.com/alexey-pelykh/lhremote#hide-feed-author | hide-feed-author} CLI command. */
@@ -20,13 +21,19 @@ export async function handleHideFeedAuthor(
 ): Promise<void> {
   let result: HideFeedAuthorOutput;
   try {
-    result = await hideFeedAuthor({
+    result = await withLoggedInStateRetryAtPort(
+      options.cdpPort,
+      options.cdpHost ?? "127.0.0.1",
+      options.allowRemote ?? false,
+      () =>
+        hideFeedAuthor({
       feedIndex,
       cdpPort: options.cdpPort,
       cdpHost: options.cdpHost,
       allowRemote: options.allowRemote,
       dryRun: options.dryRun,
-    });
+      }),
+    );
   } catch (error) {
     const message = errorMessage(error);
     process.stderr.write(`${message}\n`);

--- a/packages/cli/src/handlers/like-person-posts.ts
+++ b/packages/cli/src/handlers/like-person-posts.ts
@@ -7,6 +7,7 @@ import {
   type EphemeralActionResult,
   CampaignExecutionError,
   CampaignTimeoutError,
+  withLoggedInStateRetryAtPort,
 } from "@lhremote/core";
 
 /** Handle the {@link https://github.com/alexey-pelykh/lhremote#like-person-posts | like-person-posts} CLI command. */
@@ -49,7 +50,12 @@ export async function handleLikePersonPosts(options: {
 
   let result: EphemeralActionResult;
   try {
-    result = await likePersonPosts({
+    result = await withLoggedInStateRetryAtPort(
+      options.cdpPort,
+      options.cdpHost ?? "127.0.0.1",
+      options.allowRemote ?? false,
+      () =>
+        likePersonPosts({
       personId: options.personId,
       url: options.url,
       numberOfArticles: options.numberOfArticles,
@@ -65,7 +71,8 @@ export async function handleLikePersonPosts(options: {
       cdpHost: options.cdpHost,
       allowRemote: options.allowRemote,
       accountId: options.accountId,
-    });
+      }),
+    );
   } catch (error) {
     if (error instanceof CampaignExecutionError || error instanceof CampaignTimeoutError) {
       process.stderr.write(`${error.message}\n`);

--- a/packages/cli/src/handlers/react-to-comment.ts
+++ b/packages/cli/src/handlers/react-to-comment.ts
@@ -6,6 +6,7 @@ import {
   reactToComment,
   type ReactToCommentOutput,
   type ReactionType,
+  withLoggedInStateRetryAtPort,
 } from "@lhremote/core";
 
 /** Handle the {@link https://github.com/alexey-pelykh/lhremote#react-to-comment | react-to-comment} CLI command. */
@@ -23,7 +24,12 @@ export async function handleReactToComment(
 ): Promise<void> {
   let result: ReactToCommentOutput;
   try {
-    result = await reactToComment({
+    result = await withLoggedInStateRetryAtPort(
+      options.cdpPort,
+      options.cdpHost ?? "127.0.0.1",
+      options.allowRemote ?? false,
+      () =>
+        reactToComment({
       postUrl,
       commentUrn,
       reactionType: (options.type as ReactionType | undefined),
@@ -31,7 +37,8 @@ export async function handleReactToComment(
       cdpHost: options.cdpHost,
       allowRemote: options.allowRemote,
       dryRun: options.dryRun,
-    });
+      }),
+    );
   } catch (error) {
     const message = errorMessage(error);
     process.stderr.write(`${message}\n`);

--- a/packages/cli/src/handlers/react-to-post.ts
+++ b/packages/cli/src/handlers/react-to-post.ts
@@ -6,6 +6,7 @@ import {
   reactToPost,
   type ReactToPostOutput,
   type ReactionType,
+  withLoggedInStateRetryAtPort,
 } from "@lhremote/core";
 
 /** Handle the {@link https://github.com/alexey-pelykh/lhremote#react-to-post | react-to-post} CLI command. */
@@ -22,14 +23,20 @@ export async function handleReactToPost(
 ): Promise<void> {
   let result: ReactToPostOutput;
   try {
-    result = await reactToPost({
-      postUrl,
-      reactionType: (options.type as ReactionType | undefined),
-      cdpPort: options.cdpPort,
-      cdpHost: options.cdpHost,
-      allowRemote: options.allowRemote,
-      dryRun: options.dryRun,
-    });
+    result = await withLoggedInStateRetryAtPort(
+      options.cdpPort,
+      options.cdpHost ?? "127.0.0.1",
+      options.allowRemote ?? false,
+      () =>
+        reactToPost({
+          postUrl,
+          reactionType: (options.type as ReactionType | undefined),
+          cdpPort: options.cdpPort,
+          cdpHost: options.cdpHost,
+          allowRemote: options.allowRemote,
+          dryRun: options.dryRun,
+        }),
+    );
   } catch (error) {
     const message = errorMessage(error);
     process.stderr.write(`${message}\n`);

--- a/packages/cli/src/handlers/scrape-messaging-history.ts
+++ b/packages/cli/src/handlers/scrape-messaging-history.ts
@@ -7,6 +7,7 @@ import {
   InstanceNotRunningError,
   scrapeMessagingHistory,
   type ScrapeMessagingHistoryOutput,
+  withLoggedInStateRetryAtPort,
 } from "@lhremote/core";
 
 /** Handle the {@link https://github.com/alexey-pelykh/lhremote#profiles--messaging | scrape-messaging-history} CLI command. */
@@ -28,13 +29,19 @@ export async function handleScrapeMessagingHistory(options: {
 
   let result: ScrapeMessagingHistoryOutput;
   try {
-    result = await scrapeMessagingHistory({
+    result = await withLoggedInStateRetryAtPort(
+      options.cdpPort,
+      options.cdpHost ?? "127.0.0.1",
+      options.allowRemote ?? false,
+      () =>
+        scrapeMessagingHistory({
       personIds: options.personId,
       pauseOthers: options.pauseOthers,
       cdpPort: options.cdpPort,
       cdpHost: options.cdpHost,
       allowRemote: options.allowRemote,
-    });
+      }),
+    );
   } catch (error) {
     if (error instanceof InstanceNotRunningError) {
       process.stderr.write(`${error.message}\n`);

--- a/packages/cli/src/handlers/search-posts.ts
+++ b/packages/cli/src/handlers/search-posts.ts
@@ -5,6 +5,7 @@ import {
   errorMessage,
   searchPosts,
   type SearchPostsOutput,
+  withLoggedInStateRetryAtPort,
 } from "@lhremote/core";
 
 /** Handle the {@link https://github.com/alexey-pelykh/lhremote#search-posts | search-posts} CLI command. */
@@ -21,14 +22,20 @@ export async function handleSearchPosts(
 ): Promise<void> {
   let result: SearchPostsOutput;
   try {
-    result = await searchPosts({
+    result = await withLoggedInStateRetryAtPort(
+      options.cdpPort,
+      options.cdpHost ?? "127.0.0.1",
+      options.allowRemote ?? false,
+      () =>
+        searchPosts({
       query,
       cursor: options.cursor,
       count: options.count,
       cdpPort: options.cdpPort,
       cdpHost: options.cdpHost,
       allowRemote: options.allowRemote,
-    });
+      }),
+    );
   } catch (error) {
     const message = errorMessage(error);
     process.stderr.write(`${message}\n`);

--- a/packages/cli/src/handlers/unfollow-from-feed.ts
+++ b/packages/cli/src/handlers/unfollow-from-feed.ts
@@ -5,6 +5,7 @@ import {
   errorMessage,
   unfollowFromFeed,
   type UnfollowFromFeedOutput,
+  withLoggedInStateRetryAtPort,
 } from "@lhremote/core";
 
 /** Handle the {@link https://github.com/alexey-pelykh/lhremote#unfollow-from-feed | unfollow-from-feed} CLI command. */
@@ -20,13 +21,19 @@ export async function handleUnfollowFromFeed(
 ): Promise<void> {
   let result: UnfollowFromFeedOutput;
   try {
-    result = await unfollowFromFeed({
+    result = await withLoggedInStateRetryAtPort(
+      options.cdpPort,
+      options.cdpHost ?? "127.0.0.1",
+      options.allowRemote ?? false,
+      () =>
+        unfollowFromFeed({
       feedIndex,
       cdpPort: options.cdpPort,
       cdpHost: options.cdpHost,
       allowRemote: options.allowRemote,
       dryRun: options.dryRun,
-    });
+      }),
+    );
   } catch (error) {
     const message = errorMessage(error);
     process.stderr.write(`${message}\n`);

--- a/packages/cli/src/handlers/unfollow-profile.ts
+++ b/packages/cli/src/handlers/unfollow-profile.ts
@@ -5,6 +5,7 @@ import {
   errorMessage,
   unfollowProfile,
   type UnfollowProfileOutput,
+  withLoggedInStateRetryAtPort,
 } from "@lhremote/core";
 
 /** Handle the {@link https://github.com/alexey-pelykh/lhremote#unfollow-profile | unfollow-profile} CLI command. */
@@ -20,13 +21,19 @@ export async function handleUnfollowProfile(
 ): Promise<void> {
   let result: UnfollowProfileOutput;
   try {
-    result = await unfollowProfile({
+    result = await withLoggedInStateRetryAtPort(
+      options.cdpPort,
+      options.cdpHost ?? "127.0.0.1",
+      options.allowRemote ?? false,
+      () =>
+        unfollowProfile({
       profileUrl,
       cdpPort: options.cdpPort,
       cdpHost: options.cdpHost,
       allowRemote: options.allowRemote,
       dryRun: options.dryRun,
-    });
+      }),
+    );
   } catch (error) {
     const message = errorMessage(error);
     process.stderr.write(`${message}\n`);

--- a/packages/cli/src/handlers/visit-profile.ts
+++ b/packages/cli/src/handlers/visit-profile.ts
@@ -7,6 +7,7 @@ import {
   InstanceNotRunningError,
   visitProfile,
   type VisitProfileOutput,
+  withLoggedInStateRetryAtPort,
 } from "@lhremote/core";
 
 /** Handle the {@link https://github.com/alexey-pelykh/lhremote#visit-profile | visit-profile} CLI command. */
@@ -32,7 +33,12 @@ export async function handleVisitProfile(options: {
 
   let result: VisitProfileOutput;
   try {
-    result = await visitProfile({
+    result = await withLoggedInStateRetryAtPort(
+      options.cdpPort,
+      options.cdpHost ?? "127.0.0.1",
+      options.allowRemote ?? false,
+      () =>
+        visitProfile({
       personId: options.personId,
       url: options.url,
       extractCurrentOrganizations: options.extractCurrentOrganizations,
@@ -40,7 +46,8 @@ export async function handleVisitProfile(options: {
       cdpHost: options.cdpHost,
       allowRemote: options.allowRemote,
       accountId: options.accountId,
-    });
+      }),
+    );
   } catch (error) {
     if (error instanceof InstanceNotRunningError) {
       process.stderr.write(`${error.message}\n`);

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -466,6 +466,15 @@ export {
   resolveLinkedInEntity,
   type ResolveLinkedInEntityInput,
   type ResolveLinkedInEntityOutput,
+  // LinkedIn ContentWindow state gating (#781, #782)
+  gateOnLoggedInState,
+  LoggedInStateTimeoutError,
+  waitForLoggedInState,
+  type WaitForLoggedInStateOptions,
+  LoggedInStatePersistedError,
+  withLoggedInStateRetry,
+  withLoggedInStateRetryAtPort,
+  type WithLoggedInStateRetryOptions,
 } from "./operations/index.js";
 
 // LinkedIn DOM automation & selectors

--- a/packages/core/src/operations/collect-people.test.ts
+++ b/packages/core/src/operations/collect-people.test.ts
@@ -19,6 +19,14 @@ vi.mock("../db/index.js", () => ({
   CampaignRepository: vi.fn(),
 }));
 
+vi.mock("./wait-for-logged-in-state.js", () => ({
+  gateOnLoggedInState: vi.fn().mockResolvedValue(undefined),
+  waitForLoggedInState: vi.fn().mockResolvedValue(undefined),
+  LoggedInStateTimeoutError: class extends Error {},
+}));
+
+import { waitForLoggedInState } from "./wait-for-logged-in-state.js";
+
 import type { InstanceDatabaseContext } from "../services/instance-context.js";
 import { resolveAccount } from "../services/account-resolution.js";
 import { withInstanceDatabase } from "../services/instance-context.js";
@@ -75,6 +83,7 @@ describe("collectPeople", () => {
       campaignId: 42,
       sourceType: "SearchPage",
     });
+    expect(vi.mocked(waitForLoggedInState)).toHaveBeenCalled();
   });
 
   it("uses explicit sourceType when provided", async () => {

--- a/packages/core/src/operations/collect-people.ts
+++ b/packages/core/src/operations/collect-people.ts
@@ -9,6 +9,7 @@ import { CollectionError } from "../services/errors.js";
 import { CampaignRepository } from "../db/index.js";
 import { detectSourceType, validateSourceType } from "../services/source-type-registry.js";
 import { buildCdpOptions, type ConnectionOptions } from "./types.js";
+import { waitForLoggedInState } from "./wait-for-logged-in-state.js";
 
 /**
  * Input for the collect-people operation.
@@ -91,6 +92,8 @@ export async function collectPeople(
       );
     }
     const actionId = firstAction.id;
+
+    await waitForLoggedInState(instance, { timeout: 60_000 });
 
     const collectionService = new CollectionService(instance);
     await collectionService.collect(input.sourceUrl, input.campaignId, actionId);

--- a/packages/core/src/operations/comment-on-post.test.ts
+++ b/packages/core/src/operations/comment-on-post.test.ts
@@ -37,6 +37,14 @@ vi.mock("../utils/delay.js", () => ({
   gaussianDelay: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock("./wait-for-logged-in-state.js", () => ({
+  gateOnLoggedInState: vi.fn().mockResolvedValue(undefined),
+  waitForLoggedInState: vi.fn().mockResolvedValue(undefined),
+  LoggedInStateTimeoutError: class extends Error {},
+}));
+
+import { gateOnLoggedInState } from "./wait-for-logged-in-state.js";
+
 import type { DatabaseContext } from "../services/instance-context.js";
 import { resolveAccount } from "../services/account-resolution.js";
 import { withDatabase } from "../services/instance-context.js";
@@ -144,6 +152,7 @@ describe("commentOnPost", () => {
       cdpPort: MOCK_CDP_PORT,
     });
     expect(result.success).toBe(true);
+    expect(vi.mocked(gateOnLoggedInState)).toHaveBeenCalled();
   });
 
   it("accepts /posts/ URL format", async () => {

--- a/packages/core/src/operations/comment-on-post.ts
+++ b/packages/core/src/operations/comment-on-post.ts
@@ -20,6 +20,7 @@ import { BudgetExceededError } from "../services/errors.js";
 import { withDatabase } from "../services/instance-context.js";
 import { gaussianDelay } from "../utils/delay.js";
 import { buildCdpOptions, type ConnectionOptions } from "./types.js";
+import { gateOnLoggedInState } from "./wait-for-logged-in-state.js";
 
 /** Pattern matching supported LinkedIn post URL formats. */
 const LINKEDIN_POST_URL_RE =
@@ -152,6 +153,8 @@ export async function commentOnPost(
       );
     }
   });
+
+  await gateOnLoggedInState(cdpPort, cdpHost, allowRemote, { timeout: 60_000 });
 
   // Connect to the LinkedIn webview
   const targets = await discoverTargets(cdpPort, cdpHost);

--- a/packages/core/src/operations/dismiss-feed-post.test.ts
+++ b/packages/core/src/operations/dismiss-feed-post.test.ts
@@ -31,6 +31,14 @@ vi.mock("./get-feed.js", () => ({
   scrollFeed: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock("./wait-for-logged-in-state.js", () => ({
+  gateOnLoggedInState: vi.fn().mockResolvedValue(undefined),
+  waitForLoggedInState: vi.fn().mockResolvedValue(undefined),
+  LoggedInStateTimeoutError: class extends Error {},
+}));
+
+import { gateOnLoggedInState } from "./wait-for-logged-in-state.js";
+
 import { CDPClient } from "../cdp/client.js";
 import { discoverTargets } from "../cdp/discovery.js";
 import { dismissFeedPost } from "./dismiss-feed-post.js";
@@ -104,6 +112,7 @@ describe("dismissFeedPost", () => {
     });
 
     expect(result.success).toBe(true);
+    expect(vi.mocked(gateOnLoggedInState)).toHaveBeenCalled();
   });
 
   it("throws when no LinkedIn page is found", async () => {

--- a/packages/core/src/operations/dismiss-feed-post.ts
+++ b/packages/core/src/operations/dismiss-feed-post.ts
@@ -10,6 +10,7 @@ import { gaussianDelay, maybeHesitate } from "../utils/delay.js";
 import type { ConnectionOptions } from "./types.js";
 import { navigateAwayIf } from "./navigate-away.js";
 import { waitForFeedLoad } from "./get-feed.js";
+import { gateOnLoggedInState } from "./wait-for-logged-in-state.js";
 
 /** CSS selector for feed post menu buttons. */
 const FEED_MENU_BUTTON_SELECTOR =
@@ -120,6 +121,8 @@ export async function dismissFeedPost(
         "This is a security measure to prevent remote code execution.",
     );
   }
+
+  await gateOnLoggedInState(cdpPort, cdpHost, allowRemote, { timeout: 60_000 });
 
   const targets = await discoverTargets(cdpPort, cdpHost);
   const linkedInTarget = targets.find(

--- a/packages/core/src/operations/ephemeral-action.test.ts
+++ b/packages/core/src/operations/ephemeral-action.test.ts
@@ -15,6 +15,14 @@ vi.mock("../services/ephemeral-campaign.js", () => ({
   EphemeralCampaignService: vi.fn(),
 }));
 
+vi.mock("./wait-for-logged-in-state.js", () => ({
+  gateOnLoggedInState: vi.fn().mockResolvedValue(undefined),
+  waitForLoggedInState: vi.fn().mockResolvedValue(undefined),
+  LoggedInStateTimeoutError: class extends Error {},
+}));
+
+import { waitForLoggedInState } from "./wait-for-logged-in-state.js";
+
 import type { InstanceDatabaseContext } from "../services/instance-context.js";
 import { resolveAccount } from "../services/account-resolution.js";
 import { withInstanceDatabase } from "../services/instance-context.js";
@@ -79,6 +87,7 @@ describe("executeEphemeralAction", () => {
       cdpPort: 9222,
     });
 
+    expect(vi.mocked(waitForLoggedInState)).toHaveBeenCalled();
     expect(resolveAccount).toHaveBeenCalledWith(9222, {});
     expect(withInstanceDatabase).toHaveBeenCalledWith(
       9222,

--- a/packages/core/src/operations/ephemeral-action.ts
+++ b/packages/core/src/operations/ephemeral-action.ts
@@ -6,6 +6,7 @@ import { resolveAccount } from "../services/account-resolution.js";
 import { withInstanceDatabase } from "../services/instance-context.js";
 import { EphemeralCampaignService } from "../services/ephemeral-campaign.js";
 import { buildCdpOptions, type ConnectionOptions } from "./types.js";
+import { waitForLoggedInState } from "./wait-for-logged-in-state.js";
 
 /**
  * Shared input fields for all ephemeral action operations.
@@ -42,6 +43,8 @@ export async function executeEphemeralAction(
   const accountId = await resolveAccount(cdpPort, buildCdpOptions(input));
 
   return withInstanceDatabase(cdpPort, accountId, async ({ instance, db }) => {
+    await waitForLoggedInState(instance, { timeout: 60_000 });
+
     const ephemeral = new EphemeralCampaignService(instance, db);
     return ephemeral.execute(actionType, target, actionSettings, {
       ...(input.keepCampaign !== undefined && { keepCampaign: input.keepCampaign }),

--- a/packages/core/src/operations/get-feed.test.ts
+++ b/packages/core/src/operations/get-feed.test.ts
@@ -24,6 +24,14 @@ vi.mock("../utils/delay.js", () => ({
   simulateReadingTime: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock("./wait-for-logged-in-state.js", () => ({
+  gateOnLoggedInState: vi.fn().mockResolvedValue(undefined),
+  waitForLoggedInState: vi.fn().mockResolvedValue(undefined),
+  LoggedInStateTimeoutError: class extends Error {},
+}));
+
+import { gateOnLoggedInState } from "./wait-for-logged-in-state.js";
+
 import { discoverTargets } from "../cdp/discovery.js";
 import { CDPClient } from "../cdp/client.js";
 import { getFeed, extractHashtags, parseTimestamp } from "./get-feed.js";
@@ -171,6 +179,7 @@ describe("getFeed", () => {
     ]);
 
     const result = await getFeed({ cdpPort: CDP_PORT });
+    expect(vi.mocked(gateOnLoggedInState)).toHaveBeenCalled();
 
     expect(result.posts).toHaveLength(1);
     const [post] = result.posts;

--- a/packages/core/src/operations/get-feed.ts
+++ b/packages/core/src/operations/get-feed.ts
@@ -10,6 +10,7 @@ import type { HumanizedMouse } from "../linkedin/humanized-mouse.js";
 import { delay as utilsDelay, gaussianDelay, gaussianBetween, maybeHesitate, maybeBreak, simulateReadingTime } from "../utils/delay.js";
 import type { ConnectionOptions } from "./types.js";
 import { navigateAwayIf } from "./navigate-away.js";
+import { gateOnLoggedInState } from "./wait-for-logged-in-state.js";
 
 /**
  * Input for the get-feed operation.
@@ -500,6 +501,8 @@ export async function getFeed(
         "This is a security measure to prevent remote code execution.",
     );
   }
+
+  await gateOnLoggedInState(cdpPort, cdpHost, allowRemote, { timeout: 60_000 });
 
   const targets = await discoverTargets(cdpPort, cdpHost);
   const linkedInTarget = targets.find(

--- a/packages/core/src/operations/hide-feed-author-profile.test.ts
+++ b/packages/core/src/operations/hide-feed-author-profile.test.ts
@@ -22,6 +22,14 @@ vi.mock("../utils/delay.js", () => ({
   maybeHesitate: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock("./wait-for-logged-in-state.js", () => ({
+  gateOnLoggedInState: vi.fn().mockResolvedValue(undefined),
+  waitForLoggedInState: vi.fn().mockResolvedValue(undefined),
+  LoggedInStateTimeoutError: class extends Error {},
+}));
+
+import { gateOnLoggedInState } from "./wait-for-logged-in-state.js";
+
 vi.mock("./navigate-to-profile.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./navigate-to-profile.js")>();
   return {
@@ -174,6 +182,7 @@ describe("hideFeedAuthorProfile", () => {
     });
 
     expect(result.success).toBe(true);
+    expect(vi.mocked(gateOnLoggedInState)).toHaveBeenCalled();
 
     // The confirmation-dialog probe evaluate script should reference the
     // confirm label patterns.

--- a/packages/core/src/operations/hide-feed-author-profile.ts
+++ b/packages/core/src/operations/hide-feed-author-profile.ts
@@ -9,6 +9,7 @@ import type { HumanizedMouse } from "../linkedin/humanized-mouse.js";
 import { gaussianDelay } from "../utils/delay.js";
 import { extractPublicId, navigateToProfile } from "./navigate-to-profile.js";
 import type { ConnectionOptions } from "./types.js";
+import { gateOnLoggedInState } from "./wait-for-logged-in-state.js";
 
 /** CSS selector for the profile-page overflow action menu button. */
 const PROFILE_MORE_BUTTON_SELECTOR =
@@ -108,6 +109,8 @@ export async function hideFeedAuthorProfile(
         "This is a security measure to prevent remote code execution.",
     );
   }
+
+  await gateOnLoggedInState(cdpPort, cdpHost, allowRemote, { timeout: 60_000 });
 
   const targets = await discoverTargets(cdpPort, cdpHost);
   const linkedInTarget = targets.find(

--- a/packages/core/src/operations/hide-feed-author.test.ts
+++ b/packages/core/src/operations/hide-feed-author.test.ts
@@ -29,6 +29,14 @@ vi.mock("./get-feed.js", () => ({
   waitForFeedLoad: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock("./wait-for-logged-in-state.js", () => ({
+  gateOnLoggedInState: vi.fn().mockResolvedValue(undefined),
+  waitForLoggedInState: vi.fn().mockResolvedValue(undefined),
+  LoggedInStateTimeoutError: class extends Error {},
+}));
+
+import { gateOnLoggedInState } from "./wait-for-logged-in-state.js";
+
 import { CDPClient } from "../cdp/client.js";
 import { discoverTargets } from "../cdp/discovery.js";
 import { humanizedScrollToByIndex } from "../linkedin/dom-automation.js";
@@ -87,6 +95,7 @@ describe("hideFeedAuthor", () => {
     });
 
     expect(result.success).toBe(true);
+    expect(vi.mocked(gateOnLoggedInState)).toHaveBeenCalled();
   });
 
   it("throws when no LinkedIn page is found", async () => {

--- a/packages/core/src/operations/hide-feed-author.ts
+++ b/packages/core/src/operations/hide-feed-author.ts
@@ -10,6 +10,7 @@ import { gaussianDelay } from "../utils/delay.js";
 import type { ConnectionOptions } from "./types.js";
 import { navigateAwayIf } from "./navigate-away.js";
 import { waitForFeedLoad } from "./get-feed.js";
+import { gateOnLoggedInState } from "./wait-for-logged-in-state.js";
 
 /** CSS selector for feed post menu buttons. */
 const FEED_MENU_BUTTON_SELECTOR =
@@ -62,6 +63,8 @@ export async function hideFeedAuthor(
         "This is a security measure to prevent remote code execution.",
     );
   }
+
+  await gateOnLoggedInState(cdpPort, cdpHost, allowRemote, { timeout: 60_000 });
 
   const targets = await discoverTargets(cdpPort, cdpHost);
   const linkedInTarget = targets.find(

--- a/packages/core/src/operations/index.ts
+++ b/packages/core/src/operations/index.ts
@@ -364,6 +364,20 @@ export {
   type EnrichmentCategory,
 } from "./enrich-profile.js";
 
+// LinkedIn ContentWindow state gating (see #781)
+export {
+  gateOnLoggedInState,
+  LoggedInStateTimeoutError,
+  waitForLoggedInState,
+  type WaitForLoggedInStateOptions,
+} from "./wait-for-logged-in-state.js";
+export {
+  LoggedInStatePersistedError,
+  withLoggedInStateRetry,
+  withLoggedInStateRetryAtPort,
+  type WithLoggedInStateRetryOptions,
+} from "./with-logged-in-state-retry.js";
+
 // URL building & entity resolution
 export {
   buildLinkedInUrl,

--- a/packages/core/src/operations/react-to-comment.test.ts
+++ b/packages/core/src/operations/react-to-comment.test.ts
@@ -27,6 +27,14 @@ vi.mock("../utils/delay.js", () => ({
   gaussianDelay: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock("./wait-for-logged-in-state.js", () => ({
+  gateOnLoggedInState: vi.fn().mockResolvedValue(undefined),
+  waitForLoggedInState: vi.fn().mockResolvedValue(undefined),
+  LoggedInStateTimeoutError: class extends Error {},
+}));
+
+import { gateOnLoggedInState } from "./wait-for-logged-in-state.js";
+
 import { CDPClient } from "../cdp/client.js";
 import { discoverTargets } from "../cdp/discovery.js";
 import {
@@ -191,6 +199,7 @@ describe("reactToComment", () => {
     });
 
     expect(result.success).toBe(true);
+    expect(vi.mocked(gateOnLoggedInState)).toHaveBeenCalled();
   });
 
   it("throws when no LinkedIn page is found", async () => {

--- a/packages/core/src/operations/react-to-comment.ts
+++ b/packages/core/src/operations/react-to-comment.ts
@@ -23,6 +23,7 @@ import { gaussianDelay } from "../utils/delay.js";
 import { navigateAwayIf } from "./navigate-away.js";
 import { REACTION_TYPES, type ReactionType } from "./react-to-post.js";
 import type { ConnectionOptions } from "./types.js";
+import { gateOnLoggedInState } from "./wait-for-logged-in-state.js";
 
 /** Pattern matching supported LinkedIn post URL formats. */
 const LINKEDIN_POST_URL_RE =
@@ -278,6 +279,8 @@ export async function reactToComment(
         "This is a security measure to prevent remote code execution.",
     );
   }
+
+  await gateOnLoggedInState(cdpPort, cdpHost, allowRemote, { timeout: 60_000 });
 
   const targets = await discoverTargets(cdpPort, cdpHost);
   const linkedInTarget = targets.find(

--- a/packages/core/src/operations/react-to-post.test.ts
+++ b/packages/core/src/operations/react-to-post.test.ts
@@ -26,6 +26,14 @@ vi.mock("../utils/delay.js", () => ({
   gaussianDelay: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock("./wait-for-logged-in-state.js", () => ({
+  gateOnLoggedInState: vi.fn().mockResolvedValue(undefined),
+  waitForLoggedInState: vi.fn().mockResolvedValue(undefined),
+  LoggedInStateTimeoutError: class extends Error {},
+}));
+
+import { gateOnLoggedInState } from "./wait-for-logged-in-state.js";
+
 import { CDPClient } from "../cdp/client.js";
 import { discoverTargets } from "../cdp/discovery.js";
 import { waitForElement, humanizedHover, humanizedClick, retryInteraction } from "../linkedin/dom-automation.js";
@@ -90,6 +98,7 @@ describe("reactToPost", () => {
     });
 
     expect(result.success).toBe(true);
+    expect(vi.mocked(gateOnLoggedInState)).toHaveBeenCalled();
   });
 
   it("throws when no LinkedIn page is found", async () => {

--- a/packages/core/src/operations/react-to-post.ts
+++ b/packages/core/src/operations/react-to-post.ts
@@ -17,6 +17,7 @@ import {
 } from "../linkedin/selectors.js";
 import { gaussianDelay } from "../utils/delay.js";
 import type { ConnectionOptions } from "./types.js";
+import { gateOnLoggedInState } from "./wait-for-logged-in-state.js";
 
 /**
  * Supported LinkedIn reaction types.
@@ -168,6 +169,8 @@ export async function reactToPost(
         "This is a security measure to prevent remote code execution.",
     );
   }
+
+  await gateOnLoggedInState(cdpPort, cdpHost, allowRemote, { timeout: 60_000 });
 
   const targets = await discoverTargets(cdpPort, cdpHost);
   const linkedInTarget = targets.find(

--- a/packages/core/src/operations/scrape-messaging-history.test.ts
+++ b/packages/core/src/operations/scrape-messaging-history.test.ts
@@ -24,6 +24,14 @@ vi.mock("../utils/delay.js", () => ({
   delay: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock("./wait-for-logged-in-state.js", () => ({
+  gateOnLoggedInState: vi.fn().mockResolvedValue(undefined),
+  waitForLoggedInState: vi.fn().mockResolvedValue(undefined),
+  LoggedInStateTimeoutError: class extends Error {},
+}));
+
+import { waitForLoggedInState } from "./wait-for-logged-in-state.js";
+
 import type { InstanceDatabaseContext } from "../services/instance-context.js";
 import { resolveAccount } from "../services/account-resolution.js";
 import { withInstanceDatabase } from "../services/instance-context.js";
@@ -116,6 +124,7 @@ describe("scrapeMessagingHistory", () => {
     });
 
     expect(result.success).toBe(true);
+    expect(vi.mocked(waitForLoggedInState)).toHaveBeenCalled();
     expect(result.actionType).toBe("ScrapeMessagingHistory");
     expect(result.stats).toBe(MOCK_STATS);
   });

--- a/packages/core/src/operations/scrape-messaging-history.ts
+++ b/packages/core/src/operations/scrape-messaging-history.ts
@@ -10,6 +10,7 @@ import { MessageRepository, ProfileRepository } from "../db/index.js";
 import { delay } from "../utils/delay.js";
 import { errorMessage } from "../utils/error-message.js";
 import { buildCdpOptions, type ConnectionOptions } from "./types.js";
+import { waitForLoggedInState } from "./wait-for-logged-in-state.js";
 
 /** Timeout for ephemeral campaign completion (5 minutes). */
 const CAMPAIGN_TIMEOUT = 300_000;
@@ -40,6 +41,8 @@ export async function scrapeMessagingHistory(
   const accountId = await resolveAccount(cdpPort, buildCdpOptions(input));
 
   return withInstanceDatabase(cdpPort, accountId, async ({ instance, db }) => {
+    await waitForLoggedInState(instance, { timeout: 60_000 });
+
     const campaignService = new CampaignService(instance, db);
     const profileRepo = new ProfileRepository(db);
 

--- a/packages/core/src/operations/search-posts.test.ts
+++ b/packages/core/src/operations/search-posts.test.ts
@@ -24,6 +24,14 @@ vi.mock("../utils/delay.js", () => ({
   simulateReadingTime: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock("./wait-for-logged-in-state.js", () => ({
+  gateOnLoggedInState: vi.fn().mockResolvedValue(undefined),
+  waitForLoggedInState: vi.fn().mockResolvedValue(undefined),
+  LoggedInStateTimeoutError: class extends Error {},
+}));
+
+import { gateOnLoggedInState } from "./wait-for-logged-in-state.js";
+
 import { discoverTargets } from "../cdp/discovery.js";
 import { CDPClient } from "../cdp/client.js";
 import { searchPosts } from "./search-posts.js";
@@ -127,6 +135,7 @@ describe("searchPosts", () => {
     ]);
 
     const result = await searchPosts({ query: "linkedin", cdpPort: CDP_PORT });
+    expect(vi.mocked(gateOnLoggedInState)).toHaveBeenCalled();
 
     expect(result.query).toBe("linkedin");
     expect(result.posts).toHaveLength(1);

--- a/packages/core/src/operations/search-posts.ts
+++ b/packages/core/src/operations/search-posts.ts
@@ -7,6 +7,7 @@ import { CDPClient } from "../cdp/client.js";
 import { discoverTargets } from "../cdp/discovery.js";
 import type { ConnectionOptions } from "./types.js";
 import { navigateAwayIf } from "./navigate-away.js";
+import { gateOnLoggedInState } from "./wait-for-logged-in-state.js";
 import { gaussianDelay, gaussianBetween, maybeHesitate, maybeBreak, simulateReadingTime } from "../utils/delay.js";
 import { humanizedScrollToByIndex, retryInteraction } from "../linkedin/dom-automation.js";
 import type { HumanizedMouse } from "../linkedin/humanized-mouse.js";
@@ -343,6 +344,8 @@ export async function searchPosts(
         "This is a security measure to prevent remote code execution.",
     );
   }
+
+  await gateOnLoggedInState(cdpPort, cdpHost, allowRemote, { timeout: 60_000 });
 
   const targets = await discoverTargets(cdpPort, cdpHost);
   const linkedInTarget = targets.find(

--- a/packages/core/src/operations/unfollow-from-feed.test.ts
+++ b/packages/core/src/operations/unfollow-from-feed.test.ts
@@ -30,6 +30,14 @@ vi.mock("./get-feed.js", () => ({
   waitForFeedLoad: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock("./wait-for-logged-in-state.js", () => ({
+  gateOnLoggedInState: vi.fn().mockResolvedValue(undefined),
+  waitForLoggedInState: vi.fn().mockResolvedValue(undefined),
+  LoggedInStateTimeoutError: class extends Error {},
+}));
+
+import { gateOnLoggedInState } from "./wait-for-logged-in-state.js";
+
 import { CDPClient } from "../cdp/client.js";
 import { discoverTargets } from "../cdp/discovery.js";
 import { humanizedScrollToByIndex, retryInteraction } from "../linkedin/dom-automation.js";
@@ -88,6 +96,7 @@ describe("unfollowFromFeed", () => {
     });
 
     expect(result.success).toBe(true);
+    expect(vi.mocked(gateOnLoggedInState)).toHaveBeenCalled();
   });
 
   it("throws when no LinkedIn page is found", async () => {

--- a/packages/core/src/operations/unfollow-from-feed.ts
+++ b/packages/core/src/operations/unfollow-from-feed.ts
@@ -10,6 +10,7 @@ import { gaussianDelay, maybeHesitate } from "../utils/delay.js";
 import type { ConnectionOptions } from "./types.js";
 import { navigateAwayIf } from "./navigate-away.js";
 import { waitForFeedLoad } from "./get-feed.js";
+import { gateOnLoggedInState } from "./wait-for-logged-in-state.js";
 
 /** CSS selector for feed post menu buttons. */
 const FEED_MENU_BUTTON_SELECTOR =
@@ -57,6 +58,8 @@ export async function unfollowFromFeed(
         "This is a security measure to prevent remote code execution.",
     );
   }
+
+  await gateOnLoggedInState(cdpPort, cdpHost, allowRemote, { timeout: 60_000 });
 
   const targets = await discoverTargets(cdpPort, cdpHost);
   const linkedInTarget = targets.find(

--- a/packages/core/src/operations/unfollow-profile.test.ts
+++ b/packages/core/src/operations/unfollow-profile.test.ts
@@ -22,6 +22,14 @@ vi.mock("../utils/delay.js", () => ({
   maybeHesitate: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock("./wait-for-logged-in-state.js", () => ({
+  gateOnLoggedInState: vi.fn().mockResolvedValue(undefined),
+  waitForLoggedInState: vi.fn().mockResolvedValue(undefined),
+  LoggedInStateTimeoutError: class extends Error {},
+}));
+
+import { gateOnLoggedInState } from "./wait-for-logged-in-state.js";
+
 vi.mock("./navigate-to-profile.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./navigate-to-profile.js")>();
   return {
@@ -108,6 +116,7 @@ describe("unfollowProfile", () => {
     });
 
     expect(result.success).toBe(true);
+    expect(vi.mocked(gateOnLoggedInState)).toHaveBeenCalled();
   });
 
   it("throws when no LinkedIn page is found", async () => {

--- a/packages/core/src/operations/unfollow-profile.ts
+++ b/packages/core/src/operations/unfollow-profile.ts
@@ -14,6 +14,7 @@ import {
   type FollowableTarget,
 } from "./navigate-to-profile.js";
 import type { ConnectionOptions } from "./types.js";
+import { gateOnLoggedInState } from "./wait-for-logged-in-state.js";
 
 /** aria-label prefix of a "Following {Name}" toggle button (profile or company). */
 const PROFILE_FOLLOWING_ARIA_PREFIX = "Following ";
@@ -133,6 +134,8 @@ export async function unfollowProfile(
         "This is a security measure to prevent remote code execution.",
     );
   }
+
+  await gateOnLoggedInState(cdpPort, cdpHost, allowRemote, { timeout: 60_000 });
 
   const targets = await discoverTargets(cdpPort, cdpHost);
   const linkedInTarget = targets.find(

--- a/packages/core/src/operations/visit-profile.test.ts
+++ b/packages/core/src/operations/visit-profile.test.ts
@@ -15,6 +15,14 @@ vi.mock("../db/index.js", () => ({
   ProfileRepository: vi.fn(),
 }));
 
+vi.mock("./wait-for-logged-in-state.js", () => ({
+  gateOnLoggedInState: vi.fn().mockResolvedValue(undefined),
+  waitForLoggedInState: vi.fn().mockResolvedValue(undefined),
+  LoggedInStateTimeoutError: class extends Error {},
+}));
+
+import { waitForLoggedInState } from "./wait-for-logged-in-state.js";
+
 import type { InstanceDatabaseContext } from "../services/instance-context.js";
 import { resolveAccount } from "../services/account-resolution.js";
 import { withInstanceDatabase } from "../services/instance-context.js";
@@ -97,6 +105,7 @@ describe("visitProfile", () => {
     });
 
     expect(result.success).toBe(true);
+    expect(vi.mocked(waitForLoggedInState)).toHaveBeenCalled();
     expect(result.actionType).toBe("VisitAndExtract");
     expect(result.profile).toBe(MOCK_PROFILE);
   });

--- a/packages/core/src/operations/visit-profile.ts
+++ b/packages/core/src/operations/visit-profile.ts
@@ -7,6 +7,7 @@ import { withInstanceDatabase } from "../services/instance-context.js";
 import { ProfileRepository } from "../db/index.js";
 import { extractPublicId } from "./navigate-to-profile.js";
 import { buildCdpOptions, type ConnectionOptions } from "./types.js";
+import { waitForLoggedInState } from "./wait-for-logged-in-state.js";
 
 export interface VisitProfileInput extends ConnectionOptions {
   readonly personId?: number | undefined;
@@ -42,6 +43,8 @@ export async function visitProfile(
       const existing = repo.findByPublicId(publicId);
       personId = existing.id;
     }
+
+    await waitForLoggedInState(instance, { timeout: 60_000 });
 
     await instance.executeAction("VisitAndExtract", {
       personIds: [personId],

--- a/packages/core/src/operations/wait-for-logged-in-state.test.ts
+++ b/packages/core/src/operations/wait-for-logged-in-state.test.ts
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../utils/delay.js", () => ({
+  delay: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { delay } from "../utils/delay.js";
+import type { InstanceService } from "../services/instance.js";
+import {
+  LoggedInStateTimeoutError,
+  waitForLoggedInState,
+} from "./wait-for-logged-in-state.js";
+
+interface ProbeShape {
+  ok: boolean;
+  reason?: string;
+  hostname?: string;
+  pathname?: string;
+}
+
+function makeInstance(probe: () => Promise<ProbeShape> | ProbeShape) {
+  return {
+    evaluateLinkedIn: vi.fn().mockImplementation(async () => probe()),
+  } as unknown as InstanceService;
+}
+
+describe("waitForLoggedInState", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns immediately when the first probe reports ok", async () => {
+    const instance = makeInstance(() => ({
+      ok: true,
+      hostname: "www.linkedin.com",
+      pathname: "/feed/",
+    }));
+
+    await waitForLoggedInState(instance);
+
+    expect(instance.evaluateLinkedIn).toHaveBeenCalledTimes(1);
+    expect(delay).not.toHaveBeenCalled();
+  });
+
+  it("polls until the probe reports ok", async () => {
+    let calls = 0;
+    const instance = makeInstance(() => {
+      calls++;
+      return calls < 3
+        ? { ok: false, reason: "me-not-rendered" }
+        : { ok: true };
+    });
+
+    await waitForLoggedInState(instance, { pollInterval: 100, timeout: 60_000 });
+
+    expect(instance.evaluateLinkedIn).toHaveBeenCalledTimes(3);
+    expect(delay).toHaveBeenCalledTimes(2);
+    // delay receives the configured pollInterval
+    expect(delay).toHaveBeenCalledWith(100);
+  });
+
+  it("throws LoggedInStateTimeoutError when probe never reports ok", async () => {
+    const probeMock = vi.fn().mockResolvedValue({
+      ok: false,
+      reason: "wrong-path",
+      pathname: "/checkpoint/challenge/",
+    });
+    const instance = {
+      evaluateLinkedIn: probeMock,
+    } as unknown as InstanceService;
+
+    // Use a very small timeout — with mocked `delay`, real elapsed time
+    // crosses 1ms within a handful of synchronous iterations.
+    await expect(
+      waitForLoggedInState(instance, { timeout: 1, pollInterval: 1 }),
+    ).rejects.toBeInstanceOf(LoggedInStateTimeoutError);
+  });
+
+  it("preserves the lastReason on the timeout error", async () => {
+    const probeMock = vi.fn().mockResolvedValue({
+      ok: false,
+      reason: "wrong-host",
+      hostname: "example.com",
+    });
+    const instance = {
+      evaluateLinkedIn: probeMock,
+    } as unknown as InstanceService;
+
+    try {
+      await waitForLoggedInState(instance, { timeout: 1, pollInterval: 1 });
+      expect.unreachable("expected LoggedInStateTimeoutError");
+    } catch (err) {
+      expect(err).toBeInstanceOf(LoggedInStateTimeoutError);
+      const e = err as LoggedInStateTimeoutError;
+      expect(e.lastReason).toBe("wrong-host");
+      expect(e.waitedMs).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("treats probe-time exceptions as transient and retries", async () => {
+    let calls = 0;
+    const instance = makeInstance(() => {
+      calls++;
+      if (calls === 1) throw new Error("CDP disconnected");
+      if (calls === 2) return { ok: false, reason: "me-not-rendered" };
+      return { ok: true };
+    });
+
+    await waitForLoggedInState(instance, { pollInterval: 1, timeout: 60_000 });
+
+    expect(instance.evaluateLinkedIn).toHaveBeenCalledTimes(3);
+  });
+
+  it("surfaces the throw reason in the timeout error when probes always throw", async () => {
+    const probeMock = vi.fn().mockImplementation(() => {
+      throw new Error("CDP disconnected");
+    });
+    const instance = {
+      evaluateLinkedIn: probeMock,
+    } as unknown as InstanceService;
+
+    try {
+      await waitForLoggedInState(instance, { timeout: 1, pollInterval: 1 });
+      expect.unreachable("expected LoggedInStateTimeoutError");
+    } catch (err) {
+      expect(err).toBeInstanceOf(LoggedInStateTimeoutError);
+      const e = err as LoggedInStateTimeoutError;
+      expect(e.lastReason).toContain("probe-threw");
+      expect(e.lastReason).toContain("CDP disconnected");
+    }
+  });
+
+  it("returns ok as soon as one probe succeeds even if a later one would not", async () => {
+    let calls = 0;
+    const instance = makeInstance(() => {
+      calls++;
+      if (calls === 1) return { ok: true };
+      // Subsequent probes would fail, but the helper should have already returned.
+      return { ok: false, reason: "me-not-rendered" };
+    });
+
+    await waitForLoggedInState(instance);
+
+    expect(instance.evaluateLinkedIn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/core/src/operations/wait-for-logged-in-state.ts
+++ b/packages/core/src/operations/wait-for-logged-in-state.ts
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
+import { ServiceError } from "../services/errors.js";
 import { InstanceService } from "../services/instance.js";
 import { delay } from "../utils/delay.js";
 
@@ -40,7 +41,7 @@ const LOGGED_IN_PATH_PREFIXES = [
  * re-validating the session (fresh `/me` API call in flight) or the
  * instance has dropped to a security-checkpoint page.
  */
-export class LoggedInStateTimeoutError extends Error {
+export class LoggedInStateTimeoutError extends ServiceError {
   readonly waitedMs: number;
   readonly lastReason: string;
 

--- a/packages/core/src/operations/wait-for-logged-in-state.ts
+++ b/packages/core/src/operations/wait-for-logged-in-state.ts
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { InstanceService } from "../services/instance.js";
+import { delay } from "../utils/delay.js";
+
+/**
+ * Default deadline for the gate (60s).  Long enough to cover a typical
+ * LinkedIn `/me` re-validation round-trip after a session refresh, short
+ * enough that callers don't sit indefinitely on a stuck instance.
+ */
+const DEFAULT_TIMEOUT = 60_000;
+
+/** Default poll interval between DOM probes (500ms — same cadence the LH frontend uses). */
+const DEFAULT_POLL_INTERVAL = 500;
+
+/**
+ * URL pathname prefixes that LinkedHelper's `LoggedInState.canEnter()`
+ * accepts as logged-in pages.  Mirrors the set extracted from
+ * `dist/ContentWindow/States/LinkedIn/BaseState/LoggedInState/impl/canEnter.jsc`
+ * (research/linkedhelper/state/li-window-state-machine-20260506.md §6).
+ *
+ * `/feed` is included implicitly as the default LinkedIn root.
+ */
+const LOGGED_IN_PATH_PREFIXES = [
+  "/feed",
+  "/in/",
+  "/mynetwork",
+  "/search",
+  "/messaging",
+  "/groups",
+  "/company",
+  "/posts",
+  "/events",
+];
+
+/**
+ * Thrown when the LinkedIn ContentWindow does not enter `LoggedInState`
+ * within the configured deadline.  Almost always indicates LinkedIn is
+ * re-validating the session (fresh `/me` API call in flight) or the
+ * instance has dropped to a security-checkpoint page.
+ */
+export class LoggedInStateTimeoutError extends Error {
+  readonly waitedMs: number;
+  readonly lastReason: string;
+
+  constructor(waitedMs: number, lastReason: string) {
+    super(
+      `Timed out after ${String(waitedMs)}ms waiting for LinkedIn ContentWindow to enter LoggedInState ` +
+        `(last reason: ${lastReason})`,
+    );
+    this.name = "LoggedInStateTimeoutError";
+    this.waitedMs = waitedMs;
+    this.lastReason = lastReason;
+  }
+}
+
+/**
+ * Result shape returned by the in-page DOM probe.  `ok` is true only when
+ * the LinkedIn React/SDUI nav avatar has rendered, which is a reliable
+ * proxy for `meRawData.isSuccessful` — the canonical entry condition for
+ * `LoggedInState`.
+ *
+ * Verified live via `state-spike.e2e.test.ts` against LH 2.113.62 on
+ * `/feed/` (2026-05-06 — see research/linkedhelper/state/li-window-state-machine-20260506.md
+ * §11.1 and the spike's `dom-heuristic` recording).
+ */
+interface ProbeResult {
+  readonly ok: boolean;
+  readonly reason?: string;
+  readonly hostname?: string;
+  readonly pathname?: string;
+}
+
+/**
+ * In-page predicate.  Mirrors LH's `LoggedInState.canEnter()` via DOM
+ * heuristics on the LinkedIn target — IPC-channel access to
+ * `liWindow.checkIfInLoggedInState` is not exposed on the launcher-side
+ * `mws` dispatcher (rejected as `wrong method names for callRead` and
+ * `this.mainWindow[Q] is not a function`; see #781 spike).
+ *
+ * The "me-rendered" signal is the global-nav avatar
+ * (`img[alt][src*="profile-displayphoto-shrink"]`) — only painted once
+ * the IMiniProfile React store has hydrated, which is exactly the
+ * `LoggedInState` entry condition.
+ */
+const PROBE_SCRIPT = `(() => {
+  if (location.hostname !== 'www.linkedin.com') {
+    return { ok: false, reason: 'wrong-host', hostname: location.hostname, pathname: location.pathname };
+  }
+  const PATHS = ${JSON.stringify(LOGGED_IN_PATH_PREFIXES)};
+  if (!PATHS.some(p => location.pathname.startsWith(p))) {
+    return { ok: false, reason: 'wrong-path', hostname: location.hostname, pathname: location.pathname };
+  }
+  const me = document.querySelector('img[alt][src*="profile-displayphoto-shrink"]');
+  if (!me) {
+    return { ok: false, reason: 'me-not-rendered', hostname: location.hostname, pathname: location.pathname };
+  }
+  return { ok: true, hostname: location.hostname, pathname: location.pathname };
+})()`;
+
+export interface WaitForLoggedInStateOptions {
+  /** Deadline in ms (default `60_000`). */
+  readonly timeout?: number;
+  /** Poll interval between DOM probes in ms (default `500`). */
+  readonly pollInterval?: number;
+  /**
+   * Whether to require the `LoggedInState` finality flag.  Currently
+   * unused by the DOM heuristic — kept for API parity with LH's
+   * `checkIfInLoggedInState(isFinal)` so callers and the future IPC
+   * implementation agree on the signature.  Default `true`.
+   */
+  readonly isFinal?: boolean;
+}
+
+/**
+ * Wait until the LinkedIn ContentWindow is in `LoggedInState` (the LH
+ * predicate that gates every action).  Polls the LinkedIn target's DOM
+ * every {@link WaitForLoggedInStateOptions.pollInterval | pollInterval} ms
+ * and resolves as soon as the in-page heuristic returns `ok: true`.
+ *
+ * Use this as a pre-flight gate at the start of every long-running
+ * operation (`collect-people`, `comment-on-post`, …) so a brief LinkedIn
+ * `/me` re-validation does not surface as
+ * `Action.IncorrectContentStateError` to the caller.
+ *
+ * @throws {LoggedInStateTimeoutError} if the heuristic does not report
+ *   `ok: true` before the deadline.
+ */
+export async function waitForLoggedInState(
+  instance: InstanceService,
+  opts: WaitForLoggedInStateOptions = {},
+): Promise<void> {
+  const timeout = opts.timeout ?? DEFAULT_TIMEOUT;
+  const pollInterval = opts.pollInterval ?? DEFAULT_POLL_INTERVAL;
+  const start = Date.now();
+  const deadline = start + timeout;
+
+  let lastReason = "no-probe-yet";
+  while (Date.now() < deadline) {
+    let probe: ProbeResult;
+    try {
+      probe = await instance.evaluateLinkedIn<ProbeResult>(PROBE_SCRIPT, false);
+    } catch (err) {
+      lastReason = `probe-threw: ${err instanceof Error ? err.message : String(err)}`;
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) break;
+      await delay(Math.min(pollInterval, remaining));
+      continue;
+    }
+
+    if (probe.ok) return;
+    lastReason = probe.reason ?? "unknown";
+
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) break;
+    await delay(Math.min(pollInterval, remaining));
+  }
+
+  throw new LoggedInStateTimeoutError(Date.now() - start, lastReason);
+}
+
+/**
+ * Convenience wrapper for operations that drive the LinkedIn webview via
+ * a raw {@link CDPClient} and don't already have an
+ * {@link InstanceService} in scope (`comment-on-post`, `react-to-post`,
+ * `unfollow-from-feed`, etc.).
+ *
+ * Opens a temporary `InstanceService`, runs the gate, then disconnects.
+ * Operations that already construct an `InstanceService` (via
+ * `withInstanceDatabase`) should call {@link waitForLoggedInState}
+ * directly instead of routing through this wrapper.
+ */
+export async function gateOnLoggedInState(
+  cdpPort: number,
+  cdpHost: string,
+  allowRemote: boolean,
+  opts: WaitForLoggedInStateOptions = {},
+): Promise<void> {
+  const instance = new InstanceService(cdpPort, { host: cdpHost, allowRemote });
+  await instance.connect();
+  try {
+    await waitForLoggedInState(instance, opts);
+  } finally {
+    instance.disconnect();
+  }
+}

--- a/packages/core/src/operations/with-logged-in-state-retry.test.ts
+++ b/packages/core/src/operations/with-logged-in-state-retry.test.ts
@@ -145,7 +145,11 @@ describe("withLoggedInStateRetry", () => {
       expect(err).toBeInstanceOf(LoggedInStatePersistedError);
       const e = err as LoggedInStatePersistedError;
       expect(e.innerError).toBe(original);
-      expect(e.waitedMs).toBe(12_345);
+      // waitedMs reflects ACTUAL elapsed time across all wait attempts, not
+      // the configured deadline.  Mocked waitForLoggedInState resolves
+      // immediately, so the elapsed time is small but non-negative.
+      expect(e.waitedMs).toBeGreaterThanOrEqual(0);
+      expect(e.waitedMs).toBeLessThan(12_345);
     }
   });
 

--- a/packages/core/src/operations/with-logged-in-state-retry.test.ts
+++ b/packages/core/src/operations/with-logged-in-state-retry.test.ts
@@ -1,0 +1,235 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("./wait-for-logged-in-state.js", () => ({
+  waitForLoggedInState: vi.fn().mockResolvedValue(undefined),
+  LoggedInStateTimeoutError: class LoggedInStateTimeoutError extends Error {},
+}));
+
+vi.mock("../services/instance.js", () => ({
+  InstanceService: vi.fn(),
+}));
+
+vi.mock("../cdp/index.js", () => ({
+  resolveInstancePort: vi.fn().mockImplementation(async (port: number) => port),
+}));
+
+import { waitForLoggedInState } from "./wait-for-logged-in-state.js";
+import { InstanceService } from "../services/instance.js";
+import {
+  LoggedInStatePersistedError,
+  withLoggedInStateRetry,
+  withLoggedInStateRetryAtPort,
+} from "./with-logged-in-state-retry.js";
+
+const instance = {} as InstanceService;
+
+describe("withLoggedInStateRetry", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns op result on first success — no wait, no retry", async () => {
+    const op = vi.fn().mockResolvedValue("ok");
+
+    const result = await withLoggedInStateRetry(instance, op);
+
+    expect(result).toBe("ok");
+    expect(op).toHaveBeenCalledTimes(1);
+    expect(waitForLoggedInState).not.toHaveBeenCalled();
+  });
+
+  it("rethrows non-IncorrectContentStateError without waiting", async () => {
+    const op = vi.fn().mockRejectedValue(new Error("Some unrelated CDP failure"));
+
+    await expect(withLoggedInStateRetry(instance, op)).rejects.toThrow(
+      "Some unrelated CDP failure",
+    );
+
+    expect(op).toHaveBeenCalledTimes(1);
+    expect(waitForLoggedInState).not.toHaveBeenCalled();
+  });
+
+  it("retries once after IncorrectContentStateError and succeeds", async () => {
+    const op = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new Error("Action.IncorrectContentStateError: Incorrect web-page state"),
+      )
+      .mockResolvedValueOnce("ok");
+
+    const result = await withLoggedInStateRetry(instance, op);
+
+    expect(result).toBe("ok");
+    expect(op).toHaveBeenCalledTimes(2);
+    expect(waitForLoggedInState).toHaveBeenCalledTimes(1);
+    expect(waitForLoggedInState).toHaveBeenCalledWith(instance, { timeout: 60_000 });
+  });
+
+  it("recognises the canonical predicate-failure phrasing", async () => {
+    const op = vi
+      .fn()
+      .mockRejectedValueOnce(
+        new Error("state `li-logged-in-loading` is not `LoggedInState`"),
+      )
+      .mockResolvedValueOnce("ok");
+
+    const result = await withLoggedInStateRetry(instance, op);
+
+    expect(result).toBe("ok");
+    expect(waitForLoggedInState).toHaveBeenCalledTimes(1);
+  });
+
+  it("recognises the IncorrectStateType class name", async () => {
+    const err = new Error("state `li-logged-in-loading` is not `LoggedInState`");
+    err.name = "IncorrectStateType";
+    const op = vi.fn().mockRejectedValueOnce(err).mockResolvedValueOnce("ok");
+
+    const result = await withLoggedInStateRetry(instance, op);
+
+    expect(result).toBe("ok");
+    expect(waitForLoggedInState).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws LoggedInStatePersistedError when retries exhausted", async () => {
+    const op = vi.fn().mockRejectedValue(
+      new Error("Action.IncorrectContentStateError: Incorrect web-page state"),
+    );
+
+    await expect(
+      withLoggedInStateRetry(instance, op, { maxRetries: 1 }),
+    ).rejects.toBeInstanceOf(LoggedInStatePersistedError);
+
+    expect(op).toHaveBeenCalledTimes(2);
+    expect(waitForLoggedInState).toHaveBeenCalledTimes(1);
+  });
+
+  it("respects custom maxRetries", async () => {
+    const op = vi.fn().mockRejectedValue(
+      new Error("Action.IncorrectContentStateError"),
+    );
+
+    await expect(
+      withLoggedInStateRetry(instance, op, { maxRetries: 3 }),
+    ).rejects.toBeInstanceOf(LoggedInStatePersistedError);
+
+    expect(op).toHaveBeenCalledTimes(4);
+    expect(waitForLoggedInState).toHaveBeenCalledTimes(3);
+  });
+
+  it("forwards waitTimeout to waitForLoggedInState", async () => {
+    const op = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Action.IncorrectContentStateError"))
+      .mockResolvedValueOnce("ok");
+
+    await withLoggedInStateRetry(instance, op, { waitTimeout: 30_000 });
+
+    expect(waitForLoggedInState).toHaveBeenCalledWith(instance, { timeout: 30_000 });
+  });
+
+  it("preserves the original error inside LoggedInStatePersistedError", async () => {
+    const original = new Error("Action.IncorrectContentStateError: Incorrect web-page state");
+    const op = vi.fn().mockRejectedValue(original);
+
+    try {
+      await withLoggedInStateRetry(instance, op, { maxRetries: 1, waitTimeout: 12_345 });
+      expect.unreachable("expected LoggedInStatePersistedError");
+    } catch (err) {
+      expect(err).toBeInstanceOf(LoggedInStatePersistedError);
+      const e = err as LoggedInStatePersistedError;
+      expect(e.innerError).toBe(original);
+      expect(e.waitedMs).toBe(12_345);
+    }
+  });
+
+  it("propagates errors thrown by waitForLoggedInState", async () => {
+    const gateError = new Error("gate timed out");
+    vi.mocked(waitForLoggedInState).mockRejectedValueOnce(gateError);
+
+    const op = vi.fn().mockRejectedValueOnce(new Error("Action.IncorrectContentStateError"));
+
+    await expect(withLoggedInStateRetry(instance, op)).rejects.toBe(gateError);
+    expect(op).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("withLoggedInStateRetryAtPort", () => {
+  let connectMock: ReturnType<typeof vi.fn>;
+  let disconnectMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    connectMock = vi.fn().mockResolvedValue(undefined);
+    disconnectMock = vi.fn();
+    vi.mocked(InstanceService).mockImplementation(function () {
+      return { connect: connectMock, disconnect: disconnectMock } as unknown as InstanceService;
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns op result on first success — no InstanceService construction", async () => {
+    const op = vi.fn().mockResolvedValue("ok");
+
+    const result = await withLoggedInStateRetryAtPort(9222, "127.0.0.1", false, op);
+
+    expect(result).toBe("ok");
+    expect(op).toHaveBeenCalledTimes(1);
+    expect(InstanceService).not.toHaveBeenCalled();
+    expect(waitForLoggedInState).not.toHaveBeenCalled();
+  });
+
+  it("rethrows non-IncorrectContentStateError without constructing InstanceService", async () => {
+    const op = vi.fn().mockRejectedValue(new Error("unrelated CDP failure"));
+
+    await expect(withLoggedInStateRetryAtPort(9222, "127.0.0.1", false, op)).rejects.toThrow(
+      "unrelated CDP failure",
+    );
+    expect(InstanceService).not.toHaveBeenCalled();
+    expect(waitForLoggedInState).not.toHaveBeenCalled();
+  });
+
+  it("constructs InstanceService and waits on retry for IncorrectContentStateError", async () => {
+    const op = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("Action.IncorrectContentStateError"))
+      .mockResolvedValueOnce("ok");
+
+    const result = await withLoggedInStateRetryAtPort(9222, "127.0.0.1", false, op);
+
+    expect(result).toBe("ok");
+    expect(op).toHaveBeenCalledTimes(2);
+    expect(InstanceService).toHaveBeenCalledTimes(1);
+    expect(InstanceService).toHaveBeenCalledWith(9222, { host: "127.0.0.1", allowRemote: false });
+    expect(waitForLoggedInState).toHaveBeenCalledTimes(1);
+    expect(disconnectMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("disconnects the InstanceService even if waitForLoggedInState throws", async () => {
+    const gateError = new Error("gate timed out");
+    vi.mocked(waitForLoggedInState).mockRejectedValueOnce(gateError);
+    const op = vi.fn().mockRejectedValueOnce(new Error("Action.IncorrectContentStateError"));
+
+    await expect(withLoggedInStateRetryAtPort(9222, "127.0.0.1", false, op)).rejects.toBe(gateError);
+    expect(disconnectMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("throws LoggedInStatePersistedError when retries exhausted", async () => {
+    const op = vi.fn().mockRejectedValue(new Error("Action.IncorrectContentStateError"));
+
+    await expect(
+      withLoggedInStateRetryAtPort(9222, "127.0.0.1", false, op, { maxRetries: 1 }),
+    ).rejects.toBeInstanceOf(LoggedInStatePersistedError);
+
+    expect(op).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/core/src/operations/with-logged-in-state-retry.ts
+++ b/packages/core/src/operations/with-logged-in-state-retry.ts
@@ -1,0 +1,172 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { resolveInstancePort } from "../cdp/index.js";
+import { InstanceService } from "../services/instance.js";
+import { waitForLoggedInState } from "./wait-for-logged-in-state.js";
+
+/**
+ * Default deadline for the post-failure `waitForLoggedInState` (60s).
+ * Mirrors {@link waitForLoggedInState}'s default — the retry path waits
+ * the same amount as a fresh gate before declaring the CW genuinely stuck.
+ */
+const DEFAULT_WAIT_TIMEOUT = 60_000;
+
+/** Default retry budget (one extra attempt after the wait). */
+const DEFAULT_MAX_RETRIES = 1;
+
+/**
+ * Thrown when the LinkedHelper instance keeps surfacing
+ * `Action.IncorrectContentStateError` (or its `IncorrectStateType`/
+ * `StateIsNotFinal` siblings) after the configured retry budget — i.e.
+ * the LinkedIn ContentWindow is genuinely stuck in a non-`LoggedInState`
+ * variant (security checkpoint, persistent re-authentication, etc.).
+ *
+ * Wraps the original error as {@link innerError} so callers can inspect
+ * the underlying failure mode.
+ */
+export class LoggedInStatePersistedError extends Error {
+  readonly waitedMs: number;
+  readonly innerError: Error;
+
+  constructor(waitedMs: number, innerError: Error) {
+    super(
+      `LinkedIn ContentWindow stuck in non-LoggedInState after ${String(waitedMs)}ms — ` +
+        `${innerError.message}`,
+    );
+    this.name = "LoggedInStatePersistedError";
+    this.waitedMs = waitedMs;
+    this.innerError = innerError;
+  }
+}
+
+export interface WithLoggedInStateRetryOptions {
+  /** Maximum number of retries after the initial failure (default `1`). */
+  readonly maxRetries?: number;
+  /** Deadline for the post-failure `waitForLoggedInState` in ms (default `60_000`). */
+  readonly waitTimeout?: number;
+}
+
+/**
+ * Heuristic: does this error look like LinkedHelper's
+ * `Action.IncorrectContentStateError` (or one of its framework-level
+ * siblings, `IncorrectStateType` / `StateIsNotFinal`)?
+ *
+ * The error surfaces through CDP `Runtime.evaluate` as a plain `Error`
+ * whose `.message` carries either the literal class name or the
+ * canonical predicate-failure phrasing
+ * (`state \`<X>\` is not \`<Y>\``).  See research §5.1 / §5.2 for the
+ * underlying class hierarchy.
+ *
+ * Conservative match: we accept any of the LH-specific class names AND
+ * the predicate phrasing.  A false negative just skips the retry; a
+ * false positive surfaces as `LoggedInStatePersistedError` after one
+ * unnecessary wait — both are acceptable failure modes.
+ */
+function isIncorrectContentStateError(err: unknown): boolean {
+  if (!err) return false;
+  const message = err instanceof Error ? err.message : typeof err === "string" ? err : "";
+  const name = err instanceof Error ? err.name : "";
+
+  if (!message && !name) return false;
+  return (
+    /Action\.IncorrectContentStateError/i.test(message) ||
+    /IncorrectContentStateError/.test(name) ||
+    /IncorrectStateType/.test(message) ||
+    /IncorrectStateType/.test(name) ||
+    /StateIsNotFinal/.test(message) ||
+    /StateIsNotFinal/.test(name) ||
+    // Canonical predicate-failure phrasing emitted by the framework.
+    /state\s+`[^`]+`\s+is\s+not\s+`[^`]+`/.test(message) ||
+    /Incorrect\s+web-page\s+state/i.test(message)
+  );
+}
+
+/**
+ * Run an operation with one transparent retry when the underlying
+ * LinkedHelper action fails with `Action.IncorrectContentStateError`.
+ *
+ * Flow:
+ * 1. Run `op()`.  Return on success.
+ * 2. On failure, classify: not an `IncorrectContentStateError` → rethrow.
+ * 3. Out of retry budget → wrap as {@link LoggedInStatePersistedError} and rethrow.
+ * 4. Wait for `LoggedInState` (up to {@link WithLoggedInStateRetryOptions.waitTimeout}).
+ *    If the wait itself times out, the resulting `LoggedInStateTimeoutError`
+ *    propagates — the caller sees the gate failure, not the retry failure.
+ * 5. Loop.
+ *
+ * Mirrors LH's own `CampaignController.ensureCwIsInLoggedInState`
+ * pattern (research §10) at a coarser granularity: we don't have the
+ * launcher's renavigation budget, so the wrapper relies on LinkedIn
+ * settling within `waitTimeout` rather than forcing a fresh navigation.
+ *
+ * @throws {LoggedInStatePersistedError} when retries are exhausted and
+ *   the same `IncorrectContentStateError` is still surfacing.
+ */
+export async function withLoggedInStateRetry<T>(
+  instance: InstanceService,
+  op: () => Promise<T>,
+  opts: WithLoggedInStateRetryOptions = {},
+): Promise<T> {
+  const maxRetries = opts.maxRetries ?? DEFAULT_MAX_RETRIES;
+  const waitTimeout = opts.waitTimeout ?? DEFAULT_WAIT_TIMEOUT;
+
+  let attempt = 0;
+  while (true) {
+    try {
+      return await op();
+    } catch (err) {
+      if (!isIncorrectContentStateError(err)) {
+        throw err;
+      }
+      if (attempt >= maxRetries) {
+        const inner = err instanceof Error ? err : new Error(String(err));
+        throw new LoggedInStatePersistedError(waitTimeout, inner);
+      }
+      attempt++;
+      await waitForLoggedInState(instance, { timeout: waitTimeout });
+    }
+  }
+}
+
+/**
+ * Convenience wrapper for CLI/MCP handlers that don't already have an
+ * {@link InstanceService} in scope.  Behaves identically to
+ * {@link withLoggedInStateRetry} but lazily constructs an
+ * `InstanceService` on the failure path only — the happy path issues
+ * zero extra CDP connections.
+ */
+export async function withLoggedInStateRetryAtPort<T>(
+  cdpPort: number | undefined,
+  cdpHost: string,
+  allowRemote: boolean,
+  op: () => Promise<T>,
+  opts: WithLoggedInStateRetryOptions = {},
+): Promise<T> {
+  const maxRetries = opts.maxRetries ?? DEFAULT_MAX_RETRIES;
+  const waitTimeout = opts.waitTimeout ?? DEFAULT_WAIT_TIMEOUT;
+
+  let attempt = 0;
+  while (true) {
+    try {
+      return await op();
+    } catch (err) {
+      if (!isIncorrectContentStateError(err)) {
+        throw err;
+      }
+      if (attempt >= maxRetries) {
+        const inner = err instanceof Error ? err : new Error(String(err));
+        throw new LoggedInStatePersistedError(waitTimeout, inner);
+      }
+      attempt++;
+      const resolvedPort = await resolveInstancePort(cdpPort, cdpHost);
+      const instance = new InstanceService(resolvedPort, { host: cdpHost, allowRemote });
+      await instance.connect();
+      try {
+        await waitForLoggedInState(instance, { timeout: waitTimeout });
+      } finally {
+        instance.disconnect();
+      }
+    }
+  }
+}

--- a/packages/core/src/operations/with-logged-in-state-retry.ts
+++ b/packages/core/src/operations/with-logged-in-state-retry.ts
@@ -2,6 +2,7 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import { resolveInstancePort } from "../cdp/index.js";
+import { ServiceError } from "../services/errors.js";
 import { InstanceService } from "../services/instance.js";
 import { waitForLoggedInState } from "./wait-for-logged-in-state.js";
 
@@ -25,7 +26,7 @@ const DEFAULT_MAX_RETRIES = 1;
  * Wraps the original error as {@link innerError} so callers can inspect
  * the underlying failure mode.
  */
-export class LoggedInStatePersistedError extends Error {
+export class LoggedInStatePersistedError extends ServiceError {
   readonly waitedMs: number;
   readonly innerError: Error;
 
@@ -112,6 +113,7 @@ export async function withLoggedInStateRetry<T>(
   const waitTimeout = opts.waitTimeout ?? DEFAULT_WAIT_TIMEOUT;
 
   let attempt = 0;
+  let totalWaitedMs = 0;
   while (true) {
     try {
       return await op();
@@ -121,10 +123,15 @@ export async function withLoggedInStateRetry<T>(
       }
       if (attempt >= maxRetries) {
         const inner = err instanceof Error ? err : new Error(String(err));
-        throw new LoggedInStatePersistedError(waitTimeout, inner);
+        throw new LoggedInStatePersistedError(totalWaitedMs, inner);
       }
       attempt++;
-      await waitForLoggedInState(instance, { timeout: waitTimeout });
+      const waitStart = Date.now();
+      try {
+        await waitForLoggedInState(instance, { timeout: waitTimeout });
+      } finally {
+        totalWaitedMs += Date.now() - waitStart;
+      }
     }
   }
 }
@@ -147,6 +154,7 @@ export async function withLoggedInStateRetryAtPort<T>(
   const waitTimeout = opts.waitTimeout ?? DEFAULT_WAIT_TIMEOUT;
 
   let attempt = 0;
+  let totalWaitedMs = 0;
   while (true) {
     try {
       return await op();
@@ -156,16 +164,21 @@ export async function withLoggedInStateRetryAtPort<T>(
       }
       if (attempt >= maxRetries) {
         const inner = err instanceof Error ? err : new Error(String(err));
-        throw new LoggedInStatePersistedError(waitTimeout, inner);
+        throw new LoggedInStatePersistedError(totalWaitedMs, inner);
       }
       attempt++;
-      const resolvedPort = await resolveInstancePort(cdpPort, cdpHost);
-      const instance = new InstanceService(resolvedPort, { host: cdpHost, allowRemote });
-      await instance.connect();
+      const waitStart = Date.now();
       try {
-        await waitForLoggedInState(instance, { timeout: waitTimeout });
+        const resolvedPort = await resolveInstancePort(cdpPort, cdpHost);
+        const instance = new InstanceService(resolvedPort, { host: cdpHost, allowRemote });
+        await instance.connect();
+        try {
+          await waitForLoggedInState(instance, { timeout: waitTimeout });
+        } finally {
+          instance.disconnect();
+        }
       } finally {
-        instance.disconnect();
+        totalWaitedMs += Date.now() - waitStart;
       }
     }
   }

--- a/packages/core/src/services/instance.ts
+++ b/packages/core/src/services/instance.ts
@@ -257,6 +257,26 @@ export class InstanceService {
   }
 
   /**
+   * Evaluate a JavaScript expression against the LinkedIn webview.
+   *
+   * Targets the linkedin.com page (not the LinkedHelper UI), so the script
+   * sees `document`, `location`, etc. of the LinkedIn React/SDUI tree.
+   * Used by {@link waitForLoggedInState} (DOM heuristic for the LH
+   * `LoggedInState` predicate) and any future direct-LinkedIn-DOM probes.
+   *
+   * @param expression  JavaScript source to evaluate.
+   * @param awaitPromise Whether to await a Promise result (default `true`).
+   * @throws {ServiceError} if the LinkedIn client is not connected.
+   */
+  async evaluateLinkedIn<T = unknown>(
+    expression: string,
+    awaitPromise = true,
+  ): Promise<T> {
+    const client = this.ensureLinkedInClient();
+    return client.evaluate<T>(expression, awaitPromise);
+  }
+
+  /**
    * Navigate the LinkedIn webview to the given URL.
    *
    * Enables the CDP Page domain so that `Page.loadEventFired` events

--- a/packages/e2e/src/state-spike.e2e.test.ts
+++ b/packages/e2e/src/state-spike.e2e.test.ts
@@ -1,0 +1,427 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+/**
+ * Spike: Verify LinkedHelper `liWindow` state IPC channel (#781)
+ *
+ * Probes whether `mws.callRead`/`callWrite`/`get` round-trip correctly to
+ * the LinkedIn ContentWindow state-machine helpers from outside the LH
+ * process.  See research/linkedhelper/state/li-window-state-machine-20260506.md
+ * §12 for the verification gap this spike closes.
+ *
+ * Probes (all run via instance.evaluateUI):
+ * - `mws.callRead('liWindow', 'checkIfInLoggedInState', true)` (topic+method form)
+ * - `mws.callRead('liWindow.checkIfInLoggedInState', true)`    (dotted form)
+ * - `mws.get('liWindow', 'state[extracted]')`                  (state snapshot)
+ * - `mws.callWrite('liWindow', 'waitLoggedInState', true, 5000)`
+ *
+ * Goal: prove the channel works (or doesn't) before relying on it in the
+ * `waitForLoggedInState` helper.  Records findings to console for inspection.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import {
+  describeE2E,
+  forceStopInstance,
+  launchApp,
+  quitApp,
+  resolveAccountId,
+  retryAsync,
+} from "@lhremote/core/testing";
+import {
+  type AppService,
+  CDPClient,
+  discoverInstancePort,
+  discoverTargets,
+  InstanceService,
+  LauncherService,
+  startInstanceWithRecovery,
+} from "@lhremote/core";
+
+/** LinkedIn feed URL — the canonical logged-in URL where checkIfInLoggedInState should return true. */
+const FEED_URL = "https://www.linkedin.com/feed/";
+
+/**
+ * Evaluate an arbitrary expression on the UI target and return the
+ * result or error.
+ */
+async function probeExpression<T = unknown>(
+  instance: InstanceService,
+  expression: string,
+): Promise<{ ok: true; value: T } | { ok: false; error: string }> {
+  try {
+    const value = await instance.evaluateUI<T>(expression);
+    return { ok: true, value };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return { ok: false, error: msg };
+  }
+}
+
+const findings: Array<{ section: string; test: string; result: unknown }> = [];
+
+function recordFinding(section: string, test: string, result: unknown): void {
+  findings.push({ section, test, result });
+  console.log(`\n=== [${section}] ${test} ===`);
+  console.log(JSON.stringify(result, null, 2));
+}
+
+describeE2E("spike: liWindow state IPC channel (#781)", () => {
+  let app: AppService;
+  let port: number;
+  let accountId: number;
+  let instance: InstanceService;
+  let instancePort: number;
+
+  beforeAll(async () => {
+    const launched = await launchApp();
+    app = launched.app;
+    port = launched.port;
+
+    accountId = await resolveAccountId(port);
+
+    const launcher = new LauncherService(port);
+    await retryAsync(() => launcher.connect(), { retries: 3, delay: 1_000 });
+    await startInstanceWithRecovery(launcher, accountId, port);
+    launcher.disconnect();
+
+    const discoveredInstancePort = await discoverInstancePort(port);
+    if (discoveredInstancePort === null) {
+      throw new Error(`No instance CDP port discovered from launcher port ${String(port)}`);
+    }
+    instancePort = discoveredInstancePort;
+
+    instance = new InstanceService(instancePort);
+    await instance.connect();
+
+    // Navigate to feed and give LH a moment to settle into LoggedInState
+    // before any probe — without this, the first probe may catch the CW in
+    // LoggedInLoadingState and report `false` for an unrelated reason.
+    await instance.navigateLinkedIn(FEED_URL);
+    await new Promise((resolve) => setTimeout(resolve, 8_000));
+  }, 180_000);
+
+  afterAll(async () => {
+    instance?.disconnect();
+
+    const launcher = new LauncherService(port);
+    try {
+      await launcher.connect();
+      await forceStopInstance(launcher, accountId, port);
+    } catch {
+      // Best-effort cleanup
+    } finally {
+      launcher.disconnect();
+    }
+
+    await quitApp(app);
+
+    console.log("\n\n====== STATE SPIKE FINDINGS SUMMARY ======");
+    console.log(JSON.stringify(findings, null, 2));
+    console.log("==========================================\n");
+  }, 60_000);
+
+  describe("1. checkIfInLoggedInState — invocation forms", () => {
+    it("probes mws.callRead('liWindow', 'checkIfInLoggedInState', true) — topic+method form", async () => {
+      const result = await probeExpression(instance, `(async () => {
+        const mws = window.mainWindowService;
+        if (!mws) return { status: 'no_mws' };
+        try {
+          const r = await mws.callRead('liWindow', 'checkIfInLoggedInState', true);
+          return { status: 'ok', resultType: typeof r, value: r };
+        } catch (e) {
+          return { status: 'error', error: String(e && e.message || e) };
+        }
+      })()`);
+      recordFinding("checkIfInLoggedInState", "callRead('liWindow','checkIfInLoggedInState',true)", result);
+      expect(result.ok).toBe(true);
+    }, 30_000);
+
+    it("probes mws.callRead('liWindow.checkIfInLoggedInState', true) — dotted form", async () => {
+      const result = await probeExpression(instance, `(async () => {
+        const mws = window.mainWindowService;
+        if (!mws) return { status: 'no_mws' };
+        try {
+          const r = await mws.callRead('liWindow.checkIfInLoggedInState', true);
+          return { status: 'ok', resultType: typeof r, value: r };
+        } catch (e) {
+          return { status: 'error', error: String(e && e.message || e) };
+        }
+      })()`);
+      recordFinding("checkIfInLoggedInState", "callRead('liWindow.checkIfInLoggedInState',true)", result);
+      expect(result.ok).toBe(true);
+    }, 30_000);
+
+    it("probes mws.callRead('liWindow', 'checkIfInLoggedInState', false) — accept loading variants", async () => {
+      const result = await probeExpression(instance, `(async () => {
+        const mws = window.mainWindowService;
+        if (!mws) return { status: 'no_mws' };
+        try {
+          const r = await mws.callRead('liWindow', 'checkIfInLoggedInState', false);
+          return { status: 'ok', resultType: typeof r, value: r };
+        } catch (e) {
+          return { status: 'error', error: String(e && e.message || e) };
+        }
+      })()`);
+      recordFinding("checkIfInLoggedInState", "callRead('liWindow','checkIfInLoggedInState',false)", result);
+      expect(result.ok).toBe(true);
+    }, 30_000);
+
+    it("probes mws.callRead('liWindow', 'checkIfInLoggedInState') — no isFinal arg", async () => {
+      const result = await probeExpression(instance, `(async () => {
+        const mws = window.mainWindowService;
+        if (!mws) return { status: 'no_mws' };
+        try {
+          const r = await mws.callRead('liWindow', 'checkIfInLoggedInState');
+          return { status: 'ok', resultType: typeof r, value: r };
+        } catch (e) {
+          return { status: 'error', error: String(e && e.message || e) };
+        }
+      })()`);
+      recordFinding("checkIfInLoggedInState", "callRead('liWindow','checkIfInLoggedInState')", result);
+      expect(result.ok).toBe(true);
+    }, 30_000);
+  });
+
+  describe("2. state[extracted] getter", () => {
+    it("probes mws.get('liWindow', 'state[extracted]') — topic+key form", async () => {
+      const result = await probeExpression(instance, `(async () => {
+        const mws = window.mainWindowService;
+        if (!mws) return { status: 'no_mws' };
+        try {
+          const r = await mws.get('liWindow', 'state[extracted]');
+          return {
+            status: 'ok',
+            resultType: typeof r,
+            keys: r && typeof r === 'object' ? Object.keys(r).slice(0, 30) : null,
+            preview: r && typeof r === 'object' ? JSON.parse(JSON.stringify(r)) : r,
+          };
+        } catch (e) {
+          return { status: 'error', error: String(e && e.message || e) };
+        }
+      })()`);
+      recordFinding("state[extracted]", "get('liWindow','state[extracted]')", result);
+      expect(result.ok).toBe(true);
+    }, 30_000);
+
+    it("probes mws.get('liWindow.state[extracted]') — dotted form", async () => {
+      const result = await probeExpression(instance, `(async () => {
+        const mws = window.mainWindowService;
+        if (!mws) return { status: 'no_mws' };
+        try {
+          const r = await mws.get('liWindow.state[extracted]');
+          return {
+            status: 'ok',
+            resultType: typeof r,
+            keys: r && typeof r === 'object' ? Object.keys(r).slice(0, 30) : null,
+          };
+        } catch (e) {
+          return { status: 'error', error: String(e && e.message || e) };
+        }
+      })()`);
+      recordFinding("state[extracted]", "get('liWindow.state[extracted]')", result);
+      expect(result.ok).toBe(true);
+    }, 30_000);
+
+    it("probes mws.get('liWindow', 'state') — alternate key", async () => {
+      const result = await probeExpression(instance, `(async () => {
+        const mws = window.mainWindowService;
+        if (!mws) return { status: 'no_mws' };
+        try {
+          const r = await mws.get('liWindow', 'state');
+          return {
+            status: 'ok',
+            resultType: typeof r,
+            keys: r && typeof r === 'object' ? Object.keys(r).slice(0, 30) : null,
+          };
+        } catch (e) {
+          return { status: 'error', error: String(e && e.message || e) };
+        }
+      })()`);
+      recordFinding("state[extracted]", "get('liWindow','state')", result);
+      expect(result.ok).toBe(true);
+    }, 30_000);
+  });
+
+  describe("3. waitLoggedInState (awaitable)", () => {
+    it("probes mws.callWrite('liWindow', 'waitLoggedInState', true, 5000)", async () => {
+      const result = await probeExpression(instance, `(async () => {
+        const mws = window.mainWindowService;
+        if (!mws) return { status: 'no_mws' };
+        const start = Date.now();
+        try {
+          const r = await mws.callWrite('liWindow', 'waitLoggedInState', true, 5000);
+          return { status: 'ok', resultType: typeof r, value: r, elapsedMs: Date.now() - start };
+        } catch (e) {
+          return { status: 'error', error: String(e && e.message || e), elapsedMs: Date.now() - start };
+        }
+      })()`);
+      recordFinding("waitLoggedInState", "callWrite('liWindow','waitLoggedInState',true,5000)", result);
+      expect(result.ok).toBe(true);
+    }, 30_000);
+
+    it("probes mws.callRead('liWindow', 'waitLoggedInState', true, 5000)", async () => {
+      const result = await probeExpression(instance, `(async () => {
+        const mws = window.mainWindowService;
+        if (!mws) return { status: 'no_mws' };
+        const start = Date.now();
+        try {
+          const r = await mws.callRead('liWindow', 'waitLoggedInState', true, 5000);
+          return { status: 'ok', resultType: typeof r, value: r, elapsedMs: Date.now() - start };
+        } catch (e) {
+          return { status: 'error', error: String(e && e.message || e), elapsedMs: Date.now() - start };
+        }
+      })()`);
+      recordFinding("waitLoggedInState", "callRead('liWindow','waitLoggedInState',true,5000)", result);
+      expect(result.ok).toBe(true);
+    }, 30_000);
+  });
+
+  describe("4. callRaw + alternate dispatchers (escape hatches)", () => {
+    it("probes mws.callRaw('liWindow.checkIfInLoggedInState', true) — dotted form", async () => {
+      const result = await probeExpression(instance, `(async () => {
+        const mws = window.mainWindowService;
+        if (!mws) return { status: 'no_mws' };
+        if (typeof mws.callRaw !== 'function') return { status: 'callRaw_absent' };
+        try {
+          const r = await mws.callRaw('liWindow.checkIfInLoggedInState', true);
+          return { status: 'ok', resultType: typeof r, value: r };
+        } catch (e) {
+          return { status: 'error', error: String(e && e.message || e) };
+        }
+      })()`);
+      recordFinding("callRaw", "callRaw('liWindow.checkIfInLoggedInState',true)", result);
+      expect(result.ok).toBe(true);
+    }, 30_000);
+
+    it("probes mws.callRaw('liWindow', 'checkIfInLoggedInState', true) — topic+method form", async () => {
+      const result = await probeExpression(instance, `(async () => {
+        const mws = window.mainWindowService;
+        if (!mws) return { status: 'no_mws' };
+        if (typeof mws.callRaw !== 'function') return { status: 'callRaw_absent' };
+        try {
+          const r = await mws.callRaw('liWindow', 'checkIfInLoggedInState', true);
+          return { status: 'ok', resultType: typeof r, value: r };
+        } catch (e) {
+          return { status: 'error', error: String(e && e.message || e) };
+        }
+      })()`);
+      recordFinding("callRaw", "callRaw('liWindow','checkIfInLoggedInState',true)", result);
+      expect(result.ok).toBe(true);
+    }, 30_000);
+
+    it("probes mws.getContentWindow() shape (names-only)", async () => {
+      const result = await probeExpression(instance, `(async () => {
+        const mws = window.mainWindowService;
+        if (!mws) return { status: 'no_mws' };
+        if (typeof mws.getContentWindow !== 'function') return { status: 'getContentWindow_absent' };
+        try {
+          const cw = await mws.getContentWindow();
+          if (!cw) return { status: 'ok', value: null };
+          return {
+            status: 'ok',
+            resultType: typeof cw,
+            ctor: cw.constructor && cw.constructor.name,
+            ownKeys: Object.keys(cw).slice(0, 30),
+            // typeof of candidate methods — never read values from a remote-proxy.
+            checkIfInLoggedInStateType: typeof cw.checkIfInLoggedInState,
+            waitLoggedInStateType: typeof cw.waitLoggedInState,
+            stateType: typeof cw.state,
+            isFinalType: typeof cw.isFinal,
+          };
+        } catch (e) {
+          return { status: 'error', error: String(e && e.message || e) };
+        }
+      })()`);
+      recordFinding("getContentWindow", "getContentWindow() shape", result);
+      expect(result.ok).toBe(true);
+    }, 30_000);
+
+    it("probes window.mainWindowService.mainWindow.contentWindow shape (names-only)", async () => {
+      const result = await probeExpression(instance, `(async () => {
+        const mws = window.mainWindowService;
+        if (!mws) return { status: 'no_mws' };
+        const mw = mws.mainWindow;
+        if (!mw) return { status: 'mainWindow_absent' };
+        const cw = mw.contentWindow;
+        if (cw === undefined) return { status: 'contentWindow_undefined' };
+        try {
+          // names-only — DO NOT read values, see V2113-MWS-TYPED-CALL.md note
+          // about @electron/remote proxy values causing main-process crashes.
+          return {
+            status: 'ok',
+            resultType: typeof cw,
+            isNull: cw === null,
+            ctor: cw && cw.constructor && cw.constructor.name,
+            ownKeys: cw ? Object.keys(cw).slice(0, 30) : null,
+          };
+        } catch (e) {
+          return { status: 'error', error: String(e && e.message || e) };
+        }
+      })()`);
+      recordFinding("contentWindow", "mws.mainWindow.contentWindow shape", result);
+      expect(result.ok).toBe(true);
+    }, 30_000);
+
+    it("verifies DOM heuristic on LinkedIn target — research §11.1 fallback", async () => {
+      // The IPC channel above is closed for the liWindow topic — fall back
+      // to the DOM heuristic recommended in research §11.1.  Open a
+      // dedicated CDPClient on the LinkedIn target (the InstanceService's
+      // evaluateUI runs against the Electron renderer, not linkedin.com).
+      const targets = await discoverTargets(instancePort);
+      const linkedInTarget = targets.find(
+        (t) => t.type === "page" && t.url.includes("linkedin.com"),
+      );
+      if (!linkedInTarget) throw new Error("No linkedin.com target found");
+
+      const liClient = new CDPClient(instancePort);
+      await liClient.connect(linkedInTarget.id);
+      try {
+        const result = await liClient.evaluate<unknown>(`(() => {
+          const out = { hostname: location.hostname, pathname: location.pathname };
+          const PATHS = ['/feed', '/in/', '/mynetwork', '/search', '/messaging', '/groups', '/company', '/posts', '/events'];
+          out.pathMatch = PATHS.some(p => location.pathname.startsWith(p));
+          // Probe several plausible "me-rendered" selectors: the global nav
+          // avatar, the profile-displayphoto image, and a generic header.
+          out.hasGlobalNavAvatar = !!document.querySelector('img[data-test-app-aware-link]');
+          out.hasProfileShrinkImg = !!document.querySelector('img[alt][src*="profile-displayphoto-shrink"]');
+          out.hasGlobalNav = !!document.querySelector('nav.global-nav, [data-test-global-nav]');
+          out.hasGlobalNavMeButton = !!document.querySelector('button[id*="global-nav-typeahead"], li-icon[type="me-icon"], [data-control-name="nav.settings"]');
+          out.hasMain = !!document.querySelector('main');
+          out.hasGlobalNavSearch = !!document.querySelector('.global-nav__search, input[role="combobox"][placeholder*="Search"]');
+          // Capture title for cross-checking.
+          out.title = document.title;
+          return out;
+        })()`);
+        recordFinding("dom-heuristic", "LinkedIn target DOM probes", { ok: true, value: result });
+      } finally {
+        liClient.disconnect();
+      }
+    }, 30_000);
+
+    it("enumerates dispatcher methods + topic candidates on mws prototype", async () => {
+      const result = await probeExpression(instance, `(async () => {
+        const mws = window.mainWindowService;
+        if (!mws) return { status: 'no_mws' };
+        const protoNames = [];
+        try {
+          let p = Object.getPrototypeOf(mws);
+          let depth = 0;
+          while (p && p !== Object.prototype && depth < 5) {
+            protoNames.push({
+              ctor: p.constructor && p.constructor.name,
+              names: Object.getOwnPropertyNames(p).slice(0, 100),
+            });
+            p = Object.getPrototypeOf(p);
+            depth++;
+          }
+        } catch (e) {
+          return { status: 'error', error: String(e && e.message || e) };
+        }
+        return { status: 'ok', protoNames, ownKeys: Object.keys(mws) };
+      })()`);
+      recordFinding("dispatcher-shape", "mws prototype enumeration", result);
+      expect(result.ok).toBe(true);
+    }, 30_000);
+  });
+});

--- a/packages/e2e/src/state-spike.e2e.test.ts
+++ b/packages/e2e/src/state-spike.e2e.test.ts
@@ -377,7 +377,14 @@ describeE2E("spike: liWindow state IPC channel (#781)", () => {
       const liClient = new CDPClient(instancePort);
       await liClient.connect(linkedInTarget.id);
       try {
-        const result = await liClient.evaluate<unknown>(`(() => {
+        const result = await liClient.evaluate<{
+          hostname: string;
+          pathname: string;
+          pathMatch: boolean;
+          hasProfileShrinkImg: boolean;
+          hasMain: boolean;
+          title: string;
+        }>(`(() => {
           const out = { hostname: location.hostname, pathname: location.pathname };
           const PATHS = ['/feed', '/in/', '/mynetwork', '/search', '/messaging', '/groups', '/company', '/posts', '/events'];
           out.pathMatch = PATHS.some(p => location.pathname.startsWith(p));
@@ -394,6 +401,16 @@ describeE2E("spike: liWindow state IPC channel (#781)", () => {
           return out;
         })()`);
         recordFinding("dom-heuristic", "LinkedIn target DOM probes", { ok: true, value: result });
+
+        // Regression assertions: any future LinkedIn rewrite that breaks one
+        // of these signals must surface here so the helper's predicate can
+        // be re-tuned before `waitForLoggedInState` falls behind.
+        expect(result.hostname, "hostname must match LH LoggedInState.canEnter").toBe("www.linkedin.com");
+        expect(result.pathMatch, "pathname must match the LoggedInState path-prefix set").toBe(true);
+        expect(
+          result.hasProfileShrinkImg,
+          "profile-displayphoto-shrink avatar must render once meRawData hydrates — this is the helper's primary signal",
+        ).toBe(true);
       } finally {
         liClient.disconnect();
       }

--- a/packages/mcp/src/tools/collect-people.ts
+++ b/packages/mcp/src/tools/collect-people.ts
@@ -6,6 +6,7 @@ import {
   CollectionBusyError,
   CollectionError,
   collectPeople,
+  withLoggedInStateRetryAtPort,
 } from "@lhremote/core";
 import { z } from "zod";
 import { cdpConnectionSchema, mcpCatchAll, mcpError, mcpSuccess } from "../helpers.js";
@@ -51,7 +52,12 @@ export function registerCollectPeople(server: McpServer): void {
     },
     async ({ campaignId, sourceUrl, limit, maxPages, pageSize, sourceType, cdpPort, cdpHost, allowRemote }) => {
       try {
-        const result = await collectPeople({
+        const result = await withLoggedInStateRetryAtPort(
+          cdpPort,
+          cdpHost ?? "127.0.0.1",
+          allowRemote ?? false,
+          () =>
+            collectPeople({
           campaignId,
           sourceUrl,
           ...(limit !== undefined && { limit }),
@@ -61,7 +67,8 @@ export function registerCollectPeople(server: McpServer): void {
           cdpPort,
           ...(cdpHost !== undefined && { cdpHost }),
           ...(allowRemote !== undefined && { allowRemote }),
-        });
+          }),
+        );
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         if (error instanceof CollectionBusyError) {

--- a/packages/mcp/src/tools/comment-on-post.ts
+++ b/packages/mcp/src/tools/comment-on-post.ts
@@ -2,7 +2,7 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { commentOnPost } from "@lhremote/core";
+import { commentOnPost, withLoggedInStateRetryAtPort } from "@lhremote/core";
 import { z } from "zod";
 import { cdpConnectionSchema, mcpCatchAll, mcpSuccess } from "../helpers.js";
 
@@ -51,7 +51,12 @@ export function registerCommentOnPost(server: McpServer): void {
     },
     async ({ postUrl, text, parentCommentUrn, mentions, dryRun, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await commentOnPost({ postUrl, text, parentCommentUrn, mentions, dryRun, cdpPort, cdpHost, allowRemote, accountId });
+        const result = await withLoggedInStateRetryAtPort(
+          cdpPort,
+          cdpHost ?? "127.0.0.1",
+          allowRemote ?? false,
+          () => commentOnPost({ postUrl, text, parentCommentUrn, mentions, dryRun, cdpPort, cdpHost, allowRemote, accountId }),
+        );
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         return mcpCatchAll(error, "Failed to comment on post");

--- a/packages/mcp/src/tools/comment-on-post.ts
+++ b/packages/mcp/src/tools/comment-on-post.ts
@@ -2,7 +2,10 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { commentOnPost, withLoggedInStateRetryAtPort } from "@lhremote/core";
+import {
+  commentOnPost,
+  withLoggedInStateRetryAtPort,
+} from "@lhremote/core";
 import { z } from "zod";
 import { cdpConnectionSchema, mcpCatchAll, mcpSuccess } from "../helpers.js";
 

--- a/packages/mcp/src/tools/dismiss-feed-post.ts
+++ b/packages/mcp/src/tools/dismiss-feed-post.ts
@@ -2,7 +2,9 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dismissFeedPost } from "@lhremote/core";
+import { dismissFeedPost ,
+  withLoggedInStateRetryAtPort,
+} from "@lhremote/core";
 import { z } from "zod";
 import { cdpConnectionSchema, mcpCatchAll, mcpSuccess } from "../helpers.js";
 
@@ -18,13 +20,19 @@ export function registerDismissFeedPost(server: McpServer): void {
     },
     async ({ feedIndex, dryRun, cdpPort, cdpHost, allowRemote }) => {
       try {
-        const result = await dismissFeedPost({
+        const result = await withLoggedInStateRetryAtPort(
+          cdpPort,
+          cdpHost ?? "127.0.0.1",
+          allowRemote ?? false,
+          () =>
+            dismissFeedPost({
           feedIndex,
           cdpPort,
           cdpHost,
           allowRemote,
           dryRun,
-        });
+          }),
+        );
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         return mcpCatchAll(error, "Failed to dismiss feed post");

--- a/packages/mcp/src/tools/dismiss-feed-post.ts
+++ b/packages/mcp/src/tools/dismiss-feed-post.ts
@@ -2,7 +2,8 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { dismissFeedPost ,
+import {
+  dismissFeedPost,
   withLoggedInStateRetryAtPort,
 } from "@lhremote/core";
 import { z } from "zod";

--- a/packages/mcp/src/tools/endorse-skills.ts
+++ b/packages/mcp/src/tools/endorse-skills.ts
@@ -2,7 +2,9 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { endorseSkills } from "@lhremote/core";
+import { endorseSkills ,
+  withLoggedInStateRetryAtPort,
+} from "@lhremote/core";
 import { z } from "zod";
 import { cdpConnectionSchema, mcpCatchAll, mcpError, mcpSuccess } from "../helpers.js";
 
@@ -54,9 +56,15 @@ export function registerEndorseSkills(server: McpServer): void {
       }
 
       try {
-        const result = await endorseSkills({
+        const result = await withLoggedInStateRetryAtPort(
+          cdpPort,
+          cdpHost ?? "127.0.0.1",
+          allowRemote ?? false,
+          () =>
+            endorseSkills({
           personId, url, skillNames, limit, skipIfNotEndorsable, keepCampaign, timeout, cdpPort, cdpHost, allowRemote, accountId,
-        });
+          }),
+        );
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         return mcpCatchAll(error, "Failed to endorse skills");

--- a/packages/mcp/src/tools/endorse-skills.ts
+++ b/packages/mcp/src/tools/endorse-skills.ts
@@ -2,7 +2,8 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { endorseSkills ,
+import {
+  endorseSkills,
   withLoggedInStateRetryAtPort,
 } from "@lhremote/core";
 import { z } from "zod";

--- a/packages/mcp/src/tools/follow-person.ts
+++ b/packages/mcp/src/tools/follow-person.ts
@@ -2,7 +2,8 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { followPerson ,
+import {
+  followPerson,
   withLoggedInStateRetryAtPort,
 } from "@lhremote/core";
 import { z } from "zod";

--- a/packages/mcp/src/tools/follow-person.ts
+++ b/packages/mcp/src/tools/follow-person.ts
@@ -2,7 +2,9 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { followPerson } from "@lhremote/core";
+import { followPerson ,
+  withLoggedInStateRetryAtPort,
+} from "@lhremote/core";
 import { z } from "zod";
 import { cdpConnectionSchema, mcpCatchAll, mcpError, mcpSuccess } from "../helpers.js";
 
@@ -48,9 +50,15 @@ export function registerFollowPerson(server: McpServer): void {
       }
 
       try {
-        const result = await followPerson({
+        const result = await withLoggedInStateRetryAtPort(
+          cdpPort,
+          cdpHost ?? "127.0.0.1",
+          allowRemote ?? false,
+          () =>
+            followPerson({
           personId, url, mode, skipIfUnfollowable, keepCampaign, timeout, cdpPort, cdpHost, allowRemote, accountId,
-        });
+          }),
+        );
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         return mcpCatchAll(error, "Failed to follow person");

--- a/packages/mcp/src/tools/get-feed.ts
+++ b/packages/mcp/src/tools/get-feed.ts
@@ -2,7 +2,9 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { getFeed } from "@lhremote/core";
+import { getFeed ,
+  withLoggedInStateRetryAtPort,
+} from "@lhremote/core";
 import { z } from "zod";
 import { cdpConnectionSchema, mcpCatchAll, mcpSuccess } from "../helpers.js";
 
@@ -29,13 +31,19 @@ export function registerGetFeed(server: McpServer): void {
     },
     async ({ count, cursor, cdpPort, cdpHost, allowRemote }) => {
       try {
-        const result = await getFeed({
+        const result = await withLoggedInStateRetryAtPort(
+          cdpPort,
+          cdpHost ?? "127.0.0.1",
+          allowRemote ?? false,
+          () =>
+            getFeed({
           count,
           cursor,
           cdpPort,
           cdpHost,
           allowRemote,
-        });
+          }),
+        );
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         return mcpCatchAll(error, "Failed to get feed");

--- a/packages/mcp/src/tools/get-feed.ts
+++ b/packages/mcp/src/tools/get-feed.ts
@@ -2,7 +2,8 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { getFeed ,
+import {
+  getFeed,
   withLoggedInStateRetryAtPort,
 } from "@lhremote/core";
 import { z } from "zod";

--- a/packages/mcp/src/tools/hide-feed-author-profile.ts
+++ b/packages/mcp/src/tools/hide-feed-author-profile.ts
@@ -2,7 +2,8 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { hideFeedAuthorProfile ,
+import {
+  hideFeedAuthorProfile,
   withLoggedInStateRetryAtPort,
 } from "@lhremote/core";
 import { z } from "zod";

--- a/packages/mcp/src/tools/hide-feed-author-profile.ts
+++ b/packages/mcp/src/tools/hide-feed-author-profile.ts
@@ -2,7 +2,9 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { hideFeedAuthorProfile } from "@lhremote/core";
+import { hideFeedAuthorProfile ,
+  withLoggedInStateRetryAtPort,
+} from "@lhremote/core";
 import { z } from "zod";
 import { cdpConnectionSchema, mcpCatchAll, mcpSuccess } from "../helpers.js";
 
@@ -29,13 +31,19 @@ export function registerHideFeedAuthorProfile(server: McpServer): void {
     },
     async ({ profileUrl, dryRun, cdpPort, cdpHost, allowRemote }) => {
       try {
-        const result = await hideFeedAuthorProfile({
+        const result = await withLoggedInStateRetryAtPort(
+          cdpPort,
+          cdpHost ?? "127.0.0.1",
+          allowRemote ?? false,
+          () =>
+            hideFeedAuthorProfile({
           profileUrl,
           cdpPort,
           cdpHost,
           allowRemote,
           dryRun,
-        });
+          }),
+        );
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         return mcpCatchAll(error, "Failed to hide feed author via profile");

--- a/packages/mcp/src/tools/hide-feed-author.ts
+++ b/packages/mcp/src/tools/hide-feed-author.ts
@@ -2,7 +2,9 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { hideFeedAuthor } from "@lhremote/core";
+import { hideFeedAuthor ,
+  withLoggedInStateRetryAtPort,
+} from "@lhremote/core";
 import { z } from "zod";
 import { cdpConnectionSchema, mcpCatchAll, mcpSuccess } from "../helpers.js";
 
@@ -18,13 +20,19 @@ export function registerHideFeedAuthor(server: McpServer): void {
     },
     async ({ feedIndex, dryRun, cdpPort, cdpHost, allowRemote }) => {
       try {
-        const result = await hideFeedAuthor({
+        const result = await withLoggedInStateRetryAtPort(
+          cdpPort,
+          cdpHost ?? "127.0.0.1",
+          allowRemote ?? false,
+          () =>
+            hideFeedAuthor({
           feedIndex,
           cdpPort,
           cdpHost,
           allowRemote,
           dryRun,
-        });
+          }),
+        );
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         return mcpCatchAll(error, "Failed to hide feed author");

--- a/packages/mcp/src/tools/hide-feed-author.ts
+++ b/packages/mcp/src/tools/hide-feed-author.ts
@@ -2,7 +2,8 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { hideFeedAuthor ,
+import {
+  hideFeedAuthor,
   withLoggedInStateRetryAtPort,
 } from "@lhremote/core";
 import { z } from "zod";

--- a/packages/mcp/src/tools/like-person-posts.ts
+++ b/packages/mcp/src/tools/like-person-posts.ts
@@ -2,7 +2,8 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { likePersonPosts ,
+import {
+  likePersonPosts,
   withLoggedInStateRetryAtPort,
 } from "@lhremote/core";
 import { z } from "zod";

--- a/packages/mcp/src/tools/like-person-posts.ts
+++ b/packages/mcp/src/tools/like-person-posts.ts
@@ -2,7 +2,9 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { likePersonPosts } from "@lhremote/core";
+import { likePersonPosts ,
+  withLoggedInStateRetryAtPort,
+} from "@lhremote/core";
 import { z } from "zod";
 import { cdpConnectionSchema, mcpCatchAll, mcpError, mcpSuccess } from "../helpers.js";
 
@@ -85,11 +87,17 @@ export function registerLikePersonPosts(server: McpServer): void {
       }
 
       try {
-        const result = await likePersonPosts({
+        const result = await withLoggedInStateRetryAtPort(
+          cdpPort,
+          cdpHost ?? "127.0.0.1",
+          allowRemote ?? false,
+          () =>
+            likePersonPosts({
           personId, url, numberOfArticles, numberOfPosts, maxAgeOfArticles, maxAgeOfPosts,
           shouldAddComment, messageTemplate: parsedMessageTemplate, skipIfNotLiked,
           keepCampaign, timeout, cdpPort, cdpHost, allowRemote, accountId,
-        });
+          }),
+        );
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         return mcpCatchAll(error, "Failed to like person posts");

--- a/packages/mcp/src/tools/react-to-comment.ts
+++ b/packages/mcp/src/tools/react-to-comment.ts
@@ -2,7 +2,9 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { reactToComment, REACTION_TYPES ,
+import {
+  reactToComment,
+  REACTION_TYPES,
   withLoggedInStateRetryAtPort,
 } from "@lhremote/core";
 import { z } from "zod";

--- a/packages/mcp/src/tools/react-to-comment.ts
+++ b/packages/mcp/src/tools/react-to-comment.ts
@@ -2,7 +2,9 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { reactToComment, REACTION_TYPES } from "@lhremote/core";
+import { reactToComment, REACTION_TYPES ,
+  withLoggedInStateRetryAtPort,
+} from "@lhremote/core";
 import { z } from "zod";
 import { cdpConnectionSchema, mcpCatchAll, mcpSuccess } from "../helpers.js";
 
@@ -34,7 +36,12 @@ export function registerReactToComment(server: McpServer): void {
     },
     async ({ postUrl, commentUrn, reactionType, dryRun, cdpPort, cdpHost, allowRemote }) => {
       try {
-        const result = await reactToComment({
+        const result = await withLoggedInStateRetryAtPort(
+          cdpPort,
+          cdpHost ?? "127.0.0.1",
+          allowRemote ?? false,
+          () =>
+            reactToComment({
           postUrl,
           commentUrn,
           reactionType: reactionType as Parameters<typeof reactToComment>[0]["reactionType"],
@@ -42,7 +49,8 @@ export function registerReactToComment(server: McpServer): void {
           cdpHost,
           allowRemote,
           dryRun,
-        });
+          }),
+        );
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         return mcpCatchAll(error, "Failed to react to comment");

--- a/packages/mcp/src/tools/react-to-post.ts
+++ b/packages/mcp/src/tools/react-to-post.ts
@@ -2,7 +2,11 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { reactToPost, REACTION_TYPES, withLoggedInStateRetryAtPort } from "@lhremote/core";
+import {
+  reactToPost,
+  REACTION_TYPES,
+  withLoggedInStateRetryAtPort,
+} from "@lhremote/core";
 import { z } from "zod";
 import { cdpConnectionSchema, mcpCatchAll, mcpSuccess } from "../helpers.js";
 

--- a/packages/mcp/src/tools/react-to-post.ts
+++ b/packages/mcp/src/tools/react-to-post.ts
@@ -2,7 +2,7 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { reactToPost, REACTION_TYPES } from "@lhremote/core";
+import { reactToPost, REACTION_TYPES, withLoggedInStateRetryAtPort } from "@lhremote/core";
 import { z } from "zod";
 import { cdpConnectionSchema, mcpCatchAll, mcpSuccess } from "../helpers.js";
 
@@ -29,14 +29,20 @@ export function registerReactToPost(server: McpServer): void {
     },
     async ({ postUrl, reactionType, dryRun, cdpPort, cdpHost, allowRemote }) => {
       try {
-        const result = await reactToPost({
-          postUrl,
-          reactionType: reactionType as Parameters<typeof reactToPost>[0]["reactionType"],
+        const result = await withLoggedInStateRetryAtPort(
           cdpPort,
-          cdpHost,
-          allowRemote,
-          dryRun,
-        });
+          cdpHost ?? "127.0.0.1",
+          allowRemote ?? false,
+          () =>
+            reactToPost({
+              postUrl,
+              reactionType: reactionType as Parameters<typeof reactToPost>[0]["reactionType"],
+              cdpPort,
+              cdpHost,
+              allowRemote,
+              dryRun,
+            }),
+        );
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         return mcpCatchAll(error, "Failed to react to post");

--- a/packages/mcp/src/tools/scrape-messaging-history.ts
+++ b/packages/mcp/src/tools/scrape-messaging-history.ts
@@ -4,6 +4,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   scrapeMessagingHistory,
+  withLoggedInStateRetryAtPort,
 } from "@lhremote/core";
 import { z } from "zod";
 import { cdpConnectionSchema, mcpCatchAll, mcpSuccess } from "../helpers.js";
@@ -28,7 +29,12 @@ export function registerScrapeMessagingHistory(server: McpServer): void {
     },
     async ({ personIds, pauseOthers, cdpPort, cdpHost, allowRemote }) => {
       try {
-        const result = await scrapeMessagingHistory({ personIds, pauseOthers, cdpPort, cdpHost, allowRemote });
+        const result = await withLoggedInStateRetryAtPort(
+          cdpPort,
+          cdpHost ?? "127.0.0.1",
+          allowRemote ?? false,
+          () => scrapeMessagingHistory({ personIds, pauseOthers, cdpPort, cdpHost, allowRemote }),
+        );
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         return mcpCatchAll(error, "Failed to scrape messaging history");

--- a/packages/mcp/src/tools/search-posts.ts
+++ b/packages/mcp/src/tools/search-posts.ts
@@ -2,7 +2,8 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { searchPosts ,
+import {
+  searchPosts,
   withLoggedInStateRetryAtPort,
 } from "@lhremote/core";
 import { z } from "zod";

--- a/packages/mcp/src/tools/search-posts.ts
+++ b/packages/mcp/src/tools/search-posts.ts
@@ -2,7 +2,9 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { searchPosts } from "@lhremote/core";
+import { searchPosts ,
+  withLoggedInStateRetryAtPort,
+} from "@lhremote/core";
 import { z } from "zod";
 import { cdpConnectionSchema, mcpCatchAll, mcpSuccess } from "../helpers.js";
 
@@ -36,14 +38,20 @@ export function registerSearchPosts(server: McpServer): void {
     },
     async ({ query, count, cursor, cdpPort, cdpHost, allowRemote }) => {
       try {
-        const result = await searchPosts({
+        const result = await withLoggedInStateRetryAtPort(
+          cdpPort,
+          cdpHost ?? "127.0.0.1",
+          allowRemote ?? false,
+          () =>
+            searchPosts({
           query,
           count,
           cursor,
           cdpPort,
           cdpHost,
           allowRemote,
-        });
+          }),
+        );
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         return mcpCatchAll(error, "Failed to search posts");

--- a/packages/mcp/src/tools/unfollow-from-feed.ts
+++ b/packages/mcp/src/tools/unfollow-from-feed.ts
@@ -2,7 +2,9 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { unfollowFromFeed } from "@lhremote/core";
+import { unfollowFromFeed ,
+  withLoggedInStateRetryAtPort,
+} from "@lhremote/core";
 import { z } from "zod";
 import { cdpConnectionSchema, mcpCatchAll, mcpSuccess } from "../helpers.js";
 
@@ -18,13 +20,19 @@ export function registerUnfollowFromFeed(server: McpServer): void {
     },
     async ({ feedIndex, dryRun, cdpPort, cdpHost, allowRemote }) => {
       try {
-        const result = await unfollowFromFeed({
+        const result = await withLoggedInStateRetryAtPort(
+          cdpPort,
+          cdpHost ?? "127.0.0.1",
+          allowRemote ?? false,
+          () =>
+            unfollowFromFeed({
           feedIndex,
           cdpPort,
           cdpHost,
           allowRemote,
           dryRun,
-        });
+          }),
+        );
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         return mcpCatchAll(error, "Failed to unfollow from feed");

--- a/packages/mcp/src/tools/unfollow-from-feed.ts
+++ b/packages/mcp/src/tools/unfollow-from-feed.ts
@@ -2,7 +2,8 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { unfollowFromFeed ,
+import {
+  unfollowFromFeed,
   withLoggedInStateRetryAtPort,
 } from "@lhremote/core";
 import { z } from "zod";

--- a/packages/mcp/src/tools/unfollow-profile.ts
+++ b/packages/mcp/src/tools/unfollow-profile.ts
@@ -2,7 +2,8 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { unfollowProfile ,
+import {
+  unfollowProfile,
   withLoggedInStateRetryAtPort,
 } from "@lhremote/core";
 import { z } from "zod";

--- a/packages/mcp/src/tools/unfollow-profile.ts
+++ b/packages/mcp/src/tools/unfollow-profile.ts
@@ -2,7 +2,9 @@
 // Copyright (C) 2026 Oleksii PELYKH
 
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { unfollowProfile } from "@lhremote/core";
+import { unfollowProfile ,
+  withLoggedInStateRetryAtPort,
+} from "@lhremote/core";
 import { z } from "zod";
 import { cdpConnectionSchema, mcpCatchAll, mcpSuccess } from "../helpers.js";
 
@@ -29,13 +31,19 @@ export function registerUnfollowProfile(server: McpServer): void {
     },
     async ({ profileUrl, dryRun, cdpPort, cdpHost, allowRemote }) => {
       try {
-        const result = await unfollowProfile({
+        const result = await withLoggedInStateRetryAtPort(
+          cdpPort,
+          cdpHost ?? "127.0.0.1",
+          allowRemote ?? false,
+          () =>
+            unfollowProfile({
           profileUrl,
           cdpPort,
           cdpHost,
           allowRemote,
           dryRun,
-        });
+          }),
+        );
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         return mcpCatchAll(error, "Failed to unfollow target");

--- a/packages/mcp/src/tools/visit-profile.ts
+++ b/packages/mcp/src/tools/visit-profile.ts
@@ -4,6 +4,7 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   visitProfile,
+  withLoggedInStateRetryAtPort,
 } from "@lhremote/core";
 import { z } from "zod";
 import { cdpConnectionSchema, mcpCatchAll, mcpError, mcpSuccess } from "../helpers.js";
@@ -42,7 +43,12 @@ export function registerVisitProfile(server: McpServer): void {
       }
 
       try {
-        const result = await visitProfile({ personId, url, extractCurrentOrganizations, cdpPort, cdpHost, allowRemote, accountId });
+        const result = await withLoggedInStateRetryAtPort(
+          cdpPort,
+          cdpHost ?? "127.0.0.1",
+          allowRemote ?? false,
+          () => visitProfile({ personId, url, extractCurrentOrganizations, cdpPort, cdpHost, allowRemote, accountId }),
+        );
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         return mcpCatchAll(error, "Failed to visit profile");


### PR DESCRIPTION
Closes #781
Closes #782

## Summary

LinkedHelper enters `LoggedInLoadingState` whenever LinkedIn re-validates
the session (`/me` API in flight). Every action issued in that window
fails with `Action.IncorrectContentStateError: state \`li-logged-in-loading\`
is not \`LoggedInState\``. This PR adds a pre-flight gate that waits for
`LoggedInState` and a transient-retry wrapper that re-runs the op once
when LH surfaces this error class.

### Spike result (Phase 1 — `packages/e2e/src/state-spike.e2e.test.ts`)

Probed `mws` IPC channel for `liWindow` topic. **The IPC channel is
closed** for `liWindow.*` from outside the LH process:

| Probe | Result |
|---|---|
| `mws.callRead('liWindow', 'checkIfInLoggedInState', true)` | `wrong method names for callRead` |
| `mws.callRead('liWindow.checkIfInLoggedInState', true)` | `wrong method names for callRead` |
| `mws.callWrite('liWindow', 'waitLoggedInState', true, 5000)` | `wrong method names for callRead` |
| `mws.callRaw('liWindow.checkIfInLoggedInState', true)` | `this.mainWindow[Q] is not a function` |
| `mws.get('liWindow', 'state[extracted]')` | `undefined` |
| `mws.getContentWindow()` | `null` |
| `mws.mainWindow.contentWindow` | `ContentWindow` proxy — recursing risks `@electron/remote` main-process crash |

Fell back to the DOM heuristic from research §11.1: `host =
www.linkedin.com` AND `pathname` matches the LH `LoggedInState.canEnter`
prefix set AND `img[alt][src*="profile-displayphoto-shrink"]` is
rendered. Verified live on `/feed/`. Spike test ships as regression
coverage so any future LH IPC change is caught.

## Approach (Phase 2)

- `waitForLoggedInState(instance, opts)` polls `instance.evaluateLinkedIn`
  every 500 ms (default 60 s deadline). Throws `LoggedInStateTimeoutError`
  on deadline exit with `{ waitedMs, lastReason }`.
- `gateOnLoggedInState(cdpPort, cdpHost, allowRemote, opts)` is a
  convenience for ops that drive via a raw `CDPClient` — opens a
  temporary `InstanceService`, gates, disconnects.
- `InstanceService.evaluateLinkedIn(expr)` added so the helper can probe
  the LinkedIn webview directly (mirrors the existing `evaluateUI`
  shape).

## Phase 3 — operations gated

Each op now calls the gate **before** any `navigateLinkedIn` /
`evaluateUI` / DOM evaluation. Per-op tests assert the gate is invoked.

- `collect-people` — gate before `CollectionService.collect`
- `visit-profile` — gate before `instance.executeAction("VisitAndExtract")`
- `scrape-messaging-history` — gate before campaign creation
- `ephemeral-action` (covers `follow-person`, `endorse-skills`,
  `like-person-posts`, plus the rest of the ephemeral-campaign family
  for additive safety) — gate before `EphemeralCampaignService.execute`
- `comment-on-post`, `react-to-post`, `react-to-comment`,
  `unfollow-from-feed`, `dismiss-feed-post`, `hide-feed-author`,
  `hide-feed-author-profile`, `unfollow-profile`, `get-feed`,
  `search-posts` — gate before `discoverTargets` via
  `gateOnLoggedInState`

## Phase 4 — transient retry

`withLoggedInStateRetry(instance, op, opts)` and the lazy port-based
companion `withLoggedInStateRetryAtPort(cdpPort, cdpHost, allowRemote,
op, opts)`:

1. Run `op()`. Return on success.
2. On `Action.IncorrectContentStateError` (matched by class name OR the
   canonical `state \`<X>\` is not \`<Y>\`` phrasing OR
   `IncorrectStateType`/`StateIsNotFinal`), wait for `LoggedInState`,
   then retry once.
3. If still failing, surface `LoggedInStatePersistedError` wrapping the
   inner error so callers can distinguish a stuck CW from a transient
   blip.

The port-based wrapper lazy-creates `InstanceService` only on the
failure path — zero overhead for the happy path.

### Wrapped CLI handlers (`packages/cli/src/handlers/`)

`collect-people`, `comment-on-post`, `dismiss-feed-post`,
`endorse-skills`, `follow-person`, `get-feed`, `hide-feed-author`,
`hide-feed-author-profile`, `like-person-posts`, `react-to-comment`,
`react-to-post`, `scrape-messaging-history`, `search-posts`,
`unfollow-from-feed`, `unfollow-profile`, `visit-profile`.

### Wrapped MCP tools (`packages/mcp/src/tools/`)

Same set as CLI.

## Test plan

- [x] Unit tests for `waitForLoggedInState` (poll loop, timeout error,
      transient probe exceptions, configured pollInterval, deadline
      clamping)
- [x] Unit tests for `withLoggedInStateRetry` and
      `withLoggedInStateRetryAtPort` (happy path skips InstanceService
      construction; retry path constructs once; LoggedInStatePersistedError
      preserves inner error; error-detection predicate matches LH's
      canonical phrasing)
- [x] Per-op assertions that the gate is invoked
- [x] `pnpm test` green — core 1697 / cli 553 / mcp 486 (2736 total)
- [x] `pnpm lint` clean
- [x] `pnpm build` clean across all packages
- [x] `pnpm --filter @lhremote/e2e test:e2e:file state-spike` ran live
      against LH 2.113.62 — all 14 spike tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)