### PR TITLE
(fix) mcp: forward accountId from tool handlers to core operations

### DIFF
--- a/packages/mcp/src/tools/add-people-to-collection.test.ts
+++ b/packages/mcp/src/tools/add-people-to-collection.test.ts
@@ -12,6 +12,7 @@ import { addPeopleToCollection } from "@lhremote/core";
 import { registerAddPeopleToCollection } from "./add-people-to-collection.js";
 import { describeInfrastructureErrors } from "./testing/infrastructure-errors.js";
 import { createMockServer } from "./testing/mock-server.js";
+import { describeAccountIdForwarding } from "./testing/account-id-forwarding.js";
 
 const MOCK_RESULT = {
   success: true as const,
@@ -85,4 +86,12 @@ describe("registerAddPeopleToCollection", () => {
     (error) => vi.mocked(addPeopleToCollection).mockRejectedValue(error),
     "Failed to add people to collection",
   );
+  describeAccountIdForwarding({
+    registerTool: registerAddPeopleToCollection,
+    toolName: "add-people-to-collection",
+    mock: vi.mocked(addPeopleToCollection),
+    baseArgs: { collectionId: 1, personIds: [1] },
+    mockResolvedValue: { added: 0 },
+  });
+
 });

--- a/packages/mcp/src/tools/add-people-to-collection.ts
+++ b/packages/mcp/src/tools/add-people-to-collection.ts
@@ -23,9 +23,9 @@ export function registerAddPeopleToCollection(server: McpServer): void {
         .describe("Person IDs to add to the collection"),
       ...cdpConnectionSchema,
     },
-    async ({ collectionId, personIds, cdpPort, cdpHost, allowRemote }) => {
+    async ({ collectionId, personIds, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await addPeopleToCollection({ collectionId, personIds, cdpPort, cdpHost, allowRemote });
+        const result = await addPeopleToCollection({ collectionId, personIds, cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         return mcpCatchAll(error, "Failed to add people to collection");

--- a/packages/mcp/src/tools/campaign-add-action.test.ts
+++ b/packages/mcp/src/tools/campaign-add-action.test.ts
@@ -20,6 +20,7 @@ import {
 import { registerCampaignAddAction } from "./campaign-add-action.js";
 import { describeInfrastructureErrors } from "./testing/infrastructure-errors.js";
 import { createMockServer } from "./testing/mock-server.js";
+import { describeAccountIdForwarding } from "./testing/account-id-forwarding.js";
 
 const MOCK_ACTION: CampaignAction = {
   id: 50,
@@ -137,4 +138,11 @@ describe("registerCampaignAddAction", () => {
     () => ({ campaignId: 15, name: "Visit", actionType: "VisitAndExtract", cdpPort: 9222 }),
     (error) => vi.mocked(campaignAddAction).mockRejectedValue(error),
   );
+  describeAccountIdForwarding({
+    registerTool: registerCampaignAddAction,
+    toolName: "campaign-add-action",
+    mock: vi.mocked(campaignAddAction),
+    baseArgs: { campaignId: 1, name: "x", actionType: "VisitAndExtract" },
+  });
+
 });

--- a/packages/mcp/src/tools/campaign-add-action.ts
+++ b/packages/mcp/src/tools/campaign-add-action.ts
@@ -56,6 +56,7 @@ export function registerCampaignAddAction(server: McpServer): void {
       cdpPort,
       cdpHost,
       allowRemote,
+      accountId,
     }) => {
       // Parse action settings JSON if provided
       let parsedSettings: Record<string, unknown> = {};
@@ -71,7 +72,7 @@ export function registerCampaignAddAction(server: McpServer): void {
         const result = await campaignAddAction({
           campaignId, name, actionType, description, coolDown,
           maxActionResultsPerIteration, actionSettings: parsedSettings,
-          cdpPort, cdpHost, allowRemote,
+          cdpPort, cdpHost, allowRemote, accountId,
         });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {

--- a/packages/mcp/src/tools/campaign-create.test.ts
+++ b/packages/mcp/src/tools/campaign-create.test.ts
@@ -24,6 +24,7 @@ import {
 
 import { registerCampaignCreate } from "./campaign-create.js";
 import { createMockServer } from "./testing/mock-server.js";
+import { describeAccountIdForwarding } from "./testing/account-id-forwarding.js";
 
 const YAML_CONFIG = `
 version: "1"
@@ -205,4 +206,11 @@ describe("registerCampaignCreate", () => {
       ],
     });
   });
+  describeAccountIdForwarding({
+    registerTool: registerCampaignCreate,
+    toolName: "campaign-create",
+    mock: vi.mocked(campaignCreate),
+    baseArgs: { config: "version: \"1\"\nname: x\nactions: []" },
+  });
+
 });

--- a/packages/mcp/src/tools/campaign-create.ts
+++ b/packages/mcp/src/tools/campaign-create.ts
@@ -38,7 +38,7 @@ export function registerCampaignCreate(server: McpServer): void {
         .describe("Configuration format"),
       ...cdpConnectionSchema,
     },
-    async ({ config, format, cdpPort, cdpHost, allowRemote }) => {
+    async ({ config, format, cdpPort, cdpHost, allowRemote, accountId }) => {
       // Parse campaign config
       let parsedConfig;
       try {
@@ -55,7 +55,7 @@ export function registerCampaignCreate(server: McpServer): void {
       }
 
       try {
-        const result = await campaignCreate({ config: parsedConfig, cdpPort, cdpHost, allowRemote });
+        const result = await campaignCreate({ config: parsedConfig, cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         if (error instanceof CampaignExecutionError) {

--- a/packages/mcp/src/tools/campaign-delete.test.ts
+++ b/packages/mcp/src/tools/campaign-delete.test.ts
@@ -20,6 +20,7 @@ import {
 import { registerCampaignDelete } from "./campaign-delete.js";
 import { describeInfrastructureErrors } from "./testing/infrastructure-errors.js";
 import { createMockServer } from "./testing/mock-server.js";
+import { describeAccountIdForwarding } from "./testing/account-id-forwarding.js";
 
 const DELETE_RESULT = { success: true as const, campaignId: 15, action: "archived" as const };
 
@@ -124,4 +125,11 @@ describe("registerCampaignDelete", () => {
       ],
     });
   });
+  describeAccountIdForwarding({
+    registerTool: registerCampaignDelete,
+    toolName: "campaign-delete",
+    mock: vi.mocked(campaignDelete),
+    baseArgs: { campaignId: 1 },
+  });
+
 });

--- a/packages/mcp/src/tools/campaign-delete.ts
+++ b/packages/mcp/src/tools/campaign-delete.ts
@@ -26,9 +26,9 @@ export function registerCampaignDelete(server: McpServer): void {
         .describe("Permanently delete the campaign and all related data instead of archiving"),
       ...cdpConnectionSchema,
     },
-    async ({ campaignId, hard, cdpPort, cdpHost, allowRemote }) => {
+    async ({ campaignId, hard, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await campaignDelete({ campaignId, hard, cdpPort, cdpHost, allowRemote });
+        const result = await campaignDelete({ campaignId, hard, cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         if (error instanceof CampaignExecutionError) {

--- a/packages/mcp/src/tools/campaign-erase.test.ts
+++ b/packages/mcp/src/tools/campaign-erase.test.ts
@@ -20,6 +20,7 @@ import {
 import { registerCampaignErase } from "./campaign-erase.js";
 import { describeInfrastructureErrors } from "./testing/infrastructure-errors.js";
 import { createMockServer } from "./testing/mock-server.js";
+import { describeAccountIdForwarding } from "./testing/account-id-forwarding.js";
 
 const ERASE_RESULT = { success: true as const, campaignId: 15 };
 
@@ -124,4 +125,11 @@ describe("registerCampaignErase", () => {
       ],
     });
   });
+  describeAccountIdForwarding({
+    registerTool: registerCampaignErase,
+    toolName: "campaign-erase",
+    mock: vi.mocked(campaignErase),
+    baseArgs: { campaignId: 1 },
+  });
+
 });

--- a/packages/mcp/src/tools/campaign-erase.ts
+++ b/packages/mcp/src/tools/campaign-erase.ts
@@ -22,9 +22,9 @@ export function registerCampaignErase(server: McpServer): void {
         .describe("Campaign ID"),
       ...cdpConnectionSchema,
     },
-    async ({ campaignId, cdpPort, cdpHost, allowRemote }) => {
+    async ({ campaignId, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await campaignErase({ campaignId, cdpPort, cdpHost, allowRemote });
+        const result = await campaignErase({ campaignId, cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         if (error instanceof CampaignExecutionError) {

--- a/packages/mcp/src/tools/campaign-exclude-add.test.ts
+++ b/packages/mcp/src/tools/campaign-exclude-add.test.ts
@@ -21,6 +21,7 @@ import {
 import { registerCampaignExcludeAdd } from "./campaign-exclude-add.js";
 import { describeInfrastructureErrors } from "./testing/infrastructure-errors.js";
 import { createMockServer } from "./testing/mock-server.js";
+import { describeAccountIdForwarding } from "./testing/account-id-forwarding.js";
 
 describe("registerCampaignExcludeAdd", () => {
   beforeEach(() => {
@@ -221,4 +222,12 @@ describe("registerCampaignExcludeAdd", () => {
     (error) => vi.mocked(campaignExcludeAdd).mockRejectedValue(error),
     "Failed to add to exclude list",
   );
+  describeAccountIdForwarding({
+    registerTool: registerCampaignExcludeAdd,
+    toolName: "campaign-exclude-add",
+    mock: vi.mocked(campaignExcludeAdd),
+    baseArgs: { campaignId: 1, personIds: [1] },
+    mockResolvedValue: { added: 0 },
+  });
+
 });

--- a/packages/mcp/src/tools/campaign-exclude-add.ts
+++ b/packages/mcp/src/tools/campaign-exclude-add.ts
@@ -35,9 +35,9 @@ export function registerCampaignExcludeAdd(server: McpServer): void {
         ),
       ...cdpConnectionSchema,
     },
-    async ({ campaignId, personIds, actionId, cdpPort, cdpHost, allowRemote }) => {
+    async ({ campaignId, personIds, actionId, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await campaignExcludeAdd({ campaignId, personIds, actionId, cdpPort, cdpHost, allowRemote });
+        const result = await campaignExcludeAdd({ campaignId, personIds, actionId, cdpPort, cdpHost, allowRemote, accountId });
         const targetLabel = actionId !== undefined
           ? `action ${String(actionId)} in campaign ${String(campaignId)}`
           : `campaign ${String(campaignId)}`;

--- a/packages/mcp/src/tools/campaign-exclude-list.test.ts
+++ b/packages/mcp/src/tools/campaign-exclude-list.test.ts
@@ -21,6 +21,7 @@ import {
 import { registerCampaignExcludeList } from "./campaign-exclude-list.js";
 import { describeInfrastructureErrors } from "./testing/infrastructure-errors.js";
 import { createMockServer } from "./testing/mock-server.js";
+import { describeAccountIdForwarding } from "./testing/account-id-forwarding.js";
 
 describe("registerCampaignExcludeList", () => {
   beforeEach(() => {
@@ -252,4 +253,12 @@ describe("registerCampaignExcludeList", () => {
     (error) => vi.mocked(campaignExcludeList).mockRejectedValue(error),
     "Failed to get exclude list",
   );
+  describeAccountIdForwarding({
+    registerTool: registerCampaignExcludeList,
+    toolName: "campaign-exclude-list",
+    mock: vi.mocked(campaignExcludeList),
+    baseArgs: { campaignId: 1 },
+    mockResolvedValue: { count: 0 },
+  });
+
 });

--- a/packages/mcp/src/tools/campaign-exclude-list.ts
+++ b/packages/mcp/src/tools/campaign-exclude-list.ts
@@ -31,9 +31,9 @@ export function registerCampaignExcludeList(server: McpServer): void {
         ),
       ...cdpConnectionSchema,
     },
-    async ({ campaignId, actionId, cdpPort, cdpHost, allowRemote }) => {
+    async ({ campaignId, actionId, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await campaignExcludeList({ campaignId, actionId, cdpPort, cdpHost, allowRemote });
+        const result = await campaignExcludeList({ campaignId, actionId, cdpPort, cdpHost, allowRemote, accountId });
         const targetLabel = actionId !== undefined
           ? `action ${String(actionId)} in campaign ${String(campaignId)}`
           : `campaign ${String(campaignId)}`;

--- a/packages/mcp/src/tools/campaign-exclude-remove.test.ts
+++ b/packages/mcp/src/tools/campaign-exclude-remove.test.ts
@@ -21,6 +21,7 @@ import {
 import { registerCampaignExcludeRemove } from "./campaign-exclude-remove.js";
 import { describeInfrastructureErrors } from "./testing/infrastructure-errors.js";
 import { createMockServer } from "./testing/mock-server.js";
+import { describeAccountIdForwarding } from "./testing/account-id-forwarding.js";
 
 describe("registerCampaignExcludeRemove", () => {
   beforeEach(() => {
@@ -221,4 +222,12 @@ describe("registerCampaignExcludeRemove", () => {
     (error) => vi.mocked(campaignExcludeRemove).mockRejectedValue(error),
     "Failed to remove from exclude list",
   );
+  describeAccountIdForwarding({
+    registerTool: registerCampaignExcludeRemove,
+    toolName: "campaign-exclude-remove",
+    mock: vi.mocked(campaignExcludeRemove),
+    baseArgs: { campaignId: 1, personIds: [1] },
+    mockResolvedValue: { removed: 0 },
+  });
+
 });

--- a/packages/mcp/src/tools/campaign-exclude-remove.ts
+++ b/packages/mcp/src/tools/campaign-exclude-remove.ts
@@ -35,9 +35,9 @@ export function registerCampaignExcludeRemove(server: McpServer): void {
         ),
       ...cdpConnectionSchema,
     },
-    async ({ campaignId, personIds, actionId, cdpPort, cdpHost, allowRemote }) => {
+    async ({ campaignId, personIds, actionId, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await campaignExcludeRemove({ campaignId, personIds, actionId, cdpPort, cdpHost, allowRemote });
+        const result = await campaignExcludeRemove({ campaignId, personIds, actionId, cdpPort, cdpHost, allowRemote, accountId });
         const targetLabel = actionId !== undefined
           ? `action ${String(actionId)} in campaign ${String(campaignId)}`
           : `campaign ${String(campaignId)}`;

--- a/packages/mcp/src/tools/campaign-export.test.ts
+++ b/packages/mcp/src/tools/campaign-export.test.ts
@@ -19,6 +19,7 @@ import {
 import { registerCampaignExport } from "./campaign-export.js";
 import { describeInfrastructureErrors } from "./testing/infrastructure-errors.js";
 import { createMockServer } from "./testing/mock-server.js";
+import { describeAccountIdForwarding } from "./testing/account-id-forwarding.js";
 
 describe("registerCampaignExport", () => {
   beforeEach(() => {
@@ -111,4 +112,11 @@ describe("registerCampaignExport", () => {
     (error) => vi.mocked(campaignExport).mockRejectedValue(error),
     "Failed to export campaign",
   );
+  describeAccountIdForwarding({
+    registerTool: registerCampaignExport,
+    toolName: "campaign-export",
+    mock: vi.mocked(campaignExport),
+    baseArgs: { campaignId: 1 },
+  });
+
 });

--- a/packages/mcp/src/tools/campaign-export.ts
+++ b/packages/mcp/src/tools/campaign-export.ts
@@ -26,9 +26,9 @@ export function registerCampaignExport(server: McpServer): void {
         .describe("Export format"),
       ...cdpConnectionSchema,
     },
-    async ({ campaignId, format, cdpPort, cdpHost, allowRemote }) => {
+    async ({ campaignId, format, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await campaignExport({ campaignId, format, cdpPort, cdpHost, allowRemote });
+        const result = await campaignExport({ campaignId, format, cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         return mcpCatchAll(error, "Failed to export campaign");

--- a/packages/mcp/src/tools/campaign-get.test.ts
+++ b/packages/mcp/src/tools/campaign-get.test.ts
@@ -21,6 +21,7 @@ import {
 import { registerCampaignGet } from "./campaign-get.js";
 import { describeInfrastructureErrors } from "./testing/infrastructure-errors.js";
 import { createMockServer } from "./testing/mock-server.js";
+import { describeAccountIdForwarding } from "./testing/account-id-forwarding.js";
 
 const MOCK_CAMPAIGN: Campaign = {
   id: 15,
@@ -121,4 +122,11 @@ describe("registerCampaignGet", () => {
     (error) => vi.mocked(campaignGet).mockRejectedValue(error),
     "Failed to get campaign",
   );
+  describeAccountIdForwarding({
+    registerTool: registerCampaignGet,
+    toolName: "campaign-get",
+    mock: vi.mocked(campaignGet),
+    baseArgs: { campaignId: 1 },
+  });
+
 });

--- a/packages/mcp/src/tools/campaign-get.ts
+++ b/packages/mcp/src/tools/campaign-get.ts
@@ -21,9 +21,9 @@ export function registerCampaignGet(server: McpServer): void {
         .describe("Campaign ID"),
       ...cdpConnectionSchema,
     },
-    async ({ campaignId, cdpPort, cdpHost, allowRemote }) => {
+    async ({ campaignId, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await campaignGet({ campaignId, cdpPort, cdpHost, allowRemote });
+        const result = await campaignGet({ campaignId, cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         return mcpCatchAll(error, "Failed to get campaign");

--- a/packages/mcp/src/tools/campaign-list-people.test.ts
+++ b/packages/mcp/src/tools/campaign-list-people.test.ts
@@ -22,6 +22,7 @@ import {
 import { registerCampaignListPeople } from "./campaign-list-people.js";
 import { describeInfrastructureErrors } from "./testing/infrastructure-errors.js";
 import { createMockServer } from "./testing/mock-server.js";
+import { describeAccountIdForwarding } from "./testing/account-id-forwarding.js";
 
 const SAMPLE_OUTPUT: CampaignListPeopleOutput = {
   campaignId: 10,
@@ -233,4 +234,12 @@ describe("registerCampaignListPeople", () => {
       ],
     });
   });
+  describeAccountIdForwarding({
+    registerTool: registerCampaignListPeople,
+    toolName: "campaign-list-people",
+    mock: vi.mocked(campaignListPeople),
+    baseArgs: { campaignId: 1 },
+    mockResolvedValue: { people: [], total: 0 },
+  });
+
 });

--- a/packages/mcp/src/tools/campaign-list-people.ts
+++ b/packages/mcp/src/tools/campaign-list-people.ts
@@ -46,9 +46,9 @@ export function registerCampaignListPeople(server: McpServer): void {
         .describe("Pagination offset (default: 0)"),
       ...cdpConnectionSchema,
     },
-    async ({ campaignId, actionId, status, limit, offset, cdpPort, cdpHost, allowRemote }) => {
+    async ({ campaignId, actionId, status, limit, offset, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await campaignListPeople({ campaignId, actionId, status, limit, offset, cdpPort, cdpHost, allowRemote });
+        const result = await campaignListPeople({ campaignId, actionId, status, limit, offset, cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         if (error instanceof ActionNotFoundError) {

--- a/packages/mcp/src/tools/campaign-list.test.ts
+++ b/packages/mcp/src/tools/campaign-list.test.ts
@@ -19,6 +19,7 @@ import {
 import { registerCampaignList } from "./campaign-list.js";
 import { describeInfrastructureErrors } from "./testing/infrastructure-errors.js";
 import { createMockServer } from "./testing/mock-server.js";
+import { describeAccountIdForwarding } from "./testing/account-id-forwarding.js";
 
 const MOCK_CAMPAIGNS: CampaignSummary[] = [
   {
@@ -124,4 +125,12 @@ describe("registerCampaignList", () => {
     (error) => vi.mocked(campaignList).mockRejectedValue(error),
     "Failed to list campaigns",
   );
+  describeAccountIdForwarding({
+    registerTool: registerCampaignList,
+    toolName: "campaign-list",
+    mock: vi.mocked(campaignList),
+    baseArgs: { includeArchived: false },
+    mockResolvedValue: { campaigns: [], total: 0 },
+  });
+
 });

--- a/packages/mcp/src/tools/campaign-list.ts
+++ b/packages/mcp/src/tools/campaign-list.ts
@@ -21,9 +21,9 @@ export function registerCampaignList(server: McpServer): void {
         .describe("Include archived campaigns"),
       ...cdpConnectionSchema,
     },
-    async ({ includeArchived, cdpPort, cdpHost, allowRemote }) => {
+    async ({ includeArchived, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await campaignList({ includeArchived, cdpPort, cdpHost, allowRemote });
+        const result = await campaignList({ includeArchived, cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         return mcpCatchAll(error, "Failed to list campaigns");

--- a/packages/mcp/src/tools/campaign-move-next.test.ts
+++ b/packages/mcp/src/tools/campaign-move-next.test.ts
@@ -21,6 +21,7 @@ import {
 import { registerCampaignMoveNext } from "./campaign-move-next.js";
 import { describeInfrastructureErrors } from "./testing/infrastructure-errors.js";
 import { createMockServer } from "./testing/mock-server.js";
+import { describeAccountIdForwarding } from "./testing/account-id-forwarding.js";
 
 const MOVE_RESULT = {
   success: true as const,
@@ -179,4 +180,11 @@ describe("registerCampaignMoveNext", () => {
     () => ({ campaignId: 10, actionId: 5, personIds: [100], cdpPort: 9222 }),
     (error) => vi.mocked(campaignMoveNext).mockRejectedValue(error),
   );
+  describeAccountIdForwarding({
+    registerTool: registerCampaignMoveNext,
+    toolName: "campaign-move-next",
+    mock: vi.mocked(campaignMoveNext),
+    baseArgs: { campaignId: 1, actionId: 1, personIds: [1] },
+  });
+
 });

--- a/packages/mcp/src/tools/campaign-move-next.ts
+++ b/packages/mcp/src/tools/campaign-move-next.ts
@@ -32,9 +32,9 @@ export function registerCampaignMoveNext(server: McpServer): void {
         .describe("Person IDs to advance to the next action"),
       ...cdpConnectionSchema,
     },
-    async ({ campaignId, actionId, personIds, cdpPort, cdpHost, allowRemote }) => {
+    async ({ campaignId, actionId, personIds, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await campaignMoveNext({ campaignId, actionId, personIds, cdpPort, cdpHost, allowRemote });
+        const result = await campaignMoveNext({ campaignId, actionId, personIds, cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         if (error instanceof ActionNotFoundError) {

--- a/packages/mcp/src/tools/campaign-remove-action.test.ts
+++ b/packages/mcp/src/tools/campaign-remove-action.test.ts
@@ -22,6 +22,7 @@ import {
 import { registerCampaignRemoveAction } from "./campaign-remove-action.js";
 import { describeInfrastructureErrors } from "./testing/infrastructure-errors.js";
 import { createMockServer } from "./testing/mock-server.js";
+import { describeAccountIdForwarding } from "./testing/account-id-forwarding.js";
 
 const REMOVE_RESULT = { success: true as const, campaignId: 15, removedActionId: 50 };
 
@@ -178,4 +179,11 @@ describe("registerCampaignRemoveAction", () => {
       ],
     });
   });
+  describeAccountIdForwarding({
+    registerTool: registerCampaignRemoveAction,
+    toolName: "campaign-remove-action",
+    mock: vi.mocked(campaignRemoveAction),
+    baseArgs: { campaignId: 1, actionId: 1 },
+  });
+
 });

--- a/packages/mcp/src/tools/campaign-remove-action.ts
+++ b/packages/mcp/src/tools/campaign-remove-action.ts
@@ -28,9 +28,9 @@ export function registerCampaignRemoveAction(server: McpServer): void {
         .describe("Action ID to remove"),
       ...cdpConnectionSchema,
     },
-    async ({ campaignId, actionId, cdpPort, cdpHost, allowRemote }) => {
+    async ({ campaignId, actionId, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await campaignRemoveAction({ campaignId, actionId, cdpPort, cdpHost, allowRemote });
+        const result = await campaignRemoveAction({ campaignId, actionId, cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         if (error instanceof ActionNotFoundError) {

--- a/packages/mcp/src/tools/campaign-remove-people.test.ts
+++ b/packages/mcp/src/tools/campaign-remove-people.test.ts
@@ -20,6 +20,7 @@ import {
 import { registerCampaignRemovePeople } from "./campaign-remove-people.js";
 import { describeInfrastructureErrors } from "./testing/infrastructure-errors.js";
 import { createMockServer } from "./testing/mock-server.js";
+import { describeAccountIdForwarding } from "./testing/account-id-forwarding.js";
 
 describe("registerCampaignRemovePeople", () => {
   beforeEach(() => {
@@ -173,4 +174,11 @@ describe("registerCampaignRemovePeople", () => {
     (error) => vi.mocked(campaignRemovePeople).mockRejectedValue(error),
     "Failed to remove people",
   );
+  describeAccountIdForwarding({
+    registerTool: registerCampaignRemovePeople,
+    toolName: "campaign-remove-people",
+    mock: vi.mocked(campaignRemovePeople),
+    baseArgs: { campaignId: 1, personIds: [1] },
+  });
+
 });

--- a/packages/mcp/src/tools/campaign-remove-people.ts
+++ b/packages/mcp/src/tools/campaign-remove-people.ts
@@ -26,9 +26,9 @@ export function registerCampaignRemovePeople(server: McpServer): void {
         .describe("Person IDs to remove from the campaign target list"),
       ...cdpConnectionSchema,
     },
-    async ({ campaignId, personIds, cdpPort, cdpHost, allowRemote }) => {
+    async ({ campaignId, personIds, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await campaignRemovePeople({ campaignId, personIds, cdpPort, cdpHost, allowRemote });
+        const result = await campaignRemovePeople({ campaignId, personIds, cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         if (error instanceof CampaignExecutionError) {

--- a/packages/mcp/src/tools/campaign-reorder-actions.test.ts
+++ b/packages/mcp/src/tools/campaign-reorder-actions.test.ts
@@ -22,6 +22,7 @@ import {
 import { registerCampaignReorderActions } from "./campaign-reorder-actions.js";
 import { describeInfrastructureErrors } from "./testing/infrastructure-errors.js";
 import { createMockServer } from "./testing/mock-server.js";
+import { describeAccountIdForwarding } from "./testing/account-id-forwarding.js";
 
 const MOCK_ACTIONS: CampaignAction[] = [
   {
@@ -186,4 +187,11 @@ describe("registerCampaignReorderActions", () => {
       ],
     });
   });
+  describeAccountIdForwarding({
+    registerTool: registerCampaignReorderActions,
+    toolName: "campaign-reorder-actions",
+    mock: vi.mocked(campaignReorderActions),
+    baseArgs: { campaignId: 1, actionIds: [1] },
+  });
+
 });

--- a/packages/mcp/src/tools/campaign-reorder-actions.ts
+++ b/packages/mcp/src/tools/campaign-reorder-actions.ts
@@ -27,9 +27,9 @@ export function registerCampaignReorderActions(server: McpServer): void {
         .describe("Action IDs in the desired order"),
       ...cdpConnectionSchema,
     },
-    async ({ campaignId, actionIds, cdpPort, cdpHost, allowRemote }) => {
+    async ({ campaignId, actionIds, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await campaignReorderActions({ campaignId, actionIds, cdpPort, cdpHost, allowRemote });
+        const result = await campaignReorderActions({ campaignId, actionIds, cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         if (error instanceof ActionNotFoundError) {

--- a/packages/mcp/src/tools/campaign-retry.test.ts
+++ b/packages/mcp/src/tools/campaign-retry.test.ts
@@ -19,6 +19,7 @@ import {
 import { registerCampaignRetry } from "./campaign-retry.js";
 import { describeInfrastructureErrors } from "./testing/infrastructure-errors.js";
 import { createMockServer } from "./testing/mock-server.js";
+import { describeAccountIdForwarding } from "./testing/account-id-forwarding.js";
 
 const RETRY_RESULT = {
   success: true as const,
@@ -123,4 +124,11 @@ describe("registerCampaignRetry", () => {
     (error) => vi.mocked(campaignRetry).mockRejectedValue(error),
     "Failed to reset persons for retry",
   );
+  describeAccountIdForwarding({
+    registerTool: registerCampaignRetry,
+    toolName: "campaign-retry",
+    mock: vi.mocked(campaignRetry),
+    baseArgs: { campaignId: 1, personIds: [1] },
+  });
+
 });

--- a/packages/mcp/src/tools/campaign-retry.ts
+++ b/packages/mcp/src/tools/campaign-retry.ts
@@ -25,9 +25,9 @@ export function registerCampaignRetry(server: McpServer): void {
         .describe("Person IDs to reset for retry"),
       ...cdpConnectionSchema,
     },
-    async ({ campaignId, personIds, cdpPort, cdpHost, allowRemote }) => {
+    async ({ campaignId, personIds, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await campaignRetry({ campaignId, personIds, cdpPort, cdpHost, allowRemote });
+        const result = await campaignRetry({ campaignId, personIds, cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         return mcpCatchAll(error, "Failed to reset persons for retry");

--- a/packages/mcp/src/tools/campaign-start.test.ts
+++ b/packages/mcp/src/tools/campaign-start.test.ts
@@ -21,6 +21,7 @@ import {
 import { registerCampaignStart } from "./campaign-start.js";
 import { describeInfrastructureErrors } from "./testing/infrastructure-errors.js";
 import { createMockServer } from "./testing/mock-server.js";
+import { describeAccountIdForwarding } from "./testing/account-id-forwarding.js";
 
 const START_RESULT = {
   success: true as const,
@@ -162,4 +163,11 @@ describe("registerCampaignStart", () => {
       ],
     });
   });
+  describeAccountIdForwarding({
+    registerTool: registerCampaignStart,
+    toolName: "campaign-start",
+    mock: vi.mocked(campaignStart),
+    baseArgs: { campaignId: 1, personIds: [1] },
+  });
+
 });

--- a/packages/mcp/src/tools/campaign-start.ts
+++ b/packages/mcp/src/tools/campaign-start.ts
@@ -27,9 +27,9 @@ export function registerCampaignStart(server: McpServer): void {
         .describe("Person IDs to target"),
       ...cdpConnectionSchema,
     },
-    async ({ campaignId, personIds, cdpPort, cdpHost, allowRemote }) => {
+    async ({ campaignId, personIds, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await campaignStart({ campaignId, personIds, cdpPort, cdpHost, allowRemote });
+        const result = await campaignStart({ campaignId, personIds, cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         if (error instanceof CampaignTimeoutError) {

--- a/packages/mcp/src/tools/campaign-statistics.test.ts
+++ b/packages/mcp/src/tools/campaign-statistics.test.ts
@@ -22,6 +22,7 @@ import {
 import { registerCampaignStatistics } from "./campaign-statistics.js";
 import { describeInfrastructureErrors } from "./testing/infrastructure-errors.js";
 import { createMockServer } from "./testing/mock-server.js";
+import { describeAccountIdForwarding } from "./testing/account-id-forwarding.js";
 
 const SAMPLE_STATISTICS: CampaignStatistics = {
   campaignId: 10,
@@ -228,4 +229,11 @@ describe("registerCampaignStatistics", () => {
       ],
     });
   });
+  describeAccountIdForwarding({
+    registerTool: registerCampaignStatistics,
+    toolName: "campaign-statistics",
+    mock: vi.mocked(campaignStatistics),
+    baseArgs: { campaignId: 1 },
+  });
+
 });

--- a/packages/mcp/src/tools/campaign-statistics.ts
+++ b/packages/mcp/src/tools/campaign-statistics.ts
@@ -35,9 +35,9 @@ export function registerCampaignStatistics(server: McpServer): void {
         .describe("Maximum number of top errors per action (default: 5)"),
       ...cdpConnectionSchema,
     },
-    async ({ campaignId, actionId, maxErrors, cdpPort, cdpHost, allowRemote }) => {
+    async ({ campaignId, actionId, maxErrors, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await campaignStatistics({ campaignId, actionId, maxErrors, cdpPort, cdpHost, allowRemote });
+        const result = await campaignStatistics({ campaignId, actionId, maxErrors, cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         if (error instanceof ActionNotFoundError) {

--- a/packages/mcp/src/tools/campaign-status.test.ts
+++ b/packages/mcp/src/tools/campaign-status.test.ts
@@ -24,6 +24,7 @@ import {
 
 import { registerCampaignStatus } from "./campaign-status.js";
 import { createMockServer } from "./testing/mock-server.js";
+import { describeAccountIdForwarding } from "./testing/account-id-forwarding.js";
 
 const defaultStatusResult = {
   campaignId: 15,
@@ -357,4 +358,11 @@ describe("registerCampaignStatus", () => {
       ],
     });
   });
+  describeAccountIdForwarding({
+    registerTool: registerCampaignStatus,
+    toolName: "campaign-status",
+    mock: vi.mocked(campaignStatus),
+    baseArgs: { campaignId: 1 },
+  });
+
 });

--- a/packages/mcp/src/tools/campaign-status.ts
+++ b/packages/mcp/src/tools/campaign-status.ts
@@ -34,7 +34,7 @@ export function registerCampaignStatus(server: McpServer): void {
         .describe("Max results to return"),
       ...cdpConnectionSchema,
     },
-    async ({ campaignId, includeResults, limit, cdpPort, cdpHost, allowRemote }) => {
+    async ({ campaignId, includeResults, limit, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
         const result = await campaignStatus({
           campaignId,
@@ -43,6 +43,7 @@ export function registerCampaignStatus(server: McpServer): void {
           cdpPort,
           cdpHost,
           allowRemote,
+          accountId,
         });
 
         return mcpSuccess(JSON.stringify(result, null, 2));

--- a/packages/mcp/src/tools/campaign-stop.test.ts
+++ b/packages/mcp/src/tools/campaign-stop.test.ts
@@ -20,6 +20,7 @@ import {
 import { registerCampaignStop } from "./campaign-stop.js";
 import { describeInfrastructureErrors } from "./testing/infrastructure-errors.js";
 import { createMockServer } from "./testing/mock-server.js";
+import { describeAccountIdForwarding } from "./testing/account-id-forwarding.js";
 
 const STOP_RESULT = {
   success: true as const,
@@ -128,4 +129,11 @@ describe("registerCampaignStop", () => {
       ],
     });
   });
+  describeAccountIdForwarding({
+    registerTool: registerCampaignStop,
+    toolName: "campaign-stop",
+    mock: vi.mocked(campaignStop),
+    baseArgs: { campaignId: 1 },
+  });
+
 });

--- a/packages/mcp/src/tools/campaign-stop.ts
+++ b/packages/mcp/src/tools/campaign-stop.ts
@@ -22,9 +22,9 @@ export function registerCampaignStop(server: McpServer): void {
         .describe("Campaign ID"),
       ...cdpConnectionSchema,
     },
-    async ({ campaignId, cdpPort, cdpHost, allowRemote }) => {
+    async ({ campaignId, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await campaignStop({ campaignId, cdpPort, cdpHost, allowRemote });
+        const result = await campaignStop({ campaignId, cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         if (error instanceof CampaignExecutionError) {

--- a/packages/mcp/src/tools/campaign-update-action.test.ts
+++ b/packages/mcp/src/tools/campaign-update-action.test.ts
@@ -21,6 +21,7 @@ import {
 import { registerCampaignUpdateAction } from "./campaign-update-action.js";
 import { describeInfrastructureErrors } from "./testing/infrastructure-errors.js";
 import { createMockServer } from "./testing/mock-server.js";
+import { describeAccountIdForwarding } from "./testing/account-id-forwarding.js";
 
 const MOCK_ACTION: CampaignAction = {
   id: 50,
@@ -162,4 +163,11 @@ describe("registerCampaignUpdateAction", () => {
     () => ({ campaignId: 15, actionId: 50, coolDown: 30000, cdpPort: 9222 }),
     (error) => vi.mocked(campaignUpdateAction).mockRejectedValue(error),
   );
+  describeAccountIdForwarding({
+    registerTool: registerCampaignUpdateAction,
+    toolName: "campaign-update-action",
+    mock: vi.mocked(campaignUpdateAction),
+    baseArgs: { campaignId: 1, actionId: 1 },
+  });
+
 });

--- a/packages/mcp/src/tools/campaign-update-action.ts
+++ b/packages/mcp/src/tools/campaign-update-action.ts
@@ -61,6 +61,7 @@ export function registerCampaignUpdateAction(server: McpServer): void {
       cdpPort,
       cdpHost,
       allowRemote,
+      accountId,
     }) => {
       // Parse action settings JSON if provided
       let parsedSettings: Record<string, unknown> | undefined;
@@ -76,7 +77,7 @@ export function registerCampaignUpdateAction(server: McpServer): void {
         const result = await campaignUpdateAction({
           campaignId, actionId, name, description, coolDown,
           maxActionResultsPerIteration, actionSettings: parsedSettings,
-          cdpPort, cdpHost, allowRemote,
+          cdpPort, cdpHost, allowRemote, accountId,
         });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {

--- a/packages/mcp/src/tools/campaign-update.test.ts
+++ b/packages/mcp/src/tools/campaign-update.test.ts
@@ -20,6 +20,7 @@ import {
 import { registerCampaignUpdate } from "./campaign-update.js";
 import { describeInfrastructureErrors } from "./testing/infrastructure-errors.js";
 import { createMockServer } from "./testing/mock-server.js";
+import { describeAccountIdForwarding } from "./testing/account-id-forwarding.js";
 
 const MOCK_CAMPAIGN: Campaign = {
   id: 15,
@@ -151,4 +152,11 @@ describe("registerCampaignUpdate", () => {
     (error) => vi.mocked(campaignUpdate).mockRejectedValue(error),
     "Failed to update campaign",
   );
+  describeAccountIdForwarding({
+    registerTool: registerCampaignUpdate,
+    toolName: "campaign-update",
+    mock: vi.mocked(campaignUpdate),
+    baseArgs: { campaignId: 1, name: "New Name" },
+  });
+
 });

--- a/packages/mcp/src/tools/campaign-update.ts
+++ b/packages/mcp/src/tools/campaign-update.ts
@@ -30,7 +30,7 @@ export function registerCampaignUpdate(server: McpServer): void {
         .describe("New campaign description (null to clear)"),
       ...cdpConnectionSchema,
     },
-    async ({ campaignId, name, description, cdpPort, cdpHost, allowRemote }) => {
+    async ({ campaignId, name, description, cdpPort, cdpHost, allowRemote, accountId }) => {
       // Validate that at least one field is provided
       if (name === undefined && description === undefined) {
         return mcpError("At least one of name or description must be provided.");
@@ -41,7 +41,7 @@ export function registerCampaignUpdate(server: McpServer): void {
       if (description !== undefined) updates.description = description;
 
       try {
-        const result = await campaignUpdate({ campaignId, updates, cdpPort, cdpHost, allowRemote });
+        const result = await campaignUpdate({ campaignId, updates, cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         return mcpCatchAll(error, "Failed to update campaign");

--- a/packages/mcp/src/tools/check-replies.test.ts
+++ b/packages/mcp/src/tools/check-replies.test.ts
@@ -20,6 +20,7 @@ import {
 import { registerCheckReplies } from "./check-replies.js";
 import { describeInfrastructureErrors } from "./testing/infrastructure-errors.js";
 import { createMockServer } from "./testing/mock-server.js";
+import { describeAccountIdForwarding } from "./testing/account-id-forwarding.js";
 
 const MOCK_CONVERSATIONS: ConversationMessages[] = [
   {
@@ -259,4 +260,11 @@ describe("registerCheckReplies", () => {
     (error) => vi.mocked(checkReplies).mockRejectedValue(error),
     "Failed to check replies",
   );
+  describeAccountIdForwarding({
+    registerTool: registerCheckReplies,
+    toolName: "check-replies",
+    mock: vi.mocked(checkReplies),
+    baseArgs: { personIds: [1] },
+  });
+
 });

--- a/packages/mcp/src/tools/check-replies.ts
+++ b/packages/mcp/src/tools/check-replies.ts
@@ -32,9 +32,9 @@ export function registerCheckReplies(server: McpServer): void {
         ),
       ...cdpConnectionSchema,
     },
-    async ({ personIds, since, pauseOthers, cdpPort, cdpHost, allowRemote }) => {
+    async ({ personIds, since, pauseOthers, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await checkReplies({ personIds, since, pauseOthers, cdpPort, cdpHost, allowRemote });
+        const result = await checkReplies({ personIds, since, pauseOthers, cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         return mcpCatchAll(error, "Failed to check replies");

--- a/packages/mcp/src/tools/check-status.test.ts
+++ b/packages/mcp/src/tools/check-status.test.ts
@@ -120,4 +120,23 @@ describe("registerCheckStatus", () => {
       ],
     });
   });
+
+  it("forwards accountId via buildCdpOptions when supplied (regression #793)", async () => {
+    const { server, getHandler } = createMockServer();
+    registerCheckStatus(server);
+
+    mockedCheckStatus.mockResolvedValue({
+      launcher: { reachable: false, port: 9222 },
+      instances: [],
+      databases: [],
+    });
+
+    const handler = getHandler("check-status");
+    await handler({ cdpPort: 9222, accountId: 12345 });
+
+    expect(mockedCheckStatus).toHaveBeenCalledWith(
+      9222,
+      expect.objectContaining({ accountId: 12345 }),
+    );
+  });
 });

--- a/packages/mcp/src/tools/check-status.ts
+++ b/packages/mcp/src/tools/check-status.ts
@@ -13,9 +13,9 @@ export function registerCheckStatus(server: McpServer): void {
     {
       ...cdpConnectionSchema,
     },
-    async ({ cdpPort, cdpHost, allowRemote }) => {
+    async ({ cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const report = await checkStatus(cdpPort, buildCdpOptions({ cdpHost, allowRemote }));
+        const report = await checkStatus(cdpPort, buildCdpOptions({ cdpHost, allowRemote, accountId }));
 
         return mcpSuccess(JSON.stringify(report, null, 2));
       } catch (error) {

--- a/packages/mcp/src/tools/collect-people.test.ts
+++ b/packages/mcp/src/tools/collect-people.test.ts
@@ -20,6 +20,7 @@ import {
 import { registerCollectPeople } from "./collect-people.js";
 import { describeInfrastructureErrors } from "./testing/infrastructure-errors.js";
 import { createMockServer } from "./testing/mock-server.js";
+import { describeAccountIdForwarding } from "./testing/account-id-forwarding.js";
 
 describe("registerCollectPeople", () => {
   beforeEach(() => {
@@ -175,4 +176,11 @@ describe("registerCollectPeople", () => {
     (error) => vi.mocked(collectPeople).mockRejectedValue(error),
     "Failed to collect people",
   );
+  describeAccountIdForwarding({
+    registerTool: registerCollectPeople,
+    toolName: "collect-people",
+    mock: vi.mocked(collectPeople),
+    baseArgs: { campaignId: 1, sourceUrl: "https://www.linkedin.com/search/results/people/" },
+  });
+
 });

--- a/packages/mcp/src/tools/collect-people.ts
+++ b/packages/mcp/src/tools/collect-people.ts
@@ -50,7 +50,7 @@ export function registerCollectPeople(server: McpServer): void {
         .describe("Explicit source type to bypass URL detection (e.g., SearchPage, MyConnections)"),
       ...cdpConnectionSchema,
     },
-    async ({ campaignId, sourceUrl, limit, maxPages, pageSize, sourceType, cdpPort, cdpHost, allowRemote }) => {
+    async ({ campaignId, sourceUrl, limit, maxPages, pageSize, sourceType, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
         const result = await withLoggedInStateRetryAtPort(
           cdpPort,
@@ -67,6 +67,7 @@ export function registerCollectPeople(server: McpServer): void {
           cdpPort,
           ...(cdpHost !== undefined && { cdpHost }),
           ...(allowRemote !== undefined && { allowRemote }),
+          ...(accountId !== undefined && { accountId }),
           }),
         );
         return mcpSuccess(JSON.stringify(result, null, 2));

--- a/packages/mcp/src/tools/create-collection.test.ts
+++ b/packages/mcp/src/tools/create-collection.test.ts
@@ -12,6 +12,7 @@ import { createCollection } from "@lhremote/core";
 import { registerCreateCollection } from "./create-collection.js";
 import { describeInfrastructureErrors } from "./testing/infrastructure-errors.js";
 import { createMockServer } from "./testing/mock-server.js";
+import { describeAccountIdForwarding } from "./testing/account-id-forwarding.js";
 
 const MOCK_RESULT = {
   success: true as const,
@@ -79,4 +80,11 @@ describe("registerCreateCollection", () => {
     (error) => vi.mocked(createCollection).mockRejectedValue(error),
     "Failed to create collection",
   );
+  describeAccountIdForwarding({
+    registerTool: registerCreateCollection,
+    toolName: "create-collection",
+    mock: vi.mocked(createCollection),
+    baseArgs: { name: "x" },
+  });
+
 });

--- a/packages/mcp/src/tools/create-collection.ts
+++ b/packages/mcp/src/tools/create-collection.ts
@@ -18,9 +18,9 @@ export function registerCreateCollection(server: McpServer): void {
         .describe("Name for the new collection"),
       ...cdpConnectionSchema,
     },
-    async ({ name, cdpPort, cdpHost, allowRemote }) => {
+    async ({ name, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await createCollection({ name, cdpPort, cdpHost, allowRemote });
+        const result = await createCollection({ name, cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         return mcpCatchAll(error, "Failed to create collection");

--- a/packages/mcp/src/tools/delete-collection.test.ts
+++ b/packages/mcp/src/tools/delete-collection.test.ts
@@ -12,6 +12,7 @@ import { deleteCollection } from "@lhremote/core";
 import { registerDeleteCollection } from "./delete-collection.js";
 import { describeInfrastructureErrors } from "./testing/infrastructure-errors.js";
 import { createMockServer } from "./testing/mock-server.js";
+import { describeAccountIdForwarding } from "./testing/account-id-forwarding.js";
 
 const MOCK_RESULT = {
   success: true as const,
@@ -79,4 +80,11 @@ describe("registerDeleteCollection", () => {
     (error) => vi.mocked(deleteCollection).mockRejectedValue(error),
     "Failed to delete collection",
   );
+  describeAccountIdForwarding({
+    registerTool: registerDeleteCollection,
+    toolName: "delete-collection",
+    mock: vi.mocked(deleteCollection),
+    baseArgs: { collectionId: 1 },
+  });
+
 });

--- a/packages/mcp/src/tools/delete-collection.ts
+++ b/packages/mcp/src/tools/delete-collection.ts
@@ -19,9 +19,9 @@ export function registerDeleteCollection(server: McpServer): void {
         .describe("Collection ID to delete"),
       ...cdpConnectionSchema,
     },
-    async ({ collectionId, cdpPort, cdpHost, allowRemote }) => {
+    async ({ collectionId, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await deleteCollection({ collectionId, cdpPort, cdpHost, allowRemote });
+        const result = await deleteCollection({ collectionId, cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         return mcpCatchAll(error, "Failed to delete collection");

--- a/packages/mcp/src/tools/dismiss-errors.test.ts
+++ b/packages/mcp/src/tools/dismiss-errors.test.ts
@@ -15,6 +15,7 @@ import { type DismissErrorsOutput, dismissErrors } from "@lhremote/core";
 
 import { registerDismissErrors } from "./dismiss-errors.js";
 import { createMockServer } from "./testing/mock-server.js";
+import { describeAccountIdForwarding } from "./testing/account-id-forwarding.js";
 
 const mockedDismissErrors = vi.mocked(dismissErrors);
 
@@ -99,4 +100,11 @@ describe("registerDismissErrors", () => {
       allowRemote: undefined,
     });
   });
+  describeAccountIdForwarding({
+    registerTool: registerDismissErrors,
+    toolName: "dismiss-errors",
+    mock: vi.mocked(dismissErrors),
+    mockResolvedValue: { accountId: 1, dismissed: 0, nonDismissable: 0 },
+  });
+
 });

--- a/packages/mcp/src/tools/dismiss-errors.ts
+++ b/packages/mcp/src/tools/dismiss-errors.ts
@@ -13,9 +13,9 @@ export function registerDismissErrors(server: McpServer): void {
     {
       ...cdpConnectionSchema,
     },
-    async ({ cdpPort, cdpHost, allowRemote }) => {
+    async ({ cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await dismissErrors({ cdpPort, cdpHost, allowRemote });
+        const result = await dismissErrors({ cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         return mcpCatchAll(error, "Failed to dismiss errors");

--- a/packages/mcp/src/tools/dismiss-feed-post.test.ts
+++ b/packages/mcp/src/tools/dismiss-feed-post.test.ts
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { afterEach, beforeEach, describe, vi } from "vitest";
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return { ...actual, dismissFeedPost: vi.fn() };
+});
+
+import { dismissFeedPost } from "@lhremote/core";
+
+import { registerDismissFeedPost } from "./dismiss-feed-post.js";
+import { describeAccountIdForwarding } from "./testing/account-id-forwarding.js";
+
+describe("registerDismissFeedPost", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describeAccountIdForwarding({
+    registerTool: registerDismissFeedPost,
+    toolName: "dismiss-feed-post",
+    mock: vi.mocked(dismissFeedPost),
+    baseArgs: { feedIndex: 0 },
+  });
+});

--- a/packages/mcp/src/tools/dismiss-feed-post.ts
+++ b/packages/mcp/src/tools/dismiss-feed-post.ts
@@ -19,7 +19,7 @@ export function registerDismissFeedPost(server: McpServer): void {
       dryRun: z.boolean().optional().default(false).describe("When true, locate the menu item but do not click it"),
       ...cdpConnectionSchema,
     },
-    async ({ feedIndex, dryRun, cdpPort, cdpHost, allowRemote }) => {
+    async ({ feedIndex, dryRun, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
         const result = await withLoggedInStateRetryAtPort(
           cdpPort,
@@ -31,6 +31,7 @@ export function registerDismissFeedPost(server: McpServer): void {
           cdpPort,
           cdpHost,
           allowRemote,
+          accountId,
           dryRun,
           }),
         );

--- a/packages/mcp/src/tools/get-action-budget.test.ts
+++ b/packages/mcp/src/tools/get-action-budget.test.ts
@@ -11,6 +11,7 @@ vi.mock("@lhremote/core", async (importOriginal) => {
 import { getActionBudget } from "@lhremote/core";
 import { registerGetActionBudget } from "./get-action-budget.js";
 import { createMockServer } from "./testing/mock-server.js";
+import { describeAccountIdForwarding } from "./testing/account-id-forwarding.js";
 
 const MOCK_BUDGET = {
   entries: [
@@ -74,4 +75,11 @@ describe("registerGetActionBudget", () => {
     const text = (result.content[0] as { text: string }).text;
     expect(text).toContain("Failed to get action budget");
   });
+  describeAccountIdForwarding({
+    registerTool: registerGetActionBudget,
+    toolName: "get-action-budget",
+    mock: vi.mocked(getActionBudget),
+    baseArgs: { campaignId: 1, actionId: 1 },
+  });
+
 });

--- a/packages/mcp/src/tools/get-action-budget.ts
+++ b/packages/mcp/src/tools/get-action-budget.ts
@@ -13,9 +13,9 @@ export function registerGetActionBudget(server: McpServer): void {
     {
       ...cdpConnectionSchema,
     },
-    async ({ cdpPort, cdpHost, allowRemote }) => {
+    async ({ cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await getActionBudget({ cdpPort, cdpHost, allowRemote });
+        const result = await getActionBudget({ cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         return mcpCatchAll(error, "Failed to get action budget");

--- a/packages/mcp/src/tools/get-errors.test.ts
+++ b/packages/mcp/src/tools/get-errors.test.ts
@@ -15,6 +15,7 @@ import { type GetErrorsOutput, getErrors } from "@lhremote/core";
 
 import { registerGetErrors } from "./get-errors.js";
 import { createMockServer } from "./testing/mock-server.js";
+import { describeAccountIdForwarding } from "./testing/account-id-forwarding.js";
 
 const mockedGetErrors = vi.mocked(getErrors);
 
@@ -133,4 +134,10 @@ describe("registerGetErrors", () => {
       allowRemote: undefined,
     });
   });
+  describeAccountIdForwarding({
+    registerTool: registerGetErrors,
+    toolName: "get-errors",
+    mock: vi.mocked(getErrors),
+  });
+
 });

--- a/packages/mcp/src/tools/get-errors.ts
+++ b/packages/mcp/src/tools/get-errors.ts
@@ -13,9 +13,9 @@ export function registerGetErrors(server: McpServer): void {
     {
       ...cdpConnectionSchema,
     },
-    async ({ cdpPort, cdpHost, allowRemote }) => {
+    async ({ cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await getErrors({ cdpPort, cdpHost, allowRemote });
+        const result = await getErrors({ cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         return mcpCatchAll(error, "Failed to get errors");

--- a/packages/mcp/src/tools/get-feed.test.ts
+++ b/packages/mcp/src/tools/get-feed.test.ts
@@ -11,6 +11,7 @@ vi.mock("@lhremote/core", async (importOriginal) => {
 import { getFeed } from "@lhremote/core";
 import { registerGetFeed } from "./get-feed.js";
 import { createMockServer } from "./testing/mock-server.js";
+import { describeAccountIdForwarding } from "./testing/account-id-forwarding.js";
 
 const MOCK_RESULT = {
   posts: [
@@ -95,4 +96,12 @@ describe("registerGetFeed", () => {
     const text = (result.content[0] as { text: string }).text;
     expect(text).toContain("Failed to get feed");
   });
+  describeAccountIdForwarding({
+    registerTool: registerGetFeed,
+    toolName: "get-feed",
+    mock: vi.mocked(getFeed),
+    baseArgs: { count: 5 },
+    mockResolvedValue: { posts: [], nextCursor: null },
+  });
+
 });

--- a/packages/mcp/src/tools/get-feed.ts
+++ b/packages/mcp/src/tools/get-feed.ts
@@ -30,7 +30,7 @@ export function registerGetFeed(server: McpServer): void {
         ),
       ...cdpConnectionSchema,
     },
-    async ({ count, cursor, cdpPort, cdpHost, allowRemote }) => {
+    async ({ count, cursor, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
         const result = await withLoggedInStateRetryAtPort(
           cdpPort,
@@ -43,6 +43,7 @@ export function registerGetFeed(server: McpServer): void {
           cdpPort,
           cdpHost,
           allowRemote,
+          accountId,
           }),
         );
         return mcpSuccess(JSON.stringify(result, null, 2));

--- a/packages/mcp/src/tools/get-post-engagers.test.ts
+++ b/packages/mcp/src/tools/get-post-engagers.test.ts
@@ -11,6 +11,7 @@ vi.mock("@lhremote/core", async (importOriginal) => {
 import { getPostEngagers } from "@lhremote/core";
 import { registerGetPostEngagers } from "./get-post-engagers.js";
 import { createMockServer } from "./testing/mock-server.js";
+import { describeAccountIdForwarding } from "./testing/account-id-forwarding.js";
 
 const MOCK_ENGAGERS = {
   postUrn: "urn:li:activity:7123456789012345678",
@@ -108,4 +109,11 @@ describe("registerGetPostEngagers", () => {
     const text = (result.content[0] as { text: string }).text;
     expect(text).toContain("Failed to get post engagers");
   });
+  describeAccountIdForwarding({
+    registerTool: registerGetPostEngagers,
+    toolName: "get-post-engagers",
+    mock: vi.mocked(getPostEngagers),
+    baseArgs: { postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:1/" },
+  });
+
 });

--- a/packages/mcp/src/tools/get-post-engagers.ts
+++ b/packages/mcp/src/tools/get-post-engagers.ts
@@ -33,7 +33,7 @@ export function registerGetPostEngagers(server: McpServer): void {
         .describe("Number of engagers per page (default: 20)"),
       ...cdpConnectionSchema,
     },
-    async ({ postUrl, start, count, cdpPort, cdpHost, allowRemote }) => {
+    async ({ postUrl, start, count, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
         const result = await getPostEngagers({
           postUrl,
@@ -42,6 +42,7 @@ export function registerGetPostEngagers(server: McpServer): void {
           cdpPort,
           cdpHost,
           allowRemote,
+          accountId,
         });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {

--- a/packages/mcp/src/tools/get-post-stats.test.ts
+++ b/packages/mcp/src/tools/get-post-stats.test.ts
@@ -11,6 +11,7 @@ vi.mock("@lhremote/core", async (importOriginal) => {
 import { getPostStats } from "@lhremote/core";
 import { registerGetPostStats } from "./get-post-stats.js";
 import { createMockServer } from "./testing/mock-server.js";
+import { describeAccountIdForwarding } from "./testing/account-id-forwarding.js";
 
 const MOCK_STATS = {
   stats: {
@@ -79,4 +80,11 @@ describe("registerGetPostStats", () => {
     const text = (result.content[0] as { text: string }).text;
     expect(text).toContain("Failed to get post stats");
   });
+  describeAccountIdForwarding({
+    registerTool: registerGetPostStats,
+    toolName: "get-post-stats",
+    mock: vi.mocked(getPostStats),
+    baseArgs: { postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:1/" },
+  });
+
 });

--- a/packages/mcp/src/tools/get-post-stats.ts
+++ b/packages/mcp/src/tools/get-post-stats.ts
@@ -19,9 +19,9 @@ export function registerGetPostStats(server: McpServer): void {
         ),
       ...cdpConnectionSchema,
     },
-    async ({ postUrl, cdpPort, cdpHost, allowRemote }) => {
+    async ({ postUrl, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await getPostStats({ postUrl, cdpPort, cdpHost, allowRemote });
+        const result = await getPostStats({ postUrl, cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         return mcpCatchAll(error, "Failed to get post stats");

--- a/packages/mcp/src/tools/get-post.test.ts
+++ b/packages/mcp/src/tools/get-post.test.ts
@@ -12,6 +12,7 @@ import { getPost } from "@lhremote/core";
 import { registerGetPost } from "./get-post.js";
 import { describeInfrastructureErrors } from "./testing/infrastructure-errors.js";
 import { createMockServer } from "./testing/mock-server.js";
+import { describeAccountIdForwarding } from "./testing/account-id-forwarding.js";
 
 const MOCK_RESULT = {
   post: {
@@ -117,4 +118,11 @@ describe("registerGetPost", () => {
     (error) => vi.mocked(getPost).mockRejectedValue(error),
     "Failed to get post",
   );
+  describeAccountIdForwarding({
+    registerTool: registerGetPost,
+    toolName: "get-post",
+    mock: vi.mocked(getPost),
+    baseArgs: { postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:1/" },
+  });
+
 });

--- a/packages/mcp/src/tools/get-post.ts
+++ b/packages/mcp/src/tools/get-post.ts
@@ -26,7 +26,7 @@ export function registerGetPost(server: McpServer): void {
         .describe("Maximum number of comments to load (default: 100, 0 to skip)"),
       ...cdpConnectionSchema,
     },
-    async ({ postUrl, commentCount, cdpPort, cdpHost, allowRemote }) => {
+    async ({ postUrl, commentCount, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
         const result = await getPost({
           postUrl,
@@ -34,6 +34,7 @@ export function registerGetPost(server: McpServer): void {
           cdpPort,
           cdpHost,
           allowRemote,
+          accountId,
         });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {

--- a/packages/mcp/src/tools/get-profile-activity.test.ts
+++ b/packages/mcp/src/tools/get-profile-activity.test.ts
@@ -11,6 +11,7 @@ vi.mock("@lhremote/core", async (importOriginal) => {
 import { getProfileActivity } from "@lhremote/core";
 import { registerGetProfileActivity } from "./get-profile-activity.js";
 import { createMockServer } from "./testing/mock-server.js";
+import { describeAccountIdForwarding } from "./testing/account-id-forwarding.js";
 
 const MOCK_ACTIVITY = {
   profilePublicId: "johndoe",
@@ -90,4 +91,11 @@ describe("registerGetProfileActivity", () => {
     const text = (result.content[0] as { text: string }).text;
     expect(text).toContain("Failed to get profile activity");
   });
+  describeAccountIdForwarding({
+    registerTool: registerGetProfileActivity,
+    toolName: "get-profile-activity",
+    mock: vi.mocked(getProfileActivity),
+    baseArgs: { profile: "https://www.linkedin.com/in/alice/" },
+  });
+
 });

--- a/packages/mcp/src/tools/get-profile-activity.ts
+++ b/packages/mcp/src/tools/get-profile-activity.ts
@@ -30,7 +30,7 @@ export function registerGetProfileActivity(server: McpServer): void {
         .describe("Cursor token from a previous call for the next page"),
       ...cdpConnectionSchema,
     },
-    async ({ profile, count, cursor, cdpPort, cdpHost, allowRemote }) => {
+    async ({ profile, count, cursor, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
         const result = await getProfileActivity({
           profile,
@@ -39,6 +39,7 @@ export function registerGetProfileActivity(server: McpServer): void {
           cdpPort,
           cdpHost,
           allowRemote,
+          accountId,
         });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {

--- a/packages/mcp/src/tools/get-throttle-status.test.ts
+++ b/packages/mcp/src/tools/get-throttle-status.test.ts
@@ -11,6 +11,7 @@ vi.mock("@lhremote/core", async (importOriginal) => {
 import { getThrottleStatus } from "@lhremote/core";
 import { registerGetThrottleStatus } from "./get-throttle-status.js";
 import { createMockServer } from "./testing/mock-server.js";
+import { describeAccountIdForwarding } from "./testing/account-id-forwarding.js";
 
 describe("registerGetThrottleStatus", () => {
   beforeEach(() => {
@@ -73,4 +74,10 @@ describe("registerGetThrottleStatus", () => {
     const text = (result.content[0] as { text: string }).text;
     expect(text).toContain("Failed to get throttle status");
   });
+  describeAccountIdForwarding({
+    registerTool: registerGetThrottleStatus,
+    toolName: "get-throttle-status",
+    mock: vi.mocked(getThrottleStatus),
+  });
+
 });

--- a/packages/mcp/src/tools/get-throttle-status.ts
+++ b/packages/mcp/src/tools/get-throttle-status.ts
@@ -13,9 +13,9 @@ export function registerGetThrottleStatus(server: McpServer): void {
     {
       ...cdpConnectionSchema,
     },
-    async ({ cdpPort, cdpHost, allowRemote }) => {
+    async ({ cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await getThrottleStatus({ cdpPort, cdpHost, allowRemote });
+        const result = await getThrottleStatus({ cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         return mcpCatchAll(error, "Failed to get throttle status");

--- a/packages/mcp/src/tools/hide-feed-author-profile.test.ts
+++ b/packages/mcp/src/tools/hide-feed-author-profile.test.ts
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { afterEach, beforeEach, describe, vi } from "vitest";
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return { ...actual, hideFeedAuthorProfile: vi.fn() };
+});
+
+import { hideFeedAuthorProfile } from "@lhremote/core";
+
+import { registerHideFeedAuthorProfile } from "./hide-feed-author-profile.js";
+import { describeAccountIdForwarding } from "./testing/account-id-forwarding.js";
+
+describe("registerHideFeedAuthorProfile", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describeAccountIdForwarding({
+    registerTool: registerHideFeedAuthorProfile,
+    toolName: "hide-feed-author-profile",
+    mock: vi.mocked(hideFeedAuthorProfile),
+    baseArgs: { profileUrl: "https://www.linkedin.com/in/alice/" },
+  });
+});

--- a/packages/mcp/src/tools/hide-feed-author-profile.ts
+++ b/packages/mcp/src/tools/hide-feed-author-profile.ts
@@ -30,7 +30,7 @@ export function registerHideFeedAuthorProfile(server: McpServer): void {
         ),
       ...cdpConnectionSchema,
     },
-    async ({ profileUrl, dryRun, cdpPort, cdpHost, allowRemote }) => {
+    async ({ profileUrl, dryRun, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
         const result = await withLoggedInStateRetryAtPort(
           cdpPort,
@@ -42,6 +42,7 @@ export function registerHideFeedAuthorProfile(server: McpServer): void {
           cdpPort,
           cdpHost,
           allowRemote,
+          accountId,
           dryRun,
           }),
         );

--- a/packages/mcp/src/tools/hide-feed-author.test.ts
+++ b/packages/mcp/src/tools/hide-feed-author.test.ts
@@ -10,6 +10,7 @@ vi.mock("@lhremote/core", async (importOriginal) => {
 
 import { hideFeedAuthor } from "@lhremote/core";
 import { registerHideFeedAuthor } from "./hide-feed-author.js";
+import { describeAccountIdForwarding } from "./testing/account-id-forwarding.js";
 import { describeInfrastructureErrors } from "./testing/infrastructure-errors.js";
 import { createMockServer } from "./testing/mock-server.js";
 
@@ -86,4 +87,11 @@ describe("registerHideFeedAuthor", () => {
     (error) => vi.mocked(hideFeedAuthor).mockRejectedValue(error),
     "Failed to hide feed author",
   );
+
+  describeAccountIdForwarding({
+    registerTool: registerHideFeedAuthor,
+    toolName: "hide-feed-author",
+    mock: vi.mocked(hideFeedAuthor),
+    baseArgs: { feedIndex: 0 },
+  });
 });

--- a/packages/mcp/src/tools/hide-feed-author.ts
+++ b/packages/mcp/src/tools/hide-feed-author.ts
@@ -19,7 +19,7 @@ export function registerHideFeedAuthor(server: McpServer): void {
       dryRun: z.boolean().optional().default(false).describe("When true, locate the menu item but do not click it"),
       ...cdpConnectionSchema,
     },
-    async ({ feedIndex, dryRun, cdpPort, cdpHost, allowRemote }) => {
+    async ({ feedIndex, dryRun, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
         const result = await withLoggedInStateRetryAtPort(
           cdpPort,
@@ -31,6 +31,7 @@ export function registerHideFeedAuthor(server: McpServer): void {
           cdpPort,
           cdpHost,
           allowRemote,
+          accountId,
           dryRun,
           }),
         );

--- a/packages/mcp/src/tools/import-people-from-collection.test.ts
+++ b/packages/mcp/src/tools/import-people-from-collection.test.ts
@@ -15,6 +15,7 @@ import {
 import { registerImportPeopleFromCollection } from "./import-people-from-collection.js";
 import { describeInfrastructureErrors } from "./testing/infrastructure-errors.js";
 import { createMockServer } from "./testing/mock-server.js";
+import { describeAccountIdForwarding } from "./testing/account-id-forwarding.js";
 
 const MOCK_RESULT = {
   success: true as const,
@@ -119,4 +120,11 @@ describe("registerImportPeopleFromCollection", () => {
       vi.mocked(importPeopleFromCollection).mockRejectedValue(error),
     "Failed to import people from collection",
   );
+  describeAccountIdForwarding({
+    registerTool: registerImportPeopleFromCollection,
+    toolName: "import-people-from-collection",
+    mock: vi.mocked(importPeopleFromCollection),
+    baseArgs: { campaignId: 1, collectionId: 1 },
+  });
+
 });

--- a/packages/mcp/src/tools/import-people-from-collection.ts
+++ b/packages/mcp/src/tools/import-people-from-collection.ts
@@ -27,9 +27,9 @@ export function registerImportPeopleFromCollection(server: McpServer): void {
         .describe("Campaign ID to import people into"),
       ...cdpConnectionSchema,
     },
-    async ({ collectionId, campaignId, cdpPort, cdpHost, allowRemote }) => {
+    async ({ collectionId, campaignId, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await importPeopleFromCollection({ collectionId, campaignId, cdpPort, cdpHost, allowRemote });
+        const result = await importPeopleFromCollection({ collectionId, campaignId, cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         if (error instanceof CampaignExecutionError) {

--- a/packages/mcp/src/tools/import-people-from-urls.test.ts
+++ b/packages/mcp/src/tools/import-people-from-urls.test.ts
@@ -20,6 +20,7 @@ import {
 import { registerImportPeopleFromUrls } from "./import-people-from-urls.js";
 import { describeInfrastructureErrors } from "./testing/infrastructure-errors.js";
 import { createMockServer } from "./testing/mock-server.js";
+import { describeAccountIdForwarding } from "./testing/account-id-forwarding.js";
 
 describe("registerImportPeopleFromUrls", () => {
   beforeEach(() => {
@@ -188,4 +189,11 @@ describe("registerImportPeopleFromUrls", () => {
     (error) => vi.mocked(importPeopleFromUrls).mockRejectedValue(error),
     "Failed to import people",
   );
+  describeAccountIdForwarding({
+    registerTool: registerImportPeopleFromUrls,
+    toolName: "import-people-from-urls",
+    mock: vi.mocked(importPeopleFromUrls),
+    baseArgs: { campaignId: 1, linkedInUrls: ["https://www.linkedin.com/in/alice/"] },
+  });
+
 });

--- a/packages/mcp/src/tools/import-people-from-urls.ts
+++ b/packages/mcp/src/tools/import-people-from-urls.ts
@@ -26,9 +26,9 @@ export function registerImportPeopleFromUrls(server: McpServer): void {
         .describe("LinkedIn profile URLs to import"),
       ...cdpConnectionSchema,
     },
-    async ({ campaignId, linkedInUrls, cdpPort, cdpHost, allowRemote }) => {
+    async ({ campaignId, linkedInUrls, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await importPeopleFromUrls({ campaignId, linkedInUrls, cdpPort, cdpHost, allowRemote });
+        const result = await importPeopleFromUrls({ campaignId, linkedInUrls, cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         if (error instanceof CampaignExecutionError) {

--- a/packages/mcp/src/tools/list-accounts.test.ts
+++ b/packages/mcp/src/tools/list-accounts.test.ts
@@ -140,4 +140,19 @@ describe("registerListAccounts", () => {
 
     expect(LauncherService).toHaveBeenCalledWith(4567, {});
   });
+
+  it("forwards accountId via buildCdpOptions to LauncherService when supplied (regression #793)", async () => {
+    const { server, getHandler } = createMockServer();
+    registerListAccounts(server);
+
+    mockLauncher();
+
+    const handler = getHandler("list-accounts");
+    await handler({ cdpPort: 9222, accountId: 12345 });
+
+    expect(LauncherService).toHaveBeenCalledWith(
+      9222,
+      expect.objectContaining({ accountId: 12345 }),
+    );
+  });
 });

--- a/packages/mcp/src/tools/list-accounts.ts
+++ b/packages/mcp/src/tools/list-accounts.ts
@@ -20,10 +20,10 @@ export function registerListAccounts(server: McpServer): void {
           "When true, enumerate accounts across every workspace the user belongs to, not just the selected workspace. Default: false.",
         ),
     },
-    async ({ cdpPort, cdpHost, allowRemote, includeAllWorkspaces }) => {
+    async ({ cdpPort, cdpHost, allowRemote, accountId, includeAllWorkspaces }) => {
       try {
         const port = await resolveLauncherPort(cdpPort, cdpHost);
-        const launcher = new LauncherService(port, buildCdpOptions({ cdpHost, allowRemote }));
+        const launcher = new LauncherService(port, buildCdpOptions({ cdpHost, allowRemote, accountId }));
 
         try {
           await launcher.connect();

--- a/packages/mcp/src/tools/list-collections.test.ts
+++ b/packages/mcp/src/tools/list-collections.test.ts
@@ -12,6 +12,7 @@ import { listCollections } from "@lhremote/core";
 import { registerListCollections } from "./list-collections.js";
 import { describeInfrastructureErrors } from "./testing/infrastructure-errors.js";
 import { createMockServer } from "./testing/mock-server.js";
+import { describeAccountIdForwarding } from "./testing/account-id-forwarding.js";
 
 const MOCK_RESULT = {
   collections: [
@@ -80,4 +81,11 @@ describe("registerListCollections", () => {
     (error) => vi.mocked(listCollections).mockRejectedValue(error),
     "Failed to list collections",
   );
+  describeAccountIdForwarding({
+    registerTool: registerListCollections,
+    toolName: "list-collections",
+    mock: vi.mocked(listCollections),
+    mockResolvedValue: { collections: [] },
+  });
+
 });

--- a/packages/mcp/src/tools/list-collections.ts
+++ b/packages/mcp/src/tools/list-collections.ts
@@ -13,9 +13,9 @@ export function registerListCollections(server: McpServer): void {
     {
       ...cdpConnectionSchema,
     },
-    async ({ cdpPort, cdpHost, allowRemote }) => {
+    async ({ cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await listCollections({ cdpPort, cdpHost, allowRemote });
+        const result = await listCollections({ cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         return mcpCatchAll(error, "Failed to list collections");

--- a/packages/mcp/src/tools/list-workspaces.test.ts
+++ b/packages/mcp/src/tools/list-workspaces.test.ts
@@ -139,4 +139,19 @@ describe("registerListWorkspaces", () => {
 
     expect(disconnect).toHaveBeenCalledOnce();
   });
+
+  it("forwards accountId via buildCdpOptions to LauncherService when supplied (regression #793)", async () => {
+    const { server, getHandler } = createMockServer();
+    registerListWorkspaces(server);
+
+    mockLauncher();
+
+    const handler = getHandler("list-workspaces");
+    await handler({ cdpPort: 9222, accountId: 12345 });
+
+    expect(LauncherService).toHaveBeenCalledWith(
+      9222,
+      expect.objectContaining({ accountId: 12345 }),
+    );
+  });
 });

--- a/packages/mcp/src/tools/list-workspaces.ts
+++ b/packages/mcp/src/tools/list-workspaces.ts
@@ -24,10 +24,10 @@ export function registerListWorkspaces(server: McpServer): void {
     {
       ...cdpConnectionSchema,
     },
-    async ({ cdpPort, cdpHost, allowRemote }) => {
+    async ({ cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
         const port = await resolveLauncherPort(cdpPort, cdpHost);
-        const launcher = new LauncherService(port, buildCdpOptions({ cdpHost, allowRemote }));
+        const launcher = new LauncherService(port, buildCdpOptions({ cdpHost, allowRemote, accountId }));
 
         try {
           await launcher.connect();

--- a/packages/mcp/src/tools/query-messages.test.ts
+++ b/packages/mcp/src/tools/query-messages.test.ts
@@ -22,6 +22,7 @@ import {
 import { registerQueryMessages } from "./query-messages.js";
 import { describeInfrastructureErrors } from "./testing/infrastructure-errors.js";
 import { createMockServer } from "./testing/mock-server.js";
+import { describeAccountIdForwarding } from "./testing/account-id-forwarding.js";
 
 const MOCK_CHAT: Chat = {
   id: 123,
@@ -288,4 +289,10 @@ describe("registerQueryMessages", () => {
       ],
     });
   });
+  describeAccountIdForwarding({
+    registerTool: registerQueryMessages,
+    toolName: "query-messages",
+    mock: vi.mocked(queryMessages),
+  });
+
 });

--- a/packages/mcp/src/tools/query-messages.ts
+++ b/packages/mcp/src/tools/query-messages.ts
@@ -45,9 +45,9 @@ export function registerQueryMessages(server: McpServer): void {
         .describe("Pagination offset (default: 0)"),
       ...cdpConnectionSchema,
     },
-    async ({ personId, chatId, search, limit, offset, cdpPort, cdpHost, allowRemote }) => {
+    async ({ personId, chatId, search, limit, offset, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await queryMessages({ personId, chatId, search, limit, offset, cdpPort, cdpHost, allowRemote });
+        const result = await queryMessages({ personId, chatId, search, limit, offset, cdpPort, cdpHost, allowRemote, accountId });
         if (result.kind === "thread") return mcpSuccess(JSON.stringify(result.thread, null, 2));
         if (result.kind === "search") return mcpSuccess(JSON.stringify({ messages: result.messages, total: result.total }, null, 2));
         return mcpSuccess(JSON.stringify({ conversations: result.conversations, total: result.total }, null, 2));

--- a/packages/mcp/src/tools/react-to-comment.test.ts
+++ b/packages/mcp/src/tools/react-to-comment.test.ts
@@ -12,6 +12,7 @@ import { reactToComment } from "@lhremote/core";
 import { registerReactToComment } from "./react-to-comment.js";
 import { describeInfrastructureErrors } from "./testing/infrastructure-errors.js";
 import { createMockServer } from "./testing/mock-server.js";
+import { describeAccountIdForwarding } from "./testing/account-id-forwarding.js";
 
 const POST_URL = "https://www.linkedin.com/feed/update/urn:li:activity:123/";
 const COMMENT_URN = "urn:li:comment:(activity:123,456)";
@@ -96,4 +97,11 @@ describe("registerReactToComment", () => {
     (error) => vi.mocked(reactToComment).mockRejectedValue(error),
     "Failed to react to comment",
   );
+  describeAccountIdForwarding({
+    registerTool: registerReactToComment,
+    toolName: "react-to-comment",
+    mock: vi.mocked(reactToComment),
+    baseArgs: { postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:1/", commentUrn: "urn:li:comment:(activity:1,1)", reactionType: "like" },
+  });
+
 });

--- a/packages/mcp/src/tools/react-to-comment.ts
+++ b/packages/mcp/src/tools/react-to-comment.ts
@@ -36,7 +36,7 @@ export function registerReactToComment(server: McpServer): void {
       dryRun: z.boolean().optional().default(false).describe("When true, detect current reaction state without clicking"),
       ...cdpConnectionSchema,
     },
-    async ({ postUrl, commentUrn, reactionType, dryRun, cdpPort, cdpHost, allowRemote }) => {
+    async ({ postUrl, commentUrn, reactionType, dryRun, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
         const result = await withLoggedInStateRetryAtPort(
           cdpPort,
@@ -50,6 +50,7 @@ export function registerReactToComment(server: McpServer): void {
           cdpPort,
           cdpHost,
           allowRemote,
+          accountId,
           dryRun,
           }),
         );

--- a/packages/mcp/src/tools/react-to-post.test.ts
+++ b/packages/mcp/src/tools/react-to-post.test.ts
@@ -12,6 +12,7 @@ import { reactToPost } from "@lhremote/core";
 import { registerReactToPost } from "./react-to-post.js";
 import { describeInfrastructureErrors } from "./testing/infrastructure-errors.js";
 import { createMockServer } from "./testing/mock-server.js";
+import { describeAccountIdForwarding } from "./testing/account-id-forwarding.js";
 
 const MOCK_RESULT = {
   success: true as const,
@@ -95,4 +96,11 @@ describe("registerReactToPost", () => {
     (error) => vi.mocked(reactToPost).mockRejectedValue(error),
     "Failed to react to post",
   );
+  describeAccountIdForwarding({
+    registerTool: registerReactToPost,
+    toolName: "react-to-post",
+    mock: vi.mocked(reactToPost),
+    baseArgs: { postUrl: "https://www.linkedin.com/feed/update/urn:li:activity:1/", reactionType: "like" },
+  });
+
 });

--- a/packages/mcp/src/tools/react-to-post.ts
+++ b/packages/mcp/src/tools/react-to-post.ts
@@ -31,7 +31,7 @@ export function registerReactToPost(server: McpServer): void {
       dryRun: z.boolean().optional().default(false).describe("When true, detect current reaction state without clicking"),
       ...cdpConnectionSchema,
     },
-    async ({ postUrl, reactionType, dryRun, cdpPort, cdpHost, allowRemote }) => {
+    async ({ postUrl, reactionType, dryRun, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
         const result = await withLoggedInStateRetryAtPort(
           cdpPort,
@@ -44,6 +44,7 @@ export function registerReactToPost(server: McpServer): void {
               cdpPort,
               cdpHost,
               allowRemote,
+              accountId,
               dryRun,
             }),
         );

--- a/packages/mcp/src/tools/remove-people-from-collection.test.ts
+++ b/packages/mcp/src/tools/remove-people-from-collection.test.ts
@@ -12,6 +12,7 @@ import { removePeopleFromCollection } from "@lhremote/core";
 import { registerRemovePeopleFromCollection } from "./remove-people-from-collection.js";
 import { describeInfrastructureErrors } from "./testing/infrastructure-errors.js";
 import { createMockServer } from "./testing/mock-server.js";
+import { describeAccountIdForwarding } from "./testing/account-id-forwarding.js";
 
 const MOCK_RESULT = {
   success: true as const,
@@ -85,4 +86,12 @@ describe("registerRemovePeopleFromCollection", () => {
       vi.mocked(removePeopleFromCollection).mockRejectedValue(error),
     "Failed to remove people from collection",
   );
+  describeAccountIdForwarding({
+    registerTool: registerRemovePeopleFromCollection,
+    toolName: "remove-people-from-collection",
+    mock: vi.mocked(removePeopleFromCollection),
+    baseArgs: { collectionId: 1, personIds: [1] },
+    mockResolvedValue: { removed: 0 },
+  });
+
 });

--- a/packages/mcp/src/tools/remove-people-from-collection.ts
+++ b/packages/mcp/src/tools/remove-people-from-collection.ts
@@ -23,9 +23,9 @@ export function registerRemovePeopleFromCollection(server: McpServer): void {
         .describe("Person IDs to remove from the collection"),
       ...cdpConnectionSchema,
     },
-    async ({ collectionId, personIds, cdpPort, cdpHost, allowRemote }) => {
+    async ({ collectionId, personIds, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
-        const result = await removePeopleFromCollection({ collectionId, personIds, cdpPort, cdpHost, allowRemote });
+        const result = await removePeopleFromCollection({ collectionId, personIds, cdpPort, cdpHost, allowRemote, accountId });
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {
         return mcpCatchAll(error, "Failed to remove people from collection");

--- a/packages/mcp/src/tools/scrape-messaging-history.test.ts
+++ b/packages/mcp/src/tools/scrape-messaging-history.test.ts
@@ -20,6 +20,7 @@ import {
 import { registerScrapeMessagingHistory } from "./scrape-messaging-history.js";
 import { describeInfrastructureErrors } from "./testing/infrastructure-errors.js";
 import { createMockServer } from "./testing/mock-server.js";
+import { describeAccountIdForwarding } from "./testing/account-id-forwarding.js";
 
 const MOCK_STATS: MessageStats = {
   totalMessages: 2500,
@@ -167,4 +168,11 @@ describe("registerScrapeMessagingHistory", () => {
     (error) => vi.mocked(scrapeMessagingHistory).mockRejectedValue(error),
     "Failed to scrape messaging history",
   );
+  describeAccountIdForwarding({
+    registerTool: registerScrapeMessagingHistory,
+    toolName: "scrape-messaging-history",
+    mock: vi.mocked(scrapeMessagingHistory),
+    baseArgs: { personIds: [1] },
+  });
+
 });

--- a/packages/mcp/src/tools/scrape-messaging-history.ts
+++ b/packages/mcp/src/tools/scrape-messaging-history.ts
@@ -27,13 +27,13 @@ export function registerScrapeMessagingHistory(server: McpServer): void {
         ),
       ...cdpConnectionSchema,
     },
-    async ({ personIds, pauseOthers, cdpPort, cdpHost, allowRemote }) => {
+    async ({ personIds, pauseOthers, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
         const result = await withLoggedInStateRetryAtPort(
           cdpPort,
           cdpHost ?? "127.0.0.1",
           allowRemote ?? false,
-          () => scrapeMessagingHistory({ personIds, pauseOthers, cdpPort, cdpHost, allowRemote }),
+          () => scrapeMessagingHistory({ personIds, pauseOthers, cdpPort, cdpHost, allowRemote, accountId }),
         );
         return mcpSuccess(JSON.stringify(result, null, 2));
       } catch (error) {

--- a/packages/mcp/src/tools/search-posts.test.ts
+++ b/packages/mcp/src/tools/search-posts.test.ts
@@ -12,6 +12,7 @@ import { searchPosts } from "@lhremote/core";
 import type { SearchPostsOutput } from "@lhremote/core";
 import { registerSearchPosts } from "./search-posts.js";
 import { createMockServer } from "./testing/mock-server.js";
+import { describeAccountIdForwarding } from "./testing/account-id-forwarding.js";
 
 const MOCK_RESULTS: SearchPostsOutput = {
   query: "AI agents",
@@ -109,4 +110,11 @@ describe("registerSearchPosts", () => {
     const text = (result.content[0] as { text: string }).text;
     expect(text).toContain("Failed to search posts");
   });
+  describeAccountIdForwarding({
+    registerTool: registerSearchPosts,
+    toolName: "search-posts",
+    mock: vi.mocked(searchPosts),
+    baseArgs: { query: "ai" },
+  });
+
 });

--- a/packages/mcp/src/tools/search-posts.ts
+++ b/packages/mcp/src/tools/search-posts.ts
@@ -37,7 +37,7 @@ export function registerSearchPosts(server: McpServer): void {
         ),
       ...cdpConnectionSchema,
     },
-    async ({ query, count, cursor, cdpPort, cdpHost, allowRemote }) => {
+    async ({ query, count, cursor, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
         const result = await withLoggedInStateRetryAtPort(
           cdpPort,
@@ -51,6 +51,7 @@ export function registerSearchPosts(server: McpServer): void {
           cdpPort,
           cdpHost,
           allowRemote,
+          accountId,
           }),
         );
         return mcpSuccess(JSON.stringify(result, null, 2));

--- a/packages/mcp/src/tools/testing/account-id-forwarding.ts
+++ b/packages/mcp/src/tools/testing/account-id-forwarding.ts
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { type Mock, describe, expect, it } from "vitest";
+
+import { createMockServer } from "./mock-server.js";
+
+/**
+ * Shared regression test for issue #793: every MCP tool that includes
+ * `cdpConnectionSchema` must forward the optional `accountId` arg to its
+ * underlying core operation.
+ *
+ * Several wrappers historically destructured only
+ * `{ cdpPort, cdpHost, allowRemote }` from the handler args and silently
+ * dropped `accountId`, leaving multi-account users unable to target a
+ * specific instance.
+ *
+ * Validates the supplied `baseArgs` (plus `cdpPort` and `accountId`) against
+ * the tool's registered Zod schema before invoking the handler. This guards
+ * the regression test against silent drift — if a caller spells a required
+ * arg incorrectly (e.g. `urls` instead of `linkedInUrls`), the schema check
+ * fails loudly rather than letting the handler take an early-validation exit
+ * that bypasses the forwarding assertion.
+ *
+ * @param registerTool - The tool's register function (e.g. `registerCampaignList`).
+ * @param toolName - The MCP tool name string (e.g. `"campaign-list"`).
+ * @param mock - The mocked core operation (e.g. `vi.mocked(campaignList)`).
+ * @param baseArgs - Args needed for the handler aside from `accountId` and
+ *   `cdpPort`. `cdpPort: 9222` is supplied automatically and `accountId: 12345`
+ *   is added by the helper. Defaults to `{}`.
+ * @param mockResolvedValue - Value the mocked operation resolves with.
+ *   Most handlers only `JSON.stringify` the result, so a permissive default
+ *   suffices; pass an explicit shape for handlers that read result fields.
+ *   Defaults to `{}`.
+ */
+export function describeAccountIdForwarding(opts: {
+  registerTool: (server: McpServer) => void;
+  toolName: string;
+  mock: Mock;
+  baseArgs?: Record<string, unknown>;
+  mockResolvedValue?: unknown;
+}): void {
+  describe("accountId forwarding (regression #793)", () => {
+    it("forwards accountId to the underlying operation when supplied", async () => {
+      const { server, getHandler, getSchema } = createMockServer();
+      opts.registerTool(server);
+
+      opts.mock.mockResolvedValue(opts.mockResolvedValue ?? {});
+
+      const args = {
+        cdpPort: 9222,
+        ...(opts.baseArgs ?? {}),
+        accountId: 12345,
+      };
+
+      // Guard against drift: validate args against the tool's registered
+      // Zod schema before invoking the handler. Catches stale `baseArgs`
+      // entries that would otherwise let the handler short-circuit on
+      // missing/wrong required fields and bypass the forwarding assertion.
+      const schema = getSchema(opts.toolName);
+      if (schema) {
+        const parsed = schema.safeParse(args);
+        expect(
+          parsed.success,
+          parsed.success ? "" : `baseArgs failed schema validation for ${opts.toolName}: ${parsed.error.message}`,
+        ).toBe(true);
+      }
+
+      const handler = getHandler(opts.toolName);
+      await handler(args);
+
+      expect(opts.mock).toHaveBeenCalledWith(
+        expect.objectContaining({ accountId: 12345 }),
+      );
+    });
+  });
+}

--- a/packages/mcp/src/tools/unfollow-from-feed.test.ts
+++ b/packages/mcp/src/tools/unfollow-from-feed.test.ts
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { afterEach, beforeEach, describe, vi } from "vitest";
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return { ...actual, unfollowFromFeed: vi.fn() };
+});
+
+import { unfollowFromFeed } from "@lhremote/core";
+
+import { registerUnfollowFromFeed } from "./unfollow-from-feed.js";
+import { describeAccountIdForwarding } from "./testing/account-id-forwarding.js";
+
+describe("registerUnfollowFromFeed", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describeAccountIdForwarding({
+    registerTool: registerUnfollowFromFeed,
+    toolName: "unfollow-from-feed",
+    mock: vi.mocked(unfollowFromFeed),
+    baseArgs: { feedIndex: 0 },
+  });
+});

--- a/packages/mcp/src/tools/unfollow-from-feed.ts
+++ b/packages/mcp/src/tools/unfollow-from-feed.ts
@@ -19,7 +19,7 @@ export function registerUnfollowFromFeed(server: McpServer): void {
       dryRun: z.boolean().optional().default(false).describe("When true, locate the menu item but do not click it"),
       ...cdpConnectionSchema,
     },
-    async ({ feedIndex, dryRun, cdpPort, cdpHost, allowRemote }) => {
+    async ({ feedIndex, dryRun, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
         const result = await withLoggedInStateRetryAtPort(
           cdpPort,
@@ -31,6 +31,7 @@ export function registerUnfollowFromFeed(server: McpServer): void {
           cdpPort,
           cdpHost,
           allowRemote,
+          accountId,
           dryRun,
           }),
         );

--- a/packages/mcp/src/tools/unfollow-profile.test.ts
+++ b/packages/mcp/src/tools/unfollow-profile.test.ts
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// Copyright (C) 2026 Oleksii PELYKH
+
+import { afterEach, beforeEach, describe, vi } from "vitest";
+
+vi.mock("@lhremote/core", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@lhremote/core")>();
+  return { ...actual, unfollowProfile: vi.fn() };
+});
+
+import { unfollowProfile } from "@lhremote/core";
+
+import { registerUnfollowProfile } from "./unfollow-profile.js";
+import { describeAccountIdForwarding } from "./testing/account-id-forwarding.js";
+
+describe("registerUnfollowProfile", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describeAccountIdForwarding({
+    registerTool: registerUnfollowProfile,
+    toolName: "unfollow-profile",
+    mock: vi.mocked(unfollowProfile),
+    baseArgs: { profileUrl: "https://www.linkedin.com/in/alice/" },
+  });
+});

--- a/packages/mcp/src/tools/unfollow-profile.ts
+++ b/packages/mcp/src/tools/unfollow-profile.ts
@@ -30,7 +30,7 @@ export function registerUnfollowProfile(server: McpServer): void {
         ),
       ...cdpConnectionSchema,
     },
-    async ({ profileUrl, dryRun, cdpPort, cdpHost, allowRemote }) => {
+    async ({ profileUrl, dryRun, cdpPort, cdpHost, allowRemote, accountId }) => {
       try {
         const result = await withLoggedInStateRetryAtPort(
           cdpPort,
@@ -42,6 +42,7 @@ export function registerUnfollowProfile(server: McpServer): void {
           cdpPort,
           cdpHost,
           allowRemote,
+          accountId,
           dryRun,
           }),
         );


### PR DESCRIPTION
## Summary

53 MCP tool wrappers under `packages/mcp/src/tools/` destructured only `{ cdpPort, cdpHost, allowRemote }` from the handler args and forwarded only those to the core operation, **silently dropping the optional `accountId`** declared by `cdpConnectionSchema`. Multi-account users could not target a specific instance via the MCP layer.

User reproduction: with multiple LH accounts, `mcp__lhremote__campaign-list { accountId: 550116 }` failed with `AccountResolutionError: Multiple accounts found` because `accountId` never reached core.

Closes #793

## Scope

**53 MCP tool wrappers updated:**

- **50 Pattern A (direct-forward)**: handlers that destructure args + forward to a core op in one call. Added `accountId` to both destructure and forward.
- **3 Pattern B (`buildCdpOptions`)**: `check-status`, `list-accounts`, `list-workspaces`. Added `accountId` to the destructure and threaded it through `buildCdpOptions({ cdpHost, allowRemote, accountId })` (which already accepts it per `packages/core/src/operations/types.ts`). The two launcher-only tools (`list-accounts`, `list-workspaces`) accept the no-op pass-through for API uniformity.

**Already correct (not touched here):** 10 instance-level wrappers fixed in PR #786 — `visit-profile`, `follow-person`, `endorse-skills`, `like-person-posts`, `message-person`, `send-invite`, `send-inmail`, `enrich-profile`, `remove-connection`, `comment-on-post`. Plus `start-instance` / `stop-instance` which have explicit `accountId` handling for their own resolution logic.

**Out of scope:** CLI handlers under `packages/cli/src/handlers/` (per the issue body — separate concern).

## Tests

Added a shared `describeAccountIdForwarding` helper at `packages/mcp/src/tools/testing/account-id-forwarding.ts`, mirroring the existing `describeInfrastructureErrors` pattern. Each of the 53 fixed wrappers now has a regression test asserting `accountId` is propagated.

- 46 existing test files were extended with one helper invocation
- 4 new minimal test files were created for tools that previously lacked unit-test siblings (`dismiss-feed-post`, `hide-feed-author-profile`, `unfollow-from-feed`, `unfollow-profile`)
- 3 Pattern B test files received explicit assertions matching their `buildCdpOptions` / `LauncherService` constructor signature

## Test plan

- [x] `pnpm lint` — clean across all 5 packages
- [x] `pnpm test` — Tier 1+2 all green: 1707 core + 553 cli + 539 mcp tests pass (no regressions)
- [x] TypeScript strict-mode (`exactOptionalPropertyTypes`) passes
- [x] Per-file grep verification: every changed source file mentions `accountId` ≥ 2× (destructure + forward); only exclusion is `collect-people` which uses spread-with-conditional and was patched explicitly
- [ ] Manual MCP smoke check by reviewer (optional): `mcp__lhremote__campaign-list { accountId: <valid-id> }` returns the expected campaigns instead of `AccountResolutionError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)