### PR TITLE
(fix) e2e: dismiss leftover popups before each test to prevent cascade

### DIFF
--- a/packages/e2e/src/campaign-advanced.e2e.test.ts
+++ b/packages/e2e/src/campaign-advanced.e2e.test.ts
@@ -5,6 +5,7 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } 
 import { assertDefined, describeE2E, forceStopInstance, installErrorDetection, launchApp, quitApp, resolveAccountId, retryAsync } from "@lhremote/core/testing";
 import {
   type AppService,
+  dismissErrors,
   LauncherService,
   startInstanceWithRecovery,
 } from "@lhremote/core";
@@ -69,6 +70,11 @@ describeE2E("Campaign advanced operations", () => {
     }
     await quitApp(app);
   }, 60_000);
+
+  // Dismiss any leftover error popups before each test to prevent cascade failures (#792)
+  beforeEach(async () => {
+    await dismissErrors({ cdpPort: port, accountId }).catch(() => {});
+  }, 30_000);
 
   installErrorDetection(() => port);
 

--- a/packages/e2e/src/campaign-execution.e2e.test.ts
+++ b/packages/e2e/src/campaign-execution.e2e.test.ts
@@ -5,6 +5,7 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } 
 import { assertDefined, describeE2E, forceStopInstance, installErrorDetection, launchApp, quitApp, resolveAccountId, retryAsync } from "@lhremote/core/testing";
 import {
   type AppService,
+  dismissErrors,
   LauncherService,
   startInstanceWithRecovery,
 } from "@lhremote/core";
@@ -86,6 +87,11 @@ describeE2E("Campaign execution and monitoring", () => {
     }
     await quitApp(app);
   }, 60_000);
+
+  // Dismiss any leftover error popups before each test to prevent cascade failures (#792)
+  beforeEach(async () => {
+    await dismissErrors({ cdpPort: port, accountId }).catch(() => {});
+  }, 30_000);
 
   installErrorDetection(() => port);
 

--- a/packages/e2e/src/campaign-lifecycle.e2e.test.ts
+++ b/packages/e2e/src/campaign-lifecycle.e2e.test.ts
@@ -5,6 +5,7 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } 
 import { assertDefined, describeE2E, forceStopInstance, installErrorDetection, launchApp, quitApp, resolveAccountId, retryAsync } from "@lhremote/core/testing";
 import {
   type AppService,
+  dismissErrors,
   LauncherService,
   startInstanceWithRecovery,
 } from "@lhremote/core";
@@ -76,6 +77,11 @@ describeE2E("Campaign CRUD lifecycle", () => {
     }
     await quitApp(app);
   }, 60_000);
+
+  // Dismiss any leftover error popups before each test to prevent cascade failures (#792)
+  beforeEach(async () => {
+    await dismissErrors({ cdpPort: port, accountId }).catch(() => {});
+  }, 30_000);
 
   installErrorDetection(() => port);
 

--- a/packages/e2e/src/collect-people.e2e.test.ts
+++ b/packages/e2e/src/collect-people.e2e.test.ts
@@ -5,6 +5,7 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } 
 import { assertDefined, describeE2E, forceStopInstance, installErrorDetection, launchApp, quitApp, resolveAccountId, retryAsync } from "@lhremote/core/testing";
 import {
   type AppService,
+  dismissErrors,
   LauncherService,
   startInstanceWithRecovery,
 } from "@lhremote/core";
@@ -147,6 +148,11 @@ describeE2E("collect-people operation", () => {
     }
     await quitApp(app);
   }, 60_000);
+
+  // Dismiss any leftover error popups before each test to prevent cascade failures (#792)
+  beforeEach(async () => {
+    await dismissErrors({ cdpPort: port, accountId }).catch(() => {});
+  }, 30_000);
 
   installErrorDetection(() => port);
 

--- a/packages/e2e/src/hide-feed-author-profile.e2e.test.ts
+++ b/packages/e2e/src/hide-feed-author-profile.e2e.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-import { afterAll, beforeAll, expect, it } from "vitest";
+import { afterAll, beforeAll, beforeEach, expect, it } from "vitest";
 import {
   describeE2E,
   forceStopInstance,
@@ -16,6 +16,7 @@ import {
   type AppService,
   discoverInstancePort,
   discoverTargets,
+  dismissErrors,
   LauncherService,
   startInstanceWithRecovery,
 } from "@lhremote/core";
@@ -69,6 +70,14 @@ describeE2E("hide-feed-author-profile operation", () => {
       { retries: 30, delay: 2_000 },
     );
   }, 120_000);
+
+  // Dismiss any leftover error popups before each test to prevent cascade failures (#792).
+  // Pass launcher `port` (not instance `cdpPort`) so dismissErrors can clear BOTH
+  // launcher- and instance-level popups via auto-discovery — passing the instance
+  // port skips the launcher-popup branch and leaves launcher popups to cascade.
+  beforeEach(async () => {
+    await dismissErrors({ cdpPort: port, accountId }).catch(() => {});
+  }, 30_000);
 
   installErrorDetection(() => port);
 

--- a/packages/e2e/src/hide-feed-author.e2e.test.ts
+++ b/packages/e2e/src/hide-feed-author.e2e.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-import { afterAll, beforeAll, expect, it } from "vitest";
+import { afterAll, beforeAll, beforeEach, expect, it } from "vitest";
 import {
   describeE2E,
   forceStopInstance,
@@ -15,6 +15,7 @@ import {
   type AppService,
   discoverInstancePort,
   discoverTargets,
+  dismissErrors,
   type HideFeedAuthorOutput,
   LauncherService,
   startInstanceWithRecovery,
@@ -68,6 +69,14 @@ describeE2E("hide-feed-author", () => {
       { retries: 30, delay: 2_000 },
     );
   }, 120_000);
+
+  // Dismiss any leftover error popups before each test to prevent cascade failures (#792).
+  // Pass launcher `port` (not instance `cdpPort`) so dismissErrors can clear BOTH
+  // launcher- and instance-level popups via auto-discovery — passing the instance
+  // port skips the launcher-popup branch and leaves launcher popups to cascade.
+  beforeEach(async () => {
+    await dismissErrors({ cdpPort: port, accountId }).catch(() => {});
+  }, 30_000);
 
   installErrorDetection(() => port);
 

--- a/packages/e2e/src/profile-and-utility.e2e.test.ts
+++ b/packages/e2e/src/profile-and-utility.e2e.test.ts
@@ -14,6 +14,7 @@ import {
 } from "@lhremote/core/testing";
 import {
   type AppService,
+  dismissErrors,
   LauncherService,
   startInstanceWithRecovery,
 } from "@lhremote/core";
@@ -504,6 +505,11 @@ describeE2E("profile enrichment and utilities", () => {
       }
       await quitApp(app);
     }, 60_000);
+
+    // Dismiss any leftover error popups before each test to prevent cascade failures (#792)
+    beforeEach(async () => {
+      await dismissErrors({ cdpPort: port, accountId }).catch(() => {});
+    }, 30_000);
 
     installErrorDetection(() => port);
 

--- a/packages/e2e/src/unfollow-from-feed.e2e.test.ts
+++ b/packages/e2e/src/unfollow-from-feed.e2e.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-import { afterAll, beforeAll, expect, it } from "vitest";
+import { afterAll, beforeAll, beforeEach, expect, it } from "vitest";
 import {
   describeE2E,
   forceStopInstance,
@@ -15,6 +15,7 @@ import {
   type AppService,
   discoverInstancePort,
   discoverTargets,
+  dismissErrors,
   LauncherService,
   startInstanceWithRecovery,
 } from "@lhremote/core";
@@ -68,6 +69,14 @@ describeE2E("unfollow-from-feed operation", () => {
       { retries: 30, delay: 2_000 },
     );
   }, 120_000);
+
+  // Dismiss any leftover error popups before each test to prevent cascade failures (#792).
+  // Pass launcher `port` (not instance `cdpPort`) so dismissErrors can clear BOTH
+  // launcher- and instance-level popups via auto-discovery — passing the instance
+  // port skips the launcher-popup branch and leaves launcher popups to cascade.
+  beforeEach(async () => {
+    await dismissErrors({ cdpPort: port, accountId }).catch(() => {});
+  }, 30_000);
 
   installErrorDetection(() => port);
 

--- a/packages/e2e/src/unfollow-profile.e2e.test.ts
+++ b/packages/e2e/src/unfollow-profile.e2e.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // Copyright (C) 2026 Oleksii PELYKH
 
-import { afterAll, beforeAll, expect, it } from "vitest";
+import { afterAll, beforeAll, beforeEach, expect, it } from "vitest";
 import {
   describeE2E,
   forceStopInstance,
@@ -17,6 +17,7 @@ import {
   type AppService,
   discoverInstancePort,
   discoverTargets,
+  dismissErrors,
   LauncherService,
   startInstanceWithRecovery,
 } from "@lhremote/core";
@@ -70,6 +71,14 @@ describeE2E("unfollow-profile operation", () => {
       { retries: 30, delay: 2_000 },
     );
   }, 120_000);
+
+  // Dismiss any leftover error popups before each test to prevent cascade failures (#792).
+  // Pass launcher `port` (not instance `cdpPort`) so dismissErrors can clear BOTH
+  // launcher- and instance-level popups via auto-discovery — passing the instance
+  // port skips the launcher-popup branch and leaves launcher popups to cascade.
+  beforeEach(async () => {
+    await dismissErrors({ cdpPort: port, accountId }).catch(() => {});
+  }, 30_000);
 
   installErrorDetection(() => port);
 


### PR DESCRIPTION
## Summary

Adds `beforeEach(dismissErrors)` to 9 E2E test files that use `installErrorDetection` but were missing the cleanup hook. Eliminates the test-infrastructure cascade where popups left on the shared LH process by one suite (most often `collect-people` via the LH-internal saga) get picked up by the next suite's `installErrorDetection` baseline and reported as "new" popups in `afterEach`.

## Scope (intentionally narrow)

This PR fixes **test isolation only** — a test-infrastructure concern. It does NOT fix the underlying LH-internal saga that produces the popups in the first place. The saga issue (`mws.callWrite('collect', …)` is fire-and-forget and unprotected by our `withLoggedInStateRetry` gate from #781/#782) is a production concern affecting users running `collect-people` whenever LinkedIn re-validates a session — that work continues under #792 (Options B / C / D: mws pause-resume / auto-dismiss during collect / manual saga drive).

| Concern | Status | Issue |
|---|---|---|
| Test cascade across 8 unrelated suites | **Fixed by this PR** | #796 |
| LH-internal saga throws `IncorrectContentStateError` mid-flight | **Open — saga work pending** | #792 |
| collect-people's own 7 popup-detection failures | **Open — same saga work** | #792 |

## What this fixes

| Suite | Cascade impact pre-fix | Post-fix |
|---|---|---|
| `campaign-advanced`, `campaign-execution`, `campaign-lifecycle` | Cascade via residual popups | No cascade |
| `profile-and-utility`, `hide-feed-author`, `hide-feed-author-profile` | Cascade | No cascade |
| `unfollow-from-feed`, `unfollow-profile` | Cascade | No cascade |
| `collect-people` (own suite) | 7 own failures (saga) | 7 own failures (saga, **unchanged**) |

## Pattern

Mirrors the proven hook already in `feed-dismissal.e2e.test.ts:78-81`, `engagement.e2e.test.ts`, and `error-and-lifecycle.e2e.test.ts`:

```typescript
// Dismiss any leftover error popups before each test to prevent cascade failures (#796).
// Pass launcher `port` (not instance `cdpPort`) so dismissErrors can clear BOTH
// launcher- and instance-level popups via auto-discovery — passing the instance
// port skips the launcher-popup branch and leaves launcher popups to cascade.
beforeEach(async () => {
  await dismissErrors({ cdpPort: port, accountId }).catch(() => {});
}, 30_000);
```

(Files using only the launcher `port` pass `cdpPort: port` directly. Files that already declare an instance `cdpPort` were updated per Copilot review to also pass the launcher `port`, so dismissErrors clears both layers.)

## Test plan

- [x] `pnpm lint` clean (8/8 tasks success)
- [x] `pnpm test` (Tier 1+2) all green (1697 core + 486 mcp + cli/lhremote)
- [x] grep audit: 0 remaining E2E files with `installErrorDetection` but no `dismissErrors`
- [ ] Full E2E run pre-release: confirm cascade gone (deferred to release-gate run; LH installed locally only — collect-people's own saga failures will persist, that's #792 scope)

Closes #796
Refs #792 (saga work continues — the cascade fix here does not touch the underlying LH-internal saga)

🤖 Generated with [Claude Code](https://claude.com/claude-code)