### PR TITLE
(fix) e2e: resolve globalSetup path against config dir, not CWD

### DIFF
--- a/vitest.e2e.config.ts
+++ b/vitest.e2e.config.ts
@@ -1,7 +1,15 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
+import { fileURLToPath } from "node:url";
+
 import { defineConfig } from "vitest/config";
+
+// Resolve relative to THIS file so the config behaves the same regardless of
+// the cwd vitest is invoked from.  pnpm runs `vitest --config ../../vitest.e2e.config.ts`
+// from each package directory; without this, vitest 4 doubled the path to
+// `packages/e2e/packages/e2e/src/global-setup.ts` and crashed the whole suite.
+const CONFIG_DIR = fileURLToPath(new URL(".", import.meta.url));
 
 export default defineConfig({
   test: {
@@ -13,7 +21,7 @@ export default defineConfig({
     // Aborts the whole suite up front if LinkedIn ContentWindow can't enter
     // LoggedInState, instead of cascading through 60+ tests with the same
     // root cause.
-    globalSetup: ["./packages/e2e/src/global-setup.ts"],
+    globalSetup: [`${CONFIG_DIR}packages/e2e/src/global-setup.ts`],
     env: {
       // Opt in to timeout-failure diagnostics (screenshots, DOM probes)
       // for every E2E run.  Production callers (CLI, MCP) remain default-off


### PR DESCRIPTION
## Summary

Followup to #787. vitest 4 resolves `globalSetup` array entries against the process CWD, not the config-file directory. The shared `vitest.e2e.config.ts` is loaded via `vitest --config ../../vitest.e2e.config.ts` from each package directory, so the relative path `./packages/e2e/src/global-setup.ts` was being resolved to `packages/e2e/packages/e2e/src/global-setup.ts` — and crashed the whole E2E suite with `ERR_LOAD_URL` BEFORE any test file ran.

Fix: compute an absolute path via `fileURLToPath(new URL(".", import.meta.url))`.

Closes #790

## Test plan
- [x] `pnpm lint` clean
- [x] `pnpm test` clean (1697 core / 553 cli / 486 mcp)
- [x] Smoke-tested locally — vitest now starts and prints `[E2E health gate] Verifying LinkedIn ContentWindow state...`
- [ ] After merge: re-run full E2E — health gate should run, then suite should proceed normally.