### PR TITLE
(test) e2e: bump beforeAll CDP-port-discovery retry budget from 20s to 60s

### DIFF
--- a/packages/e2e/src/comment-dom-spike.e2e.test.ts
+++ b/packages/e2e/src/comment-dom-spike.e2e.test.ts
@@ -110,7 +110,7 @@ describeE2E("comment-dom regression probe (#776)", () => {
         if (p === null) throw new Error("Instance CDP port not discovered yet");
         return p;
       },
-      { retries: 10, delay: 2_000 },
+      { retries: 30, delay: 2_000 },
     );
 
     const liTarget = await retryAsync(

--- a/packages/e2e/src/engagement.e2e.test.ts
+++ b/packages/e2e/src/engagement.e2e.test.ts
@@ -90,7 +90,7 @@ describeE2E("engagement operations", () => {
         if (p === null) throw new Error("Instance CDP port not discovered yet");
         return p;
       },
-      { retries: 10, delay: 2_000 },
+      { retries: 30, delay: 2_000 },
     );
     cdpPort = instancePort;
 

--- a/packages/e2e/src/feed-dismissal.e2e.test.ts
+++ b/packages/e2e/src/feed-dismissal.e2e.test.ts
@@ -56,7 +56,7 @@ describeE2E("feed dismissal operations", () => {
         if (p === null) throw new Error("Instance CDP port not discovered yet");
         return p;
       },
-      { retries: 10, delay: 2_000 },
+      { retries: 30, delay: 2_000 },
     );
     cdpPort = instancePort;
 

--- a/packages/e2e/src/get-feed.e2e.test.ts
+++ b/packages/e2e/src/get-feed.e2e.test.ts
@@ -44,7 +44,7 @@ describeE2E("get-feed operation", () => {
         if (p === null) throw new Error("Instance CDP port not discovered yet");
         return p;
       },
-      { retries: 10, delay: 2_000 },
+      { retries: 30, delay: 2_000 },
     );
     cdpPort = instancePort;
 

--- a/packages/e2e/src/get-post-engagers.e2e.test.ts
+++ b/packages/e2e/src/get-post-engagers.e2e.test.ts
@@ -41,7 +41,7 @@ describeE2E("get-post-engagers operation", () => {
         if (p === null) throw new Error("Instance CDP port not discovered yet");
         return p;
       },
-      { retries: 10, delay: 2_000 },
+      { retries: 30, delay: 2_000 },
     );
     cdpPort = instancePort;
 

--- a/packages/e2e/src/get-post-stats.e2e.test.ts
+++ b/packages/e2e/src/get-post-stats.e2e.test.ts
@@ -57,7 +57,7 @@ describeE2E("get-post-stats operation", () => {
         if (p === null) throw new Error("Instance CDP port not discovered yet");
         return p;
       },
-      { retries: 10, delay: 2_000 },
+      { retries: 30, delay: 2_000 },
     );
     cdpPort = instancePort;
 

--- a/packages/e2e/src/get-post.e2e.test.ts
+++ b/packages/e2e/src/get-post.e2e.test.ts
@@ -57,7 +57,7 @@ describeE2E("get-post operation", () => {
         if (p === null) throw new Error("Instance CDP port not discovered yet");
         return p;
       },
-      { retries: 10, delay: 2_000 },
+      { retries: 30, delay: 2_000 },
     );
     cdpPort = instancePort;
 

--- a/packages/e2e/src/get-profile-activity.e2e.test.ts
+++ b/packages/e2e/src/get-profile-activity.e2e.test.ts
@@ -61,7 +61,7 @@ describeE2E("get-profile-activity operation", () => {
         if (p === null) throw new Error("Instance CDP port not discovered yet");
         return p;
       },
-      { retries: 10, delay: 2_000 },
+      { retries: 30, delay: 2_000 },
     );
     cdpPort = instancePort;
 

--- a/packages/e2e/src/hide-feed-author-profile.e2e.test.ts
+++ b/packages/e2e/src/hide-feed-author-profile.e2e.test.ts
@@ -52,7 +52,7 @@ describeE2E("hide-feed-author-profile operation", () => {
         if (p === null) throw new Error("Instance CDP port not discovered yet");
         return p;
       },
-      { retries: 10, delay: 2_000 },
+      { retries: 30, delay: 2_000 },
     );
     cdpPort = instancePort;
 

--- a/packages/e2e/src/hide-feed-author.e2e.test.ts
+++ b/packages/e2e/src/hide-feed-author.e2e.test.ts
@@ -51,7 +51,7 @@ describeE2E("hide-feed-author", () => {
         if (p === null) throw new Error("Instance CDP port not discovered yet");
         return p;
       },
-      { retries: 10, delay: 2_000 },
+      { retries: 30, delay: 2_000 },
     );
     cdpPort = instancePort;
 

--- a/packages/e2e/src/mention-autocomplete-spike.e2e.test.ts
+++ b/packages/e2e/src/mention-autocomplete-spike.e2e.test.ts
@@ -225,7 +225,7 @@ describeE2E("mention autocomplete spike (#712)", () => {
         if (p === null) throw new Error("Instance CDP port not discovered yet");
         return p;
       },
-      { retries: 10, delay: 2_000 },
+      { retries: 30, delay: 2_000 },
     );
 
     const liTarget = await retryAsync(

--- a/packages/e2e/src/search-posts.e2e.test.ts
+++ b/packages/e2e/src/search-posts.e2e.test.ts
@@ -44,7 +44,7 @@ describeE2E("search-posts operation", () => {
         if (p === null) throw new Error("Instance CDP port not discovered yet");
         return p;
       },
-      { retries: 10, delay: 2_000 },
+      { retries: 30, delay: 2_000 },
     );
     cdpPort = instancePort;
 

--- a/packages/e2e/src/selectors.e2e.test.ts
+++ b/packages/e2e/src/selectors.e2e.test.ts
@@ -109,7 +109,7 @@ describeE2E("LinkedIn selectors registry", () => {
         if (p === null) throw new Error("Instance CDP port not discovered yet");
         return p;
       },
-      { retries: 10, delay: 2_000 },
+      { retries: 30, delay: 2_000 },
     );
 
     // 4. Connect directly to the LinkedIn WebView target
@@ -123,7 +123,7 @@ describeE2E("LinkedIn selectors registry", () => {
         if (!li) throw new Error("LinkedIn target not found yet");
         return li;
       },
-      { retries: 10, delay: 2_000 },
+      { retries: 30, delay: 2_000 },
     );
 
     linkedInClient = new CDPClient(instancePort);

--- a/packages/e2e/src/unfollow-from-feed.e2e.test.ts
+++ b/packages/e2e/src/unfollow-from-feed.e2e.test.ts
@@ -51,7 +51,7 @@ describeE2E("unfollow-from-feed operation", () => {
         if (p === null) throw new Error("Instance CDP port not discovered yet");
         return p;
       },
-      { retries: 10, delay: 2_000 },
+      { retries: 30, delay: 2_000 },
     );
     cdpPort = instancePort;
 

--- a/packages/e2e/src/unfollow-profile.e2e.test.ts
+++ b/packages/e2e/src/unfollow-profile.e2e.test.ts
@@ -53,7 +53,7 @@ describeE2E("unfollow-profile operation", () => {
         if (p === null) throw new Error("Instance CDP port not discovered yet");
         return p;
       },
-      { retries: 10, delay: 2_000 },
+      { retries: 30, delay: 2_000 },
     );
     cdpPort = instancePort;
 


### PR DESCRIPTION
## Summary

Bump `discoverInstancePort` retry budget in 15 E2E `beforeAll` blocks from `{retries: 10, delay: 2_000}` (20s) to `{retries: 30, delay: 2_000}` (60s) — same budget already used for the LinkedIn-target-discovery retry that immediately follows in the same `beforeAll`. Aligns with the auto-memory entry "LH E2E back-to-back CDP port race".

60s is well within every consumer's `beforeAll` timeout (120s) and the port takes <2s once LH is actually running, so this is strictly headroom for the back-to-back race, not a slowdown of the happy path.

Closes #785

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm test` clean (1697 core / 553 cli / 486 mcp)
- [ ] After merge: re-run full E2E — `hide-feed-author.e2e.test.ts` (and any other file that flaked at the file level) should reach the test bodies.