### PR TITLE
(chore) release: bump claude-plugin/marketplace/server JSONs to 0.20.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "lhremote",
       "source": "./",
       "description": "LinkedHelper automation toolkit — MCP server and workflow guidance for Claude Code",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "author": {
         "name": "Alexey Pelykh"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lhremote",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "description": "LinkedHelper automation toolkit — MCP server and workflow guidance for Claude Code",
   "author": {
     "name": "Alexey Pelykh",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/alexey-pelykh/lhremote",
     "source": "github"
   },
-  "version": "0.19.0",
+  "version": "0.20.0",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "lhremote",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary

Routine post-release version bump per CLAUDE.md § Infrastructure: the release workflow does NOT auto-bump these JSONs, so they're updated in a follow-up PR after the GitHub Release is tagged.

| File | Field | 0.19.0 → 0.20.0 |
|---|---|---|
| `.claude-plugin/plugin.json` | top-level `version` | ✅ |
| `.claude-plugin/marketplace.json` | `plugins[0].version` | ✅ |
| `server.json` | top-level `version` AND `packages[0].version` | ✅ |

## Release reference

- Tag: [v0.20.0](https://github.com/alexey-pelykh/lhremote/releases/tag/v0.20.0)

## What v0.20.0 ships

- Two regression fixes for LinkedHelper 2.113.61+ that broke ALL react-to-comment and ALL comment-on-post operations: #777 (mws.call typed dispatch), #778 (LinkedIn React/SDUI comment-DOM rewrite)
- LinkedIn ContentWindow state gate: #781 + #782 (`waitForLoggedInState` pre-flight + `withLoggedInStateRetry` transient-retry wrapper)
- Suite-level CW health gate for E2E: #783 (vitest `globalSetup` aborts the whole suite if LH can't reach LoggedInState)
- E2E flake fixes: #784 (feed-dismissal MCP dry-run race), #785 (hide-feed-author back-to-back CDP race)
- Test isolation: #796 (popup-cascade fix — 9 E2E files now dismiss leftover popups in `beforeEach`)
- LH-internal collect saga monitor: #792 (opt-in `monitor: true` flag on `collect-people` auto-dismisses recoverable `IncorrectContentStateError` popups during long-running sagas)

## Test plan

- [x] All 4 version fields read 0.20.0 (`grep -n '"version"'` confirms)
- [ ] CI pass (build + lint + test on ubuntu/macos/windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)