### PR TITLE
(fix) test: extend timeout for monitor-collecting-saga timeout-state assertion

### DIFF
--- a/packages/core/src/operations/monitor-collecting-saga.test.ts
+++ b/packages/core/src/operations/monitor-collecting-saga.test.ts
@@ -328,7 +328,16 @@ describe("monitorCollectingSaga", () => {
 
     try {
       await monitorCollectingSaga(instance, {
-        timeout: 1,
+        // 50 ms gives the loop room to enter and complete at least one
+        // iteration even under slow CI (Ubuntu + vitest --coverage).
+        // With timeout=1 the deadline (start + 1 ms) can expire before
+        // `while (Date.now() < deadline)` evaluates the first time —
+        // millisecond quantization + scheduling overhead between the
+        // `start = Date.now()` capture and the loop entry — causing the
+        // body to never run, so recoveryEvents stays 0 and the >= 1
+        // assertion fails. (`delay` is mocked to resolve immediately;
+        // pollInterval timing is not the flake source.)
+        timeout: 50,
         pollInterval: 1,
       });
       expect.unreachable("expected MonitorCollectingSagaTimeoutError");


### PR DESCRIPTION
## Summary

Fix Ubuntu-only flake in \`monitor-collecting-saga.test.ts:316\` (\`propagates accumulated state into the timeout error\`).

The 1ms \`timeout\` + 1ms \`pollInterval\` raced the deadline against the first \`setTimeout(pollInterval)\`. On slow CI runners (Ubuntu under \`vitest --coverage\` instrumentation) the saga monitor reaches the timeout path with \`recoveryEvents=0\`, failing the \`>= 1\` assertion.

Surfaced on main \`46c2abb\` after #799 merged: Ubuntu CI red, macOS CI green — same code, same commit ID, deterministically code-identical → flake.

Closes #801

## Fix

Extend timeout to 50ms (keep \`pollInterval: 1\`):

\`\`\`diff
-       timeout: 1,
+       timeout: 50,
        pollInterval: 1,
\`\`\`

50ms × 1ms-per-iteration = ~50 polling iterations possible, far above any realistic CI race window. Test still completes in <100ms wall time.

## Why this is the right fix

- **Authored in #797** (\`e761e63\`) — pre-existing flake, not regression from #799
- **The sibling test (line 311-312) is unaffected**: its \`waitedMs >= 0\` and \`recoveryEvents >= 0\` assertions tolerate zero iterations, so it doesn't need the extension
- **Production code unchanged** — single test-only edit
- **No assertion semantics changed** — still tests that recoverable popups accumulate before timeout

## Test plan

- [x] Local \`npx vitest run src/operations/monitor-collecting-saga.test.ts\` — 10/10 passing
- [x] Local \`pnpm lint\` — 8/8 packages clean
- [x] Local \`pnpm test\` (Tier 1+2) — all green (539 MCP + core + cli)
- [ ] CI Ubuntu green (waiting)
- [ ] CI macOS green (waiting)
- [ ] CI Windows green (waiting)

🤖 Generated with [Claude Code](https://claude.com/claude-code)