### PR TITLE
(test) e2e: walk feed indices in dismiss-feed-post dry-run tests

### DIFF
--- a/packages/e2e/src/feed-dismissal.e2e.test.ts
+++ b/packages/e2e/src/feed-dismissal.e2e.test.ts
@@ -96,6 +96,19 @@ describeE2E("feed dismissal operations", () => {
   }, 60_000);
 
   // ── dismiss-feed-post ───────────────────────────────────────────────
+  //
+  // The first few feed posts can be sponsored or own posts (no "Not interested"
+  // option in the three-dot menu — see operations/dismiss-feed-post.ts §
+  // clickNotInterested).  Tests therefore walk index 0..N until they find a
+  // post whose three-dot menu contains "Not interested" rather than asserting
+  // on a specific index.  See issue #784 for the original flake.
+
+  /**
+   * Maximum feed indices to try when looking for a dismissable post.
+   * 5 covers the typical "1-2 sponsored at top + 1 own post pinned" worst
+   * case while keeping the upper bound on flake time bounded (≈ 5 × ~20s).
+   */
+  const MAX_FEED_INDEX_PROBE = 5;
 
   describe("dismiss-feed-post", () => {
     describe("CLI handlers", () => {
@@ -111,63 +124,113 @@ describeE2E("feed dismissal operations", () => {
       });
 
       it("dismiss-feed-post --json --dry-run reports dry-run result", async () => {
-        const stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
-        const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+        let parsed: DismissFeedPostOutput | undefined;
+        let lastError: string | undefined;
+        for (let idx = 0; idx < MAX_FEED_INDEX_PROBE; idx++) {
+          process.exitCode = undefined;
+          const stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+          const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
 
-        await handleDismissFeedPost(0, { cdpPort, json: true, dryRun: true });
+          await handleDismissFeedPost(idx, { cdpPort, json: true, dryRun: true });
 
-        const stderr = stderrSpy.mock.calls.map((c) => String(c[0])).join("");
-        expect(process.exitCode, `CLI handler error: ${stderr}`).toBeUndefined();
-        expect(stdoutSpy).toHaveBeenCalled();
+          const stderr = stderrSpy.mock.calls.map((c) => String(c[0])).join("");
+          const stdout = stdoutSpy.mock.calls.map((c) => String(c[0])).join("");
+          stdoutSpy.mockRestore();
+          stderrSpy.mockRestore();
 
-        const output = stdoutSpy.mock.calls.map((call) => String(call[0])).join("");
-        const parsed = JSON.parse(output) as DismissFeedPostOutput;
+          if (process.exitCode !== undefined) {
+            lastError = stderr || `exitCode=${String(process.exitCode)}`;
+            // Sponsored / own / hidden post — try next index
+            continue;
+          }
 
+          parsed = JSON.parse(stdout) as DismissFeedPostOutput;
+          expect(parsed.feedIndex).toBe(idx);
+          break;
+        }
+
+        if (!parsed) {
+          throw new Error(
+            `No dismissable post found in feed indices 0..${String(MAX_FEED_INDEX_PROBE - 1)} ` +
+              `(last error: ${lastError ?? "none"})`,
+          );
+        }
         expect(parsed.success).toBe(true);
-        expect(parsed.feedIndex).toBe(0);
         expect(parsed.dryRun).toBe(true);
-      }, 120_000);
+      }, 600_000);
 
       it("dismiss-feed-post --dry-run (human-friendly) includes [dry-run] prefix", async () => {
-        const stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
-        const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+        let success = false;
+        let lastError: string | undefined;
+        for (let idx = 0; idx < MAX_FEED_INDEX_PROBE; idx++) {
+          process.exitCode = undefined;
+          const stdoutSpy = vi.spyOn(process.stdout, "write").mockReturnValue(true);
+          const stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
 
-        await handleDismissFeedPost(0, { cdpPort, dryRun: true });
+          await handleDismissFeedPost(idx, { cdpPort, dryRun: true });
 
-        const stderr = stderrSpy.mock.calls.map((c) => String(c[0])).join("");
-        expect(process.exitCode, `CLI handler error: ${stderr}`).toBeUndefined();
+          const stderr = stderrSpy.mock.calls.map((c) => String(c[0])).join("");
+          const stdout = stdoutSpy.mock.calls.map((c) => String(c[0])).join("");
+          stdoutSpy.mockRestore();
+          stderrSpy.mockRestore();
 
-        const output = stdoutSpy.mock.calls.map((call) => String(call[0])).join("");
-        expect(output).toContain("[dry-run]");
-      }, 120_000);
+          if (process.exitCode !== undefined) {
+            lastError = stderr || `exitCode=${String(process.exitCode)}`;
+            continue;
+          }
+          if (stdout.includes("[dry-run]")) {
+            success = true;
+            break;
+          }
+        }
+        expect(
+          success,
+          `No dismissable post found in feed indices 0..${String(MAX_FEED_INDEX_PROBE - 1)} ` +
+            `(last error: ${lastError ?? "none"})`,
+        ).toBe(true);
+      }, 600_000);
     });
 
     describe("MCP tools", () => {
       it("dismiss-feed-post tool returns valid dry-run JSON", async () => {
         const { server, getHandler } = createMockServer();
         registerDismissFeedPost(server);
-
         const handler = getHandler("dismiss-feed-post");
-        const result = (await handler({
-          feedIndex: 0,
-          cdpPort,
-          dryRun: true,
-        })) as {
-          isError?: boolean;
-          content: { type: string; text: string }[];
-        };
 
-        expect(result.isError, `MCP tool error: ${result.content?.[0]?.text}`).toBeUndefined();
-        expect(result.content).toHaveLength(1);
+        let parsed: DismissFeedPostOutput | undefined;
+        let lastError: string | undefined;
+        for (let idx = 0; idx < MAX_FEED_INDEX_PROBE; idx++) {
+          const result = (await handler({
+            feedIndex: idx,
+            cdpPort,
+            dryRun: true,
+          })) as {
+            isError?: boolean;
+            content: { type: string; text: string }[];
+          };
 
-        const parsed = JSON.parse(
-          (result.content[0] as { text: string }).text,
-        ) as DismissFeedPostOutput;
+          if (result.isError) {
+            lastError = result.content?.[0]?.text;
+            continue;
+          }
 
+          expect(result.content).toHaveLength(1);
+          parsed = JSON.parse(
+            (result.content[0] as { text: string }).text,
+          ) as DismissFeedPostOutput;
+          expect(parsed.feedIndex).toBe(idx);
+          break;
+        }
+
+        if (!parsed) {
+          throw new Error(
+            `No dismissable post found in feed indices 0..${String(MAX_FEED_INDEX_PROBE - 1)} ` +
+              `(last error: ${lastError ?? "none"})`,
+          );
+        }
         expect(parsed.success).toBe(true);
-        expect(parsed.feedIndex).toBe(0);
         expect(parsed.dryRun).toBe(true);
-      }, 120_000);
+      }, 600_000);
     });
   });
 });


### PR DESCRIPTION
## Summary

Walk feed indices 0..4 in the three `dismiss-feed-post` dry-run tests until a non-sponsored / non-own post is found, instead of pinning to `feedIndex: 0`. Surface a structured error if none of the first 5 indices are dismissable.

The operation surface (`packages/core/src/operations/dismiss-feed-post.ts`) is unchanged — production callers still pick a deliberate `feedIndex`; only the test framing relaxes to handle natural feed variance.

Closes #784

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm test` clean (1697 core / 553 cli / 486 mcp)
- [ ] After merge: re-run full E2E — these 3 tests should pass regardless of which top-of-feed post LinkedIn serves.