### PR TITLE
(fix) mcp: forward accountId from tool handlers to core operations

### DIFF
--- a/packages/mcp/src/tools/add-people-to-collection.ts
+++ b/packages/mcp/src/tools/add-people-to-collection.ts
@@ -23,9 +23,9 @@ export function registerAddPeopleToCollection(server: McpServer): void {
         .describe("Person IDs to add to the collection"),
       ...cdpConnectionSchema,
     },
-    async ({ collectionId, personIds, cdpPort, cdpHost, allowRemote }) => {
+    async ({ collectionId, personIds, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await addPeopleToCollection({ collectionId, personIds, cdpPort, cdpHost, allowRemote });
+        const result = await addPeopleToCollection({ collectionId, personIds, cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         return mcpCatchAll(error, "Failed to add people to collection");

--- a/packages/mcp/src/tools/campaign-add-action.test.ts
+++ b/packages/mcp/src/tools/campaign-add-action.test.ts
@@ -82,6 +82,25 @@ describe("registerCampaignAddAction", () => {
     });
   });
 
+  it("forwards accountId to campaignAddAction", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignAddAction(server);
+    vi.mocked(campaignAddAction).mockResolvedValue(MOCK_ACTION);
+
+    const handler = getHandler("campaign-add-action");
+    await handler({
+      campaignId: 15,
+      name: "Visit & Extract",
+      actionType: "VisitAndExtract",
+      cdpPort: 9222,
+      accountId: 550116,
+    });
+
+    expect(campaignAddAction).toHaveBeenCalledWith(
+      expect.objectContaining({ accountId: 550116 }),
+    );
+  });
+
   it("returns error for invalid actionSettings JSON", async () => {
     const { server, getHandler } = createMockServer();
     registerCampaignAddAction(server);

--- a/packages/mcp/src/tools/campaign-add-action.ts
+++ b/packages/mcp/src/tools/campaign-add-action.ts
@@ -56,6 +56,7 @@ export function registerCampaignAddAction(server: McpServer): void {
       cdpPort,
       cdpHost,
       allowRemote,
+      accountId,
     }) => {
       // Parse action settings JSON if provided
       let parsedSettings: Record<string, unknown> = {};
@@ -71,7 +72,7 @@ export function registerCampaignAddAction(server: McpServer): void {
         const result = await campaignAddAction({
           campaignId, name, actionType, description, coolDown,
           maxActionResultsPerIteration, actionSettings: parsedSettings,
-          cdpPort, cdpHost, allowRemote,
+          cdpPort, cdpHost, allowRemote, accountId,
         });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {

--- a/packages/mcp/src/tools/campaign-create.test.ts
+++ b/packages/mcp/src/tools/campaign-create.test.ts
@@ -179,6 +179,26 @@ describe("registerCampaignCreate", () => {
     });
   });
 
+  it("forwards accountId to campaignCreate", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCampaignCreate(server);
+
+    vi.mocked(parseCampaignYaml).mockReturnValue(PARSED_CONFIG);
+    vi.mocked(campaignCreate).mockResolvedValue(MOCK_CAMPAIGN);
+
+    const handler = getHandler("campaign-create");
+    await handler({
+      config: YAML_CONFIG,
+      format: "yaml",
+      cdpPort: 9222,
+      accountId: 550116,
+    });
+
+    expect(campaignCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ accountId: 550116 }),
+    );
+  });
+
   it("returns error when campaign creation fails", async () => {
     const { server, getHandler } = createMockServer();
     registerCampaignCreate(server);

--- a/packages/mcp/src/tools/campaign-create.ts
+++ b/packages/mcp/src/tools/campaign-create.ts
@@ -38,7 +38,7 @@ export function registerCampaignCreate(server: McpServer): void {
         .describe("Configuration format"),
       ...cdpConnectionSchema,
     },
-    async ({ config, format, cdpPort, cdpHost, allowRemote }) => {
+    async ({ config, format, cdpPort, cdpHost, allowRemote, accountId }) => {
       // Parse campaign config
       let parsedConfig;
       try {
@@ -55,7 +55,7 @@ export function registerCampaignCreate(server: McpServer): void {
       }
 
       try {
-        const result = await campaignCreate({ config: parsedConfig, cdpPort, cdpHost, allowRemote });
+        const result = await campaignCreate({ config: parsedConfig, cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         if (error instanceof CampaignExecutionError) {

--- a/packages/mcp/src/tools/campaign-delete.ts
+++ b/packages/mcp/src/tools/campaign-delete.ts
@@ -26,9 +26,9 @@ export function registerCampaignDelete(server: McpServer): void {
         .describe("Permanently delete the campaign and all related data instead of archiving"),
       ...cdpConnectionSchema,
     },
-    async ({ campaignId, hard, cdpPort, cdpHost, allowRemote }) => {
+    async ({ campaignId, hard, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await campaignDelete({ campaignId, hard, cdpPort, cdpHost, allowRemote });
+        const result = await campaignDelete({ campaignId, hard, cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         if (error instanceof CampaignExecutionError) {

--- a/packages/mcp/src/tools/campaign-erase.ts
+++ b/packages/mcp/src/tools/campaign-erase.ts
@@ -22,9 +22,9 @@ export function registerCampaignErase(server: McpServer): void {
         .describe("Campaign ID"),
       ...cdpConnectionSchema,
     },
-    async ({ campaignId, cdpPort, cdpHost, allowRemote }) => {
+    async ({ campaignId, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await campaignErase({ campaignId, cdpPort, cdpHost, allowRemote });
+        const result = await campaignErase({ campaignId, cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         if (error instanceof CampaignExecutionError) {

--- a/packages/mcp/src/tools/campaign-exclude-add.ts
+++ b/packages/mcp/src/tools/campaign-exclude-add.ts
@@ -35,9 +35,9 @@ export function registerCampaignExcludeAdd(server: McpServer): void {
         ),
       ...cdpConnectionSchema,
     },
-    async ({ campaignId, personIds, actionId, cdpPort, cdpHost, allowRemote }) => {
+    async ({ campaignId, personIds, actionId, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await campaignExcludeAdd({ campaignId, personIds, actionId, cdpPort, cdpHost, allowRemote });
+        const result = await campaignExcludeAdd({ campaignId, personIds, actionId, cdpPort, cdpHost, allowRemote, accountId });
         const targetLabel = actionId !== undefined
           ? `action ${String(actionId)} in campaign ${String(campaignId)}`
           : `campaign ${String(campaignId)}`;

--- a/packages/mcp/src/tools/campaign-exclude-list.ts
+++ b/packages/mcp/src/tools/campaign-exclude-list.ts
@@ -31,9 +31,9 @@ export function registerCampaignExcludeList(server: McpServer): void {
         ),
       ...cdpConnectionSchema,
     },
-    async ({ campaignId, actionId, cdpPort, cdpHost, allowRemote }) => {
+    async ({ campaignId, actionId, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await campaignExcludeList({ campaignId, actionId, cdpPort, cdpHost, allowRemote });
+        const result = await campaignExcludeList({ campaignId, actionId, cdpPort, cdpHost, allowRemote, accountId });
         const targetLabel = actionId !== undefined
           ? `action ${String(actionId)} in campaign ${String(campaignId)}`
           : `campaign ${String(campaignId)}`;

--- a/packages/mcp/src/tools/campaign-exclude-remove.ts
+++ b/packages/mcp/src/tools/campaign-exclude-remove.ts
@@ -35,9 +35,9 @@ export function registerCampaignExcludeRemove(server: McpServer): void {
         ),
       ...cdpConnectionSchema,
     },
-    async ({ campaignId, personIds, actionId, cdpPort, cdpHost, allowRemote }) => {
+    async ({ campaignId, personIds, actionId, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await campaignExcludeRemove({ campaignId, personIds, actionId, cdpPort, cdpHost, allowRemote });
+        const result = await campaignExcludeRemove({ campaignId, personIds, actionId, cdpPort, cdpHost, allowRemote, accountId });
         const targetLabel = actionId !== undefined
           ? `action ${String(actionId)} in campaign ${String(campaignId)}`
           : `campaign ${String(campaignId)}`;

--- a/packages/mcp/src/tools/campaign-export.ts
+++ b/packages/mcp/src/tools/campaign-export.ts
@@ -26,9 +26,9 @@ export function registerCampaignExport(server: McpServer): void {
         .describe("Export format"),
       ...cdpConnectionSchema,
     },
-    async ({ campaignId, format, cdpPort, cdpHost, allowRemote }) => {
+    async ({ campaignId, format, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await campaignExport({ campaignId, format, cdpPort, cdpHost, allowRemote });
+        const result = await campaignExport({ campaignId, format, cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         return mcpCatchAll(error, "Failed to export campaign");

--- a/packages/mcp/src/tools/campaign-get.ts
+++ b/packages/mcp/src/tools/campaign-get.ts
@@ -21,9 +21,9 @@ export function registerCampaignGet(server: McpServer): void {
         .describe("Campaign ID"),
       ...cdpConnectionSchema,
     },
-    async ({ campaignId, cdpPort, cdpHost, allowRemote }) => {
+    async ({ campaignId, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await campaignGet({ campaignId, cdpPort, cdpHost, allowRemote });
+        const result = await campaignGet({ campaignId, cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         return mcpCatchAll(error, "Failed to get campaign");

--- a/packages/mcp/src/tools/campaign-list-people.ts
+++ b/packages/mcp/src/tools/campaign-list-people.ts
@@ -46,9 +46,9 @@ export function registerCampaignListPeople(server: McpServer): void {
         .describe("Pagination offset (default: 0)"),
       ...cdpConnectionSchema,
     },
-    async ({ campaignId, actionId, status, limit, offset, cdpPort, cdpHost, allowRemote }) => {
+    async ({ campaignId, actionId, status, limit, offset, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await campaignListPeople({ campaignId, actionId, status, limit, offset, cdpPort, cdpHost, allowRemote });
+        const result = await campaignListPeople({ campaignId, actionId, status, limit, offset, cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         if (error instanceof ActionNotFoundError) {

--- a/packages/mcp/src/tools/campaign-list.ts
+++ b/packages/mcp/src/tools/campaign-list.ts
@@ -21,9 +21,9 @@ export function registerCampaignList(server: McpServer): void {
         .describe("Include archived campaigns"),
       ...cdpConnectionSchema,
     },
-    async ({ includeArchived, cdpPort, cdpHost, allowRemote }) => {
+    async ({ includeArchived, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await campaignList({ includeArchived, cdpPort, cdpHost, allowRemote });
+        const result = await campaignList({ includeArchived, cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         return mcpCatchAll(error, "Failed to list campaigns");

--- a/packages/mcp/src/tools/campaign-move-next.ts
+++ b/packages/mcp/src/tools/campaign-move-next.ts
@@ -32,9 +32,9 @@ export function registerCampaignMoveNext(server: McpServer): void {
         .describe("Person IDs to advance to the next action"),
       ...cdpConnectionSchema,
     },
-    async ({ campaignId, actionId, personIds, cdpPort, cdpHost, allowRemote }) => {
+    async ({ campaignId, actionId, personIds, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await campaignMoveNext({ campaignId, actionId, personIds, cdpPort, cdpHost, allowRemote });
+        const result = await campaignMoveNext({ campaignId, actionId, personIds, cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         if (error instanceof ActionNotFoundError) {

--- a/packages/mcp/src/tools/campaign-remove-action.ts
+++ b/packages/mcp/src/tools/campaign-remove-action.ts
@@ -28,9 +28,9 @@ export function registerCampaignRemoveAction(server: McpServer): void {
         .describe("Action ID to remove"),
       ...cdpConnectionSchema,
     },
-    async ({ campaignId, actionId, cdpPort, cdpHost, allowRemote }) => {
+    async ({ campaignId, actionId, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await campaignRemoveAction({ campaignId, actionId, cdpPort, cdpHost, allowRemote });
+        const result = await campaignRemoveAction({ campaignId, actionId, cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         if (error instanceof ActionNotFoundError) {

--- a/packages/mcp/src/tools/campaign-remove-people.ts
+++ b/packages/mcp/src/tools/campaign-remove-people.ts
@@ -26,9 +26,9 @@ export function registerCampaignRemovePeople(server: McpServer): void {
         .describe("Person IDs to remove from the campaign target list"),
       ...cdpConnectionSchema,
     },
-    async ({ campaignId, personIds, cdpPort, cdpHost, allowRemote }) => {
+    async ({ campaignId, personIds, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await campaignRemovePeople({ campaignId, personIds, cdpPort, cdpHost, allowRemote });
+        const result = await campaignRemovePeople({ campaignId, personIds, cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         if (error instanceof CampaignExecutionError) {

--- a/packages/mcp/src/tools/campaign-reorder-actions.ts
+++ b/packages/mcp/src/tools/campaign-reorder-actions.ts
@@ -27,9 +27,9 @@ export function registerCampaignReorderActions(server: McpServer): void {
         .describe("Action IDs in the desired order"),
       ...cdpConnectionSchema,
     },
-    async ({ campaignId, actionIds, cdpPort, cdpHost, allowRemote }) => {
+    async ({ campaignId, actionIds, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await campaignReorderActions({ campaignId, actionIds, cdpPort, cdpHost, allowRemote });
+        const result = await campaignReorderActions({ campaignId, actionIds, cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         if (error instanceof ActionNotFoundError) {

--- a/packages/mcp/src/tools/campaign-retry.ts
+++ b/packages/mcp/src/tools/campaign-retry.ts
@@ -25,9 +25,9 @@ export function registerCampaignRetry(server: McpServer): void {
         .describe("Person IDs to reset for retry"),
       ...cdpConnectionSchema,
     },
-    async ({ campaignId, personIds, cdpPort, cdpHost, allowRemote }) => {
+    async ({ campaignId, personIds, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await campaignRetry({ campaignId, personIds, cdpPort, cdpHost, allowRemote });
+        const result = await campaignRetry({ campaignId, personIds, cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         return mcpCatchAll(error, "Failed to reset persons for retry");

--- a/packages/mcp/src/tools/campaign-start.ts
+++ b/packages/mcp/src/tools/campaign-start.ts
@@ -27,9 +27,9 @@ export function registerCampaignStart(server: McpServer): void {
         .describe("Person IDs to target"),
       ...cdpConnectionSchema,
     },
-    async ({ campaignId, personIds, cdpPort, cdpHost, allowRemote }) => {
+    async ({ campaignId, personIds, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await campaignStart({ campaignId, personIds, cdpPort, cdpHost, allowRemote });
+        const result = await campaignStart({ campaignId, personIds, cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         if (error instanceof CampaignTimeoutError) {

--- a/packages/mcp/src/tools/campaign-statistics.ts
+++ b/packages/mcp/src/tools/campaign-statistics.ts
@@ -35,9 +35,9 @@ export function registerCampaignStatistics(server: McpServer): void {
         .describe("Maximum number of top errors per action (default: 5)"),
       ...cdpConnectionSchema,
     },
-    async ({ campaignId, actionId, maxErrors, cdpPort, cdpHost, allowRemote }) => {
+    async ({ campaignId, actionId, maxErrors, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await campaignStatistics({ campaignId, actionId, maxErrors, cdpPort, cdpHost, allowRemote });
+        const result = await campaignStatistics({ campaignId, actionId, maxErrors, cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         if (error instanceof ActionNotFoundError) {

--- a/packages/mcp/src/tools/campaign-status.ts
+++ b/packages/mcp/src/tools/campaign-status.ts
@@ -34,7 +34,7 @@ export function registerCampaignStatus(server: McpServer): void {
         .describe("Max results to return"),
       ...cdpConnectionSchema,
     },
-    async ({ campaignId, includeResults, limit, cdpPort, cdpHost, allowRemote }) => {
+    async ({ campaignId, includeResults, limit, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
         const result = await campaignStatus({
           campaignId,
@@ -43,6 +43,7 @@ export function registerCampaignStatus(server: McpServer): void {
           cdpPort,
           cdpHost,
           allowRemote,
+          accountId,
         });
 
         return mcpSuccess(JSON.stringify(result, null, 2));

--- a/packages/mcp/src/tools/campaign-stop.ts
+++ b/packages/mcp/src/tools/campaign-stop.ts
@@ -22,9 +22,9 @@ export function registerCampaignStop(server: McpServer): void {
         .describe("Campaign ID"),
       ...cdpConnectionSchema,
     },
-    async ({ campaignId, cdpPort, cdpHost, allowRemote }) => {
+    async ({ campaignId, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await campaignStop({ campaignId, cdpPort, cdpHost, allowRemote });
+        const result = await campaignStop({ campaignId, cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         if (error instanceof CampaignExecutionError) {

--- a/packages/mcp/src/tools/campaign-update-action.ts
+++ b/packages/mcp/src/tools/campaign-update-action.ts
@@ -61,6 +61,7 @@ export function registerCampaignUpdateAction(server: McpServer): void {
       cdpPort,
       cdpHost,
       allowRemote,
+      accountId,
     }) => {
       // Parse action settings JSON if provided
       let parsedSettings: Record<string, unknown> | undefined;
@@ -76,7 +77,7 @@ export function registerCampaignUpdateAction(server: McpServer): void {
         const result = await campaignUpdateAction({
           campaignId, actionId, name, description, coolDown,
           maxActionResultsPerIteration, actionSettings: parsedSettings,
-          cdpPort, cdpHost, allowRemote,
+          cdpPort, cdpHost, allowRemote, accountId,
         });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {

--- a/packages/mcp/src/tools/campaign-update.ts
+++ b/packages/mcp/src/tools/campaign-update.ts
@@ -30,7 +30,7 @@ export function registerCampaignUpdate(server: McpServer): void {
         .describe("New campaign description (null to clear)"),
       ...cdpConnectionSchema,
     },
-    async ({ campaignId, name, description, cdpPort, cdpHost, allowRemote }) => {
+    async ({ campaignId, name, description, cdpPort, cdpHost, allowRemote, accountId }) => {
       // Validate that at least one field is provided
       if (name === undefined && description === undefined) {
         return mcpError("At least one of name or description must be provided.");
@@ -41,7 +41,7 @@ export function registerCampaignUpdate(server: McpServer): void {
       if (description !== undefined) updates.description = description;
 
       try {
-        const result = await campaignUpdate({ campaignId, updates, cdpPort, cdpHost, allowRemote });
+        const result = await campaignUpdate({ campaignId, updates, cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         return mcpCatchAll(error, "Failed to update campaign");

--- a/packages/mcp/src/tools/check-replies.ts
+++ b/packages/mcp/src/tools/check-replies.ts
@@ -32,9 +32,9 @@ export function registerCheckReplies(server: McpServer): void {
         ),
       ...cdpConnectionSchema,
     },
-    async ({ personIds, since, pauseOthers, cdpPort, cdpHost, allowRemote }) => {
+    async ({ personIds, since, pauseOthers, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await checkReplies({ personIds, since, pauseOthers, cdpPort, cdpHost, allowRemote });
+        const result = await checkReplies({ personIds, since, pauseOthers, cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         return mcpCatchAll(error, "Failed to check replies");

--- a/packages/mcp/src/tools/check-status.test.ts
+++ b/packages/mcp/src/tools/check-status.test.ts
@@ -101,6 +101,22 @@ describe("registerCheckStatus", () => {
     expect(mockedCheckStatus).toHaveBeenCalledWith(4567, {});
   });
 
+  it("forwards accountId to checkStatus via buildCdpOptions", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCheckStatus(server);
+
+    mockedCheckStatus.mockResolvedValue({
+      launcher: { reachable: false, port: 4567 },
+      instances: [],
+      databases: [],
+    });
+
+    const handler = getHandler("check-status");
+    await handler({ cdpPort: 4567, accountId: 550116 });
+
+    expect(mockedCheckStatus).toHaveBeenCalledWith(4567, { accountId: 550116 });
+  });
+
   it("returns error when checkStatus throws", async () => {
     const { server, getHandler } = createMockServer();
     registerCheckStatus(server);

--- a/packages/mcp/src/tools/check-status.ts
+++ b/packages/mcp/src/tools/check-status.ts
@@ -13,9 +13,9 @@ export function registerCheckStatus(server: McpServer): void {
     {
       ...cdpConnectionSchema,
     },
-    async ({ cdpPort, cdpHost, allowRemote }) => {
+    async ({ cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const report = await checkStatus(cdpPort, buildCdpOptions({ cdpHost, allowRemote }));
+        const report = await checkStatus(cdpPort, buildCdpOptions({ cdpHost, allowRemote, accountId }));
 
         return mcpSuccess(JSON.stringify(report, null, 2));
       } catch (error) {

--- a/packages/mcp/src/tools/collect-people.ts
+++ b/packages/mcp/src/tools/collect-people.ts
@@ -50,7 +50,7 @@ export function registerCollectPeople(server: McpServer): void {
         .describe("Explicit source type to bypass URL detection (e.g., SearchPage, MyConnections)"),
       ...cdpConnectionSchema,
     },
-    async ({ campaignId, sourceUrl, limit, maxPages, pageSize, sourceType, cdpPort, cdpHost, allowRemote }) => {
+    async ({ campaignId, sourceUrl, limit, maxPages, pageSize, sourceType, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
         const result = await withLoggedInStateRetryAtPort(
           cdpPort,
@@ -67,6 +67,7 @@ export function registerCollectPeople(server: McpServer): void {
           cdpPort,
           ...(cdpHost !== undefined && { cdpHost }),
           ...(allowRemote !== undefined && { allowRemote }),
+          ...(accountId !== undefined && { accountId }),
           }),
         );
         return mcpSuccess(JSON.stringify(result, null, 2));

--- a/packages/mcp/src/tools/create-collection.ts
+++ b/packages/mcp/src/tools/create-collection.ts
@@ -18,9 +18,9 @@ export function registerCreateCollection(server: McpServer): void {
         .describe("Name for the new collection"),
       ...cdpConnectionSchema,
     },
-    async ({ name, cdpPort, cdpHost, allowRemote }) => {
+    async ({ name, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await createCollection({ name, cdpPort, cdpHost, allowRemote });
+        const result = await createCollection({ name, cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         return mcpCatchAll(error, "Failed to create collection");

--- a/packages/mcp/src/tools/delete-collection.ts
+++ b/packages/mcp/src/tools/delete-collection.ts
@@ -19,9 +19,9 @@ export function registerDeleteCollection(server: McpServer): void {
         .describe("Collection ID to delete"),
       ...cdpConnectionSchema,
     },
-    async ({ collectionId, cdpPort, cdpHost, allowRemote }) => {
+    async ({ collectionId, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await deleteCollection({ collectionId, cdpPort, cdpHost, allowRemote });
+        const result = await deleteCollection({ collectionId, cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         return mcpCatchAll(error, "Failed to delete collection");

--- a/packages/mcp/src/tools/dismiss-errors.ts
+++ b/packages/mcp/src/tools/dismiss-errors.ts
@@ -13,9 +13,9 @@ export function registerDismissErrors(server: McpServer): void {
     {
       ...cdpConnectionSchema,
     },
-    async ({ cdpPort, cdpHost, allowRemote }) => {
+    async ({ cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await dismissErrors({ cdpPort, cdpHost, allowRemote });
+        const result = await dismissErrors({ cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         return mcpCatchAll(error, "Failed to dismiss errors");

--- a/packages/mcp/src/tools/dismiss-feed-post.ts
+++ b/packages/mcp/src/tools/dismiss-feed-post.ts
@@ -19,7 +19,7 @@ export function registerDismissFeedPost(server: McpServer): void {
       dryRun: z.boolean().optional().default(false).describe("When true, locate the menu item but do not click it"),
       ...cdpConnectionSchema,
     },
-    async ({ feedIndex, dryRun, cdpPort, cdpHost, allowRemote }) => {
+    async ({ feedIndex, dryRun, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
         const result = await withLoggedInStateRetryAtPort(
           cdpPort,
@@ -31,6 +31,7 @@ export function registerDismissFeedPost(server: McpServer): void {
           cdpPort,
           cdpHost,
           allowRemote,
+          accountId,
           dryRun,
           }),
         );

--- a/packages/mcp/src/tools/get-action-budget.ts
+++ b/packages/mcp/src/tools/get-action-budget.ts
@@ -13,9 +13,9 @@ export function registerGetActionBudget(server: McpServer): void {
     {
       ...cdpConnectionSchema,
     },
-    async ({ cdpPort, cdpHost, allowRemote }) => {
+    async ({ cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await getActionBudget({ cdpPort, cdpHost, allowRemote });
+        const result = await getActionBudget({ cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         return mcpCatchAll(error, "Failed to get action budget");

--- a/packages/mcp/src/tools/get-errors.ts
+++ b/packages/mcp/src/tools/get-errors.ts
@@ -13,9 +13,9 @@ export function registerGetErrors(server: McpServer): void {
     {
       ...cdpConnectionSchema,
     },
-    async ({ cdpPort, cdpHost, allowRemote }) => {
+    async ({ cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await getErrors({ cdpPort, cdpHost, allowRemote });
+        const result = await getErrors({ cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         return mcpCatchAll(error, "Failed to get errors");

--- a/packages/mcp/src/tools/get-feed.ts
+++ b/packages/mcp/src/tools/get-feed.ts
@@ -30,7 +30,7 @@ export function registerGetFeed(server: McpServer): void {
         ),
       ...cdpConnectionSchema,
     },
-    async ({ count, cursor, cdpPort, cdpHost, allowRemote }) => {
+    async ({ count, cursor, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
         const result = await withLoggedInStateRetryAtPort(
           cdpPort,
@@ -43,6 +43,7 @@ export function registerGetFeed(server: McpServer): void {
           cdpPort,
           cdpHost,
           allowRemote,
+          accountId,
           }),
         );
         return mcpSuccess(JSON.stringify(result, null, 2));

--- a/packages/mcp/src/tools/get-post-engagers.ts
+++ b/packages/mcp/src/tools/get-post-engagers.ts
@@ -33,7 +33,7 @@ export function registerGetPostEngagers(server: McpServer): void {
         .describe("Number of engagers per page (default: 20)"),
       ...cdpConnectionSchema,
     },
-    async ({ postUrl, start, count, cdpPort, cdpHost, allowRemote }) => {
+    async ({ postUrl, start, count, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
         const result = await getPostEngagers({
           postUrl,
@@ -42,6 +42,7 @@ export function registerGetPostEngagers(server: McpServer): void {
           cdpPort,
           cdpHost,
           allowRemote,
+          accountId,
         });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {

--- a/packages/mcp/src/tools/get-post-stats.ts
+++ b/packages/mcp/src/tools/get-post-stats.ts
@@ -19,9 +19,9 @@ export function registerGetPostStats(server: McpServer): void {
         ),
       ...cdpConnectionSchema,
     },
-    async ({ postUrl, cdpPort, cdpHost, allowRemote }) => {
+    async ({ postUrl, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await getPostStats({ postUrl, cdpPort, cdpHost, allowRemote });
+        const result = await getPostStats({ postUrl, cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         return mcpCatchAll(error, "Failed to get post stats");

--- a/packages/mcp/src/tools/get-post.ts
+++ b/packages/mcp/src/tools/get-post.ts
@@ -26,7 +26,7 @@ export function registerGetPost(server: McpServer): void {
         .describe("Maximum number of comments to load (default: 100, 0 to skip)"),
       ...cdpConnectionSchema,
     },
-    async ({ postUrl, commentCount, cdpPort, cdpHost, allowRemote }) => {
+    async ({ postUrl, commentCount, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
         const result = await getPost({
           postUrl,
@@ -34,6 +34,7 @@ export function registerGetPost(server: McpServer): void {
           cdpPort,
           cdpHost,
           allowRemote,
+          accountId,
         });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {

--- a/packages/mcp/src/tools/get-profile-activity.ts
+++ b/packages/mcp/src/tools/get-profile-activity.ts
@@ -30,7 +30,7 @@ export function registerGetProfileActivity(server: McpServer): void {
         .describe("Cursor token from a previous call for the next page"),
       ...cdpConnectionSchema,
     },
-    async ({ profile, count, cursor, cdpPort, cdpHost, allowRemote }) => {
+    async ({ profile, count, cursor, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
         const result = await getProfileActivity({
           profile,
@@ -39,6 +39,7 @@ export function registerGetProfileActivity(server: McpServer): void {
           cdpPort,
           cdpHost,
           allowRemote,
+          accountId,
         });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {

--- a/packages/mcp/src/tools/get-throttle-status.ts
+++ b/packages/mcp/src/tools/get-throttle-status.ts
@@ -13,9 +13,9 @@ export function registerGetThrottleStatus(server: McpServer): void {
     {
       ...cdpConnectionSchema,
     },
-    async ({ cdpPort, cdpHost, allowRemote }) => {
+    async ({ cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await getThrottleStatus({ cdpPort, cdpHost, allowRemote });
+        const result = await getThrottleStatus({ cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         return mcpCatchAll(error, "Failed to get throttle status");

--- a/packages/mcp/src/tools/hide-feed-author-profile.ts
+++ b/packages/mcp/src/tools/hide-feed-author-profile.ts
@@ -30,7 +30,7 @@ export function registerHideFeedAuthorProfile(server: McpServer): void {
         ),
       ...cdpConnectionSchema,
     },
-    async ({ profileUrl, dryRun, cdpPort, cdpHost, allowRemote }) => {
+    async ({ profileUrl, dryRun, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
         const result = await withLoggedInStateRetryAtPort(
           cdpPort,
@@ -42,6 +42,7 @@ export function registerHideFeedAuthorProfile(server: McpServer): void {
           cdpPort,
           cdpHost,
           allowRemote,
+          accountId,
           dryRun,
           }),
         );

--- a/packages/mcp/src/tools/hide-feed-author.ts
+++ b/packages/mcp/src/tools/hide-feed-author.ts
@@ -19,7 +19,7 @@ export function registerHideFeedAuthor(server: McpServer): void {
       dryRun: z.boolean().optional().default(false).describe("When true, locate the menu item but do not click it"),
       ...cdpConnectionSchema,
     },
-    async ({ feedIndex, dryRun, cdpPort, cdpHost, allowRemote }) => {
+    async ({ feedIndex, dryRun, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
         const result = await withLoggedInStateRetryAtPort(
           cdpPort,
@@ -31,6 +31,7 @@ export function registerHideFeedAuthor(server: McpServer): void {
           cdpPort,
           cdpHost,
           allowRemote,
+          accountId,
           dryRun,
           }),
         );

--- a/packages/mcp/src/tools/import-people-from-collection.ts
+++ b/packages/mcp/src/tools/import-people-from-collection.ts
@@ -27,9 +27,9 @@ export function registerImportPeopleFromCollection(server: McpServer): void {
         .describe("Campaign ID to import people into"),
       ...cdpConnectionSchema,
     },
-    async ({ collectionId, campaignId, cdpPort, cdpHost, allowRemote }) => {
+    async ({ collectionId, campaignId, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await importPeopleFromCollection({ collectionId, campaignId, cdpPort, cdpHost, allowRemote });
+        const result = await importPeopleFromCollection({ collectionId, campaignId, cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         if (error instanceof CampaignExecutionError) {

--- a/packages/mcp/src/tools/import-people-from-urls.ts
+++ b/packages/mcp/src/tools/import-people-from-urls.ts
@@ -26,9 +26,9 @@ export function registerImportPeopleFromUrls(server: McpServer): void {
         .describe("LinkedIn profile URLs to import"),
       ...cdpConnectionSchema,
     },
-    async ({ campaignId, linkedInUrls, cdpPort, cdpHost, allowRemote }) => {
+    async ({ campaignId, linkedInUrls, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await importPeopleFromUrls({ campaignId, linkedInUrls, cdpPort, cdpHost, allowRemote });
+        const result = await importPeopleFromUrls({ campaignId, linkedInUrls, cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         if (error instanceof CampaignExecutionError) {

--- a/packages/mcp/src/tools/list-accounts.ts
+++ b/packages/mcp/src/tools/list-accounts.ts
@@ -20,10 +20,10 @@ export function registerListAccounts(server: McpServer): void {
           "When true, enumerate accounts across every workspace the user belongs to, not just the selected workspace. Default: false.",
         ),
     },
-    async ({ cdpPort, cdpHost, allowRemote, includeAllWorkspaces }) => {
+    async ({ cdpPort, cdpHost, allowRemote, accountId, includeAllWorkspaces }) => {
       try {
         const port = await resolveLauncherPort(cdpPort, cdpHost);
-        const launcher = new LauncherService(port, buildCdpOptions({ cdpHost, allowRemote }));
+        const launcher = new LauncherService(port, buildCdpOptions({ cdpHost, allowRemote, accountId }));
 
         try {
           await launcher.connect();

--- a/packages/mcp/src/tools/list-collections.ts
+++ b/packages/mcp/src/tools/list-collections.ts
@@ -13,9 +13,9 @@ export function registerListCollections(server: McpServer): void {
     {
       ...cdpConnectionSchema,
     },
-    async ({ cdpPort, cdpHost, allowRemote }) => {
+    async ({ cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await listCollections({ cdpPort, cdpHost, allowRemote });
+        const result = await listCollections({ cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         return mcpCatchAll(error, "Failed to list collections");

--- a/packages/mcp/src/tools/list-workspaces.ts
+++ b/packages/mcp/src/tools/list-workspaces.ts
@@ -24,10 +24,10 @@ export function registerListWorkspaces(server: McpServer): void {
     {
       ...cdpConnectionSchema,
     },
-    async ({ cdpPort, cdpHost, allowRemote }) => {
+    async ({ cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
         const port = await resolveLauncherPort(cdpPort, cdpHost);
-        const launcher = new LauncherService(port, buildCdpOptions({ cdpHost, allowRemote }));
+        const launcher = new LauncherService(port, buildCdpOptions({ cdpHost, allowRemote, accountId }));
 
         try {
           await launcher.connect();

--- a/packages/mcp/src/tools/query-messages.ts
+++ b/packages/mcp/src/tools/query-messages.ts
@@ -45,9 +45,9 @@ export function registerQueryMessages(server: McpServer): void {
         .describe("Pagination offset (default: 0)"),
       ...cdpConnectionSchema,
     },
-    async ({ personId, chatId, search, limit, offset, cdpPort, cdpHost, allowRemote }) => {
+    async ({ personId, chatId, search, limit, offset, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await queryMessages({ personId, chatId, search, limit, offset, cdpPort, cdpHost, allowRemote });
+        const result = await queryMessages({ personId, chatId, search, limit, offset, cdpPort, cdpHost, allowRemote, accountId });
         if (result.kind === "thread") return mcpSuccess(JSON.stringify(result.thread, null, 2));
         if (result.kind === "search") return mcpSuccess(JSON.stringify({ messages: result.messages, total: result.total }, null, 2));
         return mcpSuccess(JSON.stringify({ conversations: result.conversations, total: result.total }, null, 2));

--- a/packages/mcp/src/tools/react-to-comment.ts
+++ b/packages/mcp/src/tools/react-to-comment.ts
@@ -36,7 +36,7 @@ export function registerReactToComment(server: McpServer): void {
       dryRun: z.boolean().optional().default(false).describe("When true, detect current reaction state without clicking"),
       ...cdpConnectionSchema,
     },
-    async ({ postUrl, commentUrn, reactionType, dryRun, cdpPort, cdpHost, allowRemote }) => {
+    async ({ postUrl, commentUrn, reactionType, dryRun, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
         const result = await withLoggedInStateRetryAtPort(
           cdpPort,
@@ -50,6 +50,7 @@ export function registerReactToComment(server: McpServer): void {
           cdpPort,
           cdpHost,
           allowRemote,
+          accountId,
           dryRun,
           }),
         );

--- a/packages/mcp/src/tools/react-to-post.ts
+++ b/packages/mcp/src/tools/react-to-post.ts
@@ -31,7 +31,7 @@ export function registerReactToPost(server: McpServer): void {
       dryRun: z.boolean().optional().default(false).describe("When true, detect current reaction state without clicking"),
       ...cdpConnectionSchema,
     },
-    async ({ postUrl, reactionType, dryRun, cdpPort, cdpHost, allowRemote }) => {
+    async ({ postUrl, reactionType, dryRun, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
         const result = await withLoggedInStateRetryAtPort(
           cdpPort,
@@ -44,6 +44,7 @@ export function registerReactToPost(server: McpServer): void {
               cdpPort,
               cdpHost,
               allowRemote,
+              accountId,
               dryRun,
             }),
         );

--- a/packages/mcp/src/tools/remove-people-from-collection.ts
+++ b/packages/mcp/src/tools/remove-people-from-collection.ts
@@ -23,9 +23,9 @@ export function registerRemovePeopleFromCollection(server: McpServer): void {
         .describe("Person IDs to remove from the collection"),
       ...cdpConnectionSchema,
     },
-    async ({ collectionId, personIds, cdpPort, cdpHost, allowRemote }) => {
+    async ({ collectionId, personIds, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await removePeopleFromCollection({ collectionId, personIds, cdpPort, cdpHost, allowRemote });
+        const result = await removePeopleFromCollection({ collectionId, personIds, cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         return mcpCatchAll(error, "Failed to remove people from collection");

--- a/packages/mcp/src/tools/scrape-messaging-history.ts
+++ b/packages/mcp/src/tools/scrape-messaging-history.ts
@@ -27,13 +27,13 @@ export function registerScrapeMessagingHistory(server: McpServer): void {
         ),
       ...cdpConnectionSchema,
     },
-    async ({ personIds, pauseOthers, cdpPort, cdpHost, allowRemote }) => {
+    async ({ personIds, pauseOthers, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
         const result = await withLoggedInStateRetryAtPort(
           cdpPort,
           cdpHost ?? "127.0.0.1",
           allowRemote ?? false,
-          () => scrapeMessagingHistory({ personIds, pauseOthers, cdpPort, cdpHost, allowRemote }),
+          () => scrapeMessagingHistory({ personIds, pauseOthers, cdpPort, cdpHost, allowRemote, accountId }),
         );
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {

--- a/packages/mcp/src/tools/search-posts.ts
+++ b/packages/mcp/src/tools/search-posts.ts
@@ -37,7 +37,7 @@ export function registerSearchPosts(server: McpServer): void {
         ),
       ...cdpConnectionSchema,
     },
-    async ({ query, count, cursor, cdpPort, cdpHost, allowRemote }) => {
+    async ({ query, count, cursor, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
         const result = await withLoggedInStateRetryAtPort(
           cdpPort,
@@ -51,6 +51,7 @@ export function registerSearchPosts(server: McpServer): void {
           cdpPort,
           cdpHost,
           allowRemote,
+          accountId,
           }),
         );
         return mcpSuccess(JSON.stringify(result, null, 2));

--- a/packages/mcp/src/tools/unfollow-from-feed.ts
+++ b/packages/mcp/src/tools/unfollow-from-feed.ts
@@ -19,7 +19,7 @@ export function registerUnfollowFromFeed(server: McpServer): void {
       dryRun: z.boolean().optional().default(false).describe("When true, locate the menu item but do not click it"),
       ...cdpConnectionSchema,
     },
-    async ({ feedIndex, dryRun, cdpPort, cdpHost, allowRemote }) => {
+    async ({ feedIndex, dryRun, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
         const result = await withLoggedInStateRetryAtPort(
           cdpPort,
@@ -31,6 +31,7 @@ export function registerUnfollowFromFeed(server: McpServer): void {
           cdpPort,
           cdpHost,
           allowRemote,
+          accountId,
           dryRun,
           }),
         );

--- a/packages/mcp/src/tools/unfollow-profile.ts
+++ b/packages/mcp/src/tools/unfollow-profile.ts
@@ -30,7 +30,7 @@ export function registerUnfollowProfile(server: McpServer): void {
         ),
       ...cdpConnectionSchema,
     },
-    async ({ profileUrl, dryRun, cdpPort, cdpHost, allowRemote }) => {
+    async ({ profileUrl, dryRun, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
         const result = await withLoggedInStateRetryAtPort(
           cdpPort,
@@ -42,6 +42,7 @@ export function registerUnfollowProfile(server: McpServer): void {
           cdpPort,
           cdpHost,
           allowRemote,
+          accountId,
           dryRun,
           }),
         );


### PR DESCRIPTION
Closes #793

## Summary

`cdpConnectionSchema` in `packages/mcp/src/helpers.ts` declares `accountId` as an optional field, and core (`buildCdpOptions` → `resolveAccount`) honors it. But the MCP tool handlers under `packages/mcp/src/tools/` destructured only `{ cdpPort, cdpHost, allowRemote }` from the handler args and forwarded only those to the core operation — `accountId` was silently dropped at the MCP boundary.

With multiple LinkedHelper accounts configured, this surfaced as `AccountResolutionError: Multiple accounts found` on every tool call that targets a specific account, even when `accountId` was supplied as a tool argument.

## Changes

53 tool handlers under `packages/mcp/src/tools/` updated to thread `accountId` end-to-end. Three handler shape variants exist; all three are covered:

- **One-line destructure + inline call** (e.g. `campaign-create.ts`, ~36 files): `{ ..., cdpPort, cdpHost, allowRemote, accountId }` in both the handler signature and the core-call object.
- **`buildCdpOptions({...})` wrapper** (`check-status.ts`): `accountId` added inside the `buildCdpOptions(...)` argument.
- **Multi-line destructure / multi-line core-call object** (e.g. `campaign-add-action.ts`, ~17 files): `accountId` added on its own line in both places, including the conditional-spread variant in `collect-people.ts` (`...(accountId !== undefined && { accountId })`).

Added forwarding tests in `campaign-create.test.ts`, `check-status.test.ts`, and `campaign-add-action.test.ts` — one per handler shape — asserting the core function is invoked with `accountId` when supplied.

`start-instance.ts` and `stop-instance.ts` were already correct and were not modified.

## Verification

- `pnpm install --frozen-lockfile` — clean
- `pnpm build` — clean
- `pnpm lint` — clean
- `pnpm --filter @lhremote/mcp test` — 489/489 (was 486/486 before, +3 new forwarding tests)
- Locally tested live against a 4-account LinkedHelper install: `mcp__lhremote__campaign-list { accountId: 550116 }` and `mcp__lhremote__campaign-create { accountId: 550116, ... }` now route correctly instead of failing with the multi-account error.

## Out of scope

CLI handlers under `packages/cli/src/handlers/` have a related but distinct gap — `accountId` is not in the option type, not declared as a CLI flag in `program.ts`, and not threaded into core. That fix is larger (option plumbing + flag wiring) and should land as a separate PR; happy to file it after this one merges.