### PR TITLE
(fix) core: rewrite get-post DOM scrapers for LinkedIn React/SDUI post-detail

### DIFF
--- a/packages/core/src/cdp/wait-for-post-load.test.ts
+++ b/packages/core/src/cdp/wait-for-post-load.test.ts
@@ -72,7 +72,7 @@ describe("waitForPostLoad", () => {
     expect(evaluate).toHaveBeenCalledTimes(3);
   });
 
-  it("polls with the three-stage layered readiness predicate (main-scoped author link, aria-label markers, span[dir=ltr] fallback)", async () => {
+  it("polls with the three-stage layered readiness predicate (main-scoped author link, aria-label + componentkey markers, span[dir=ltr] fallback)", async () => {
     const evaluate = vi.fn().mockResolvedValueOnce(true);
     const client = {
       evaluate,
@@ -86,10 +86,19 @@ describe("waitForPostLoad", () => {
     // nav/sidebar chips that hydrate before the post body).
     expect(script).toContain('main a[href*="/in/"]');
     expect(script).toContain('main a[href*="/company/"]');
-    // Stage 2: aria-label-based interaction markers per ADR-007.
+    // Stage 2: aria-label-based interaction markers per ADR-007.  Legacy
+    // markers retained for defensive coverage even though both currently
+    // match 0 elements post-2026-05 SDUI rewrite (lhremote#800).
     expect(script).toContain('aria-label^="React Like to "');
     expect(script).toContain('aria-label^="Comment on"');
     expect(script).toContain('aria-label^="Text editor for creating"');
+    // Stage 2 (lhremote#800 hardening): new SDUI markers — aria-label
+    // for the post-level reactions menu opener, plus a structural
+    // componentkey marker that survives aria-label rotation entirely.
+    expect(script).toContain('aria-label="Open reactions menu"');
+    expect(script).toContain(
+      '[componentkey^="expanded"][componentkey$="FeedType_FEED_DETAIL"]',
+    );
     // Stage 3: legacy span[dir="ltr"] fallback (defensive retention
     // in case LinkedIn restores the markup).
     expect(script).toContain('span[dir="ltr"]');
@@ -135,6 +144,8 @@ describe("waitForPostLoad", () => {
           hasReactLikeButton: false,
           hasCommentOnButton: false,
           hasTopLevelEditor: false,
+          hasReactionsMenu: false,
+          hasPostDetailContainer: false,
           bodyTextSnippet: "",
         };
       }
@@ -195,6 +206,8 @@ describe("capturePostLoadFailure", () => {
         hasReactLikeButton: false,
         hasCommentOnButton: false,
         hasTopLevelEditor: false,
+        hasReactionsMenu: false,
+        hasPostDetailContainer: false,
         bodyTextSnippet: "Post body text\n",
       }),
       send: vi.fn().mockResolvedValue({ data: "aGVsbG8=" }),
@@ -265,6 +278,14 @@ describe("capturePostLoadFailure", () => {
     expect(script).toContain('aria-label^="React Like to "');
     expect(script).toContain('aria-label^="Comment on"');
     expect(script).toContain('aria-label^="Text editor for creating"');
+    // lhremote#800 hardening: new SDUI readiness markers also probed
+    // so a future timeout pins which-of-N-is-missing.
+    expect(script).toContain("hasReactionsMenu");
+    expect(script).toContain("hasPostDetailContainer");
+    expect(script).toContain('aria-label="Open reactions menu"');
+    expect(script).toContain(
+      '[componentkey^="expanded"][componentkey$="FeedType_FEED_DETAIL"]',
+    );
     expect(script).toContain("bodyTextSnippet");
   });
 
@@ -376,6 +397,8 @@ describe("capturePostLoadFailure", () => {
         hasReactLikeButton: false,
         hasCommentOnButton: false,
         hasTopLevelEditor: false,
+        hasReactionsMenu: false,
+        hasPostDetailContainer: false,
         bodyTextSnippet: "",
       }),
       send: vi.fn().mockRejectedValue(new Error("captureScreenshot failed")),

--- a/packages/core/src/cdp/wait-for-post-load.ts
+++ b/packages/core/src/cdp/wait-for-post-load.ts
@@ -11,8 +11,8 @@ import type { CDPClient } from "./client.js";
 // Selectors used by both the readiness predicate ({@link waitForPostLoad}) and
 // the diagnostic probe ({@link capturePostLoadFailure}).  Centralizing them
 // keeps the two aligned: the predicate's joined disjunction is exactly the
-// union of the three probes the diagnostic reports individually, so a future
-// timeout's "which-of-three-is-missing" signal stays accurate by definition.
+// union of the probes the diagnostic reports individually, so a future
+// timeout's "which-of-N-is-missing" signal stays accurate by definition.
 // ----------------------------------------------------------------------------
 
 /**
@@ -39,19 +39,41 @@ const POST_AUTHOR_LINK_DOCUMENT_WIDE_SELECTOR =
 // the post has hydrated far enough for downstream extraction; any single
 // match satisfies the readiness predicate.  The diagnostic probe reports
 // each individually so a future timeout produces a precise
-// "which-of-three-is-missing" signal.
+// "which-of-N-is-missing" signal.
+//
+// Hardened 2026-05-07 (lhremote#800): the original `React Like to ` and
+// `Comment on` markers verified DEAD across all 4 probed post types in the
+// React/SDUI rewrite; only `Text editor for creating` survives at the
+// aria-label layer.  Adds `Open reactions menu` (new aria-label for the
+// post-level reactions opener — replaces the direct-Like trigger) and
+// the structural componentkey marker `expanded{POSTID_HASH}FeedType_FEED_DETAIL`
+// (the post-detail container — survives aria-label rotation).
 const POST_REACT_LIKE_SELECTOR =
   'main button[aria-label^="React Like to "]';
 const POST_COMMENT_ON_SELECTOR =
   'main button[aria-label^="Comment on"]';
 const POST_EDITOR_SELECTOR =
   'main [role="textbox"][aria-label^="Text editor for creating"]';
+const POST_REACTIONS_MENU_SELECTOR =
+  'main button[aria-label="Open reactions menu"]';
+const POST_DETAIL_CONTAINER_SELECTOR =
+  '[componentkey^="expanded"][componentkey$="FeedType_FEED_DETAIL"]';
 
-/** Comma-separated disjunction of the three interaction markers. */
+/**
+ * Comma-separated disjunction of all interaction markers.  The first
+ * three are the legacy aria-label-based signals (POST_REACT_LIKE_SELECTOR
+ * and POST_COMMENT_ON_SELECTOR are kept for defensive coverage in case
+ * LinkedIn restores them; both currently match 0 elements).  The last
+ * two are the lhremote#800 hardening — aria-label `Open reactions menu`
+ * (verified across 4 post types post-2026-05) plus the structural
+ * componentkey marker (immune to aria-label rotation).
+ */
 const POST_INTERACTION_SELECTOR = [
   POST_REACT_LIKE_SELECTOR,
   POST_COMMENT_ON_SELECTOR,
   POST_EDITOR_SELECTOR,
+  POST_REACTIONS_MENU_SELECTOR,
+  POST_DETAIL_CONTAINER_SELECTOR,
 ].join(", ");
 
 /**
@@ -172,7 +194,8 @@ interface CaptureCancellationState {
  * mainFeedListItemCount, mainFeedListItemsWithMenuButton,
  * mainFeedListItemsViableForPostScrape, hasAuthorLink,
  * hasAuthorLinkInMain, hasLtrSpans, hasArticles, hasReactLikeButton,
- * hasCommentOnButton, hasTopLevelEditor, bodyTextSnippet }` —
+ * hasCommentOnButton, hasTopLevelEditor, hasReactionsMenu,
+ * hasPostDetailContainer, bodyTextSnippet }` —
  * mirrors the container-selection logic in
  * `SCRAPE_POST_DETAIL_SCRIPT`: it scopes from `<main>` (fallback) →
  * `[data-testid="mainFeed"]` → `div[role="listitem"]` inside that
@@ -195,6 +218,15 @@ interface CaptureCancellationState {
  * `hasCommentOnButton`, `hasTopLevelEditor`) shadow
  * {@link waitForPostLoad}'s readiness selectors so a timeout pins
  * exactly which post-anchored signal is missing.
+ *
+ * The lhremote#800 hardening probes (`hasReactionsMenu`,
+ * `hasPostDetailContainer`) cover the new SDUI-era markers — the
+ * `Open reactions menu` aria-label that replaces the dead
+ * `React Like to ` trigger, and the structural componentkey marker
+ * for the post-detail container.  A future timeout that fires after
+ * `hasReactLikeButton` and `hasCommentOnButton` go dead but before
+ * `hasReactionsMenu` / `hasPostDetailContainer` arrive will pin the
+ * regression to the SDUI marker layer specifically.
  *
  * Mirrors the diagnostic-capture pattern documented in ADR-007 for
  * `navigateToProfile` — same env var, same artifact structure, same
@@ -270,6 +302,8 @@ async function capturePostLoadFailureInner(
     hasReactLikeButton: boolean;
     hasCommentOnButton: boolean;
     hasTopLevelEditor: boolean;
+    hasReactionsMenu: boolean;
+    hasPostDetailContainer: boolean;
     bodyTextSnippet: string;
   }>(`(() => {
     const mainFeed = document.querySelector('[data-testid="mainFeed"]');
@@ -303,6 +337,8 @@ async function capturePostLoadFailureInner(
       hasReactLikeButton: document.querySelector('${POST_REACT_LIKE_SELECTOR}') !== null,
       hasCommentOnButton: document.querySelector('${POST_COMMENT_ON_SELECTOR}') !== null,
       hasTopLevelEditor: document.querySelector('${POST_EDITOR_SELECTOR}') !== null,
+      hasReactionsMenu: document.querySelector('${POST_REACTIONS_MENU_SELECTOR}') !== null,
+      hasPostDetailContainer: document.querySelector('${POST_DETAIL_CONTAINER_SELECTOR}') !== null,
       bodyTextSnippet: (document.body ? document.body.innerText : "").slice(0, 800),
     };
   })()`);

--- a/packages/core/src/linkedin/selectors.ts
+++ b/packages/core/src/linkedin/selectors.ts
@@ -148,6 +148,86 @@ export const COMMENT_REACTIONS_MENU =
 // ── React-stack post detail (LinkedIn 2026-05 SDUI rewrite) ──────
 
 /**
+ * Outer post-detail container on the React/SDUI post-detail page.
+ *
+ * **Stack note**: as of LinkedIn's React/SDUI post-detail rewrite (live by
+ * 2026-05), the post body is wrapped by a div whose `componentkey` matches
+ * `expanded{POSTID_HASH}FeedType_FEED_DETAIL`.  Two nested elements share
+ * the same key.  This container's descendants are exactly the post body
+ * (author avatar/name links, headline, post text, post-level reaction
+ * trigger) — the comment list is a SIBLING, not a descendant, so this
+ * scope cleanly excludes comment-author and comment-text content.
+ *
+ * **Why this selector**: the legacy `[data-testid="mainFeed"]` →
+ * `div[role="listitem"]` cascade silently falls through to `<main>` after
+ * the SDUI rewrite, causing the FIRST `a[href*="/in/"]` inside `<main>`
+ * (which is the LinkedIn Premium upsell banner pointing at the current
+ * user's profile) to be selected as the post author.  Scoping by this
+ * componentkey prefix is the verified-stable mechanism for excluding
+ * sidebar / chrome / comment-list anchors.
+ *
+ * See `research/linkedin/post-detail-body-dom-react-sdui-20260507.md` and
+ * lhremote issue #800.
+ */
+export const POST_DETAIL_CONTAINER =
+  '[componentkey^="expanded"][componentkey$="FeedType_FEED_DETAIL"]';
+
+/**
+ * Fallback scope: SDUI screen wrapper for the post-detail page.
+ *
+ * Used when {@link POST_DETAIL_CONTAINER} doesn't match (e.g., LinkedIn
+ * renames the `expanded` prefix).  This selector targets the screen-level
+ * SDUI marker which has been stable since the May 2026 rewrite — but it
+ * INCLUDES the comment list as a descendant, so callers must additionally
+ * exclude `[data-component-type="LazyColumn"]` and
+ * `[componentkey^="replaceableComment_"]` when used as a post-author scope.
+ */
+export const POST_DETAIL_SDUI_SCREEN =
+  '[data-sdui-screen="com.linkedin.sdui.flagshipnav.feed.UpdateDetail"]';
+
+/**
+ * Post body text leaf — primary selector.
+ *
+ * The post body text is rendered as a `<span>` with `data-testid="expandable-text-box"`
+ * inside a `<p componentkey="feed-commentary_{UUID}">` wrapper.  This SPAN
+ * is a leaf (no nested elements split the text), so its `textContent` is
+ * the full post body verbatim.
+ *
+ * Absent on very short posts (below the truncation threshold — observed
+ * at ~25 characters).  Use {@link POST_DETAIL_BODY_COMMENTARY_WRAPPER} as
+ * the fallback when this selector returns null.
+ */
+export const POST_DETAIL_BODY_TEXT_LEAF =
+  '[data-testid="expandable-text-box"]';
+
+/**
+ * Post body wrapper — fallback selector.
+ *
+ * The `<p>` element wrapping {@link POST_DETAIL_BODY_TEXT_LEAF}.  Used
+ * when the leaf SPAN is absent (very short posts).  May contain
+ * additional whitespace from the wrapper's own structure, but is
+ * still scoped to the post body only.
+ */
+export const POST_DETAIL_BODY_COMMENTARY_WRAPPER =
+  '[componentkey^="feed-commentary_"]';
+
+/**
+ * Post-level reactions menu opener (NEW marker post-2026-05 rewrite).
+ *
+ * Replaces the legacy `button[aria-label^="React Like to "]` direct-Like
+ * trigger which is gone from the SDUI post-detail page (verified across
+ * regular / share / ugcPost / self-authored URLs).  The new aria-label is
+ * shared between post-level AND comment-level reaction openers; scope to
+ * the post container (or to a specific comment article) to disambiguate.
+ *
+ * For wait-for-post-load.ts readiness, this is the post-level analog of
+ * {@link COMMENT_REACTIONS_MENU} — they share the same selector but
+ * different scopes.
+ */
+export const POST_REACTIONS_MENU =
+  'button[aria-label="Open reactions menu"]';
+
+/**
  * Selects ANY comment article on the post-detail page.
  *
  * **Stack note**: as of LinkedIn's React/SDUI post-detail rewrite (live by
@@ -207,6 +287,35 @@ export function normalizeCommentUrnForReactStack(urn: string): string {
     const postId = legacy[2];
     const commentId = legacy[3];
     return `urn:li:comment:(urn:li:${type}:${postId},${commentId})`;
+  }
+  return urn;
+}
+
+/**
+ * Convert a React-stack comment URN (`urn:li:comment:(urn:li:activity:N,M)`)
+ * back to the legacy format (`urn:li:comment:(activity:N,M)`).
+ *
+ * Inverse of {@link normalizeCommentUrnForReactStack}.  Used by `get-post` to
+ * preserve API output stability — `get-post`'s `commentUrn` field has emitted
+ * the legacy shape since the operation existed; the SDUI rewrite would
+ * silently change the format if URNs were extracted directly from
+ * `componentkey` without renormalization.  Callers that downstream pass the
+ * URN to `comment-on-post` or `react-to-comment` are unaffected because
+ * those skills accept both forms (and re-normalize to SDUI for DOM lookups).
+ *
+ * @returns the legacy-format URN if the input matches the React-stack form;
+ *          otherwise returns the input unchanged (idempotent for legacy form
+ *          and inputs that don't match either pattern).
+ */
+export function denormalizeCommentUrnToLegacy(urn: string): string {
+  // SDUI:    urn:li:comment:(urn:li:activity:N,M)
+  // Legacy:  urn:li:comment:(activity:N,M)
+  const sdui = /^urn:li:comment:\(urn:li:(\w+):(\d+),(\d+)\)$/.exec(urn);
+  if (sdui) {
+    const type = sdui[1];
+    const postId = sdui[2];
+    const commentId = sdui[3];
+    return `urn:li:comment:(${type}:${postId},${commentId})`;
   }
   return urn;
 }

--- a/packages/core/src/operations/get-feed.test.ts
+++ b/packages/core/src/operations/get-feed.test.ts
@@ -733,6 +733,30 @@ describe("parseTimestamp", () => {
     expect(Math.abs((now - 604_800_000) - (result as number))).toBeLessThan(1000);
   });
 
+  it("parses months", () => {
+    const now = Date.now();
+    const result = parseTimestamp("1mo");
+    expect(result).toBeTypeOf("number");
+    expect(Math.abs((now - 2_592_000_000) - (result as number))).toBeLessThan(1000);
+  });
+
+  it("parses multi-digit months", () => {
+    const now = Date.now();
+    const result = parseTimestamp("11mo");
+    expect(result).toBeTypeOf("number");
+    expect(Math.abs((now - 11 * 2_592_000_000) - (result as number))).toBeLessThan(1000);
+  });
+
+  it("treats 'm' as minutes, not the start of 'mo'", () => {
+    // Regex alternation orders `mo` before `[smhdw]` so `1mo` matches `mo`,
+    // but `1m` (without `o`) must still match minutes — confirms the
+    // alternation does not over-eagerly consume `m`.
+    const now = Date.now();
+    const result = parseTimestamp("5m");
+    expect(result).toBeTypeOf("number");
+    expect(Math.abs((now - 5 * 60_000) - (result as number))).toBeLessThan(1000);
+  });
+
   it("parses ISO datetime", () => {
     expect(parseTimestamp("2026-03-25T10:00:00Z")).toBe(
       Date.parse("2026-03-25T10:00:00Z"),

--- a/packages/core/src/operations/get-feed.ts
+++ b/packages/core/src/operations/get-feed.ts
@@ -352,8 +352,14 @@ export function extractHashtags(text: string | null): string[] {
 }
 
 /**
- * Parse a relative timestamp string (e.g. "52m", "16h", "2d", "1w") or an
- * ISO date into epoch milliseconds.  Returns null for unrecognised formats.
+ * Parse a relative timestamp string (e.g. "52m", "16h", "2d", "1w", "1mo") or
+ * an ISO date into epoch milliseconds.  Returns null for unrecognised formats.
+ *
+ * The `mo` (month) unit is approximated as 30 days — LinkedIn emits `Nmo`
+ * for posts ~30-330 days old (per `getPost`'s post-detail body extraction);
+ * without it, the `Nmo` regex match in `get-post.ts` would still produce
+ * `null` here, silently dropping `publishedAt` for older posts.  The 30-day
+ * approximation is consistent with LinkedIn's own UX (which also rounds).
  */
 export function parseTimestamp(raw: string | null): number | null {
   if (!raw) return null;
@@ -362,8 +368,10 @@ export function parseTimestamp(raw: string | null): number | null {
   const asDate = Date.parse(raw);
   if (!isNaN(asDate)) return asDate;
 
-  // Relative time: Ns, Nm, Nh, Nd, Nw
-  const match = raw.match(/^(\d+)([smhdw])$/);
+  // Relative time: Ns, Nm, Nh, Nd, Nw, Nmo (mo = ~30 days).  The alternation
+  // tries `mo` before `[smhdw]` so `1mo` matches `mo` (longer alternative),
+  // not `m` followed by leftover `o`.
+  const match = raw.match(/^(\d+)(mo|[smhdw])$/);
   if (!match) return null;
 
   const value = parseInt(match[1] ?? "0", 10);
@@ -376,6 +384,7 @@ export function parseTimestamp(raw: string | null): number | null {
     h: 3_600_000,
     d: 86_400_000,
     w: 604_800_000,
+    mo: 2_592_000_000,
   };
 
   return now - value * (multipliers[unit] ?? 0);

--- a/packages/core/src/operations/get-post.ts
+++ b/packages/core/src/operations/get-post.ts
@@ -6,6 +6,7 @@ import type { PostComment, PostDetail } from "../types/post.js";
 import { CDPClient } from "../cdp/client.js";
 import { discoverTargets } from "../cdp/discovery.js";
 import { waitForPostLoad } from "../cdp/wait-for-post-load.js";
+import { denormalizeCommentUrnToLegacy } from "../linkedin/selectors.js";
 import { gaussianDelay } from "../utils/delay.js";
 import type { ConnectionOptions } from "./types.js";
 import { extractPostUrn, resolvePostDetailUrl } from "./get-post-stats.js";
@@ -75,10 +76,17 @@ interface RawComment {
  * JavaScript source evaluated inside the LinkedIn post detail page to
  * extract post metadata from the rendered DOM.
  *
- * The post detail page (`/feed/update/{urn}/`) renders a single post
- * using the same SSR feed structure as the home feed.  The script looks
- * for `[data-testid="mainFeed"]` → `div[role="listitem"]` first, then
- * falls back to the full document.
+ * Post-2026-05 LinkedIn migrated `/posts/...` to a React + CSS Modules
+ * + SDUI stack (see lhremote#800 + research file
+ * `post-detail-body-dom-react-sdui-20260507.md`).  The legacy anchors
+ * `[data-testid="mainFeed"]`, `<article>`, and `span[dir="ltr"]` are
+ * all gone.  The script now scopes to the post-detail container by
+ * `[componentkey^="expanded"][componentkey$="FeedType_FEED_DETAIL"]`,
+ * which contains EXACTLY the post body (author links, headline, text,
+ * post-level reactions trigger) and excludes the LinkedIn chrome
+ * (Premium banner, sidebar, comment list, comment authors) — all of
+ * which the legacy fallback-to-`<main>` cascade was incorrectly
+ * picking up.
  */
 const SCRAPE_POST_DETAIL_SCRIPT = `(() => {
   let authorName = null;
@@ -90,53 +98,71 @@ const SCRAPE_POST_DETAIL_SCRIPT = `(() => {
   let shareCount = 0;
   let timestamp = null;
 
-  // Narrow scope: try mainFeed listitem, then <main>, then document
-  let scope = document.querySelector('main') || document;
-  const feedList = document.querySelector('[data-testid="mainFeed"]');
-  if (feedList) {
-    const items = feedList.querySelectorAll('div[role="listitem"]');
-    for (const item of items) {
-      if (item.offsetHeight < 100) continue;
-      const menuBtn = item.querySelector('button[aria-label^="Open control menu for post"]');
-      if (menuBtn) {
-        scope = item;
-        break;
-      }
-    }
-  }
+  // Scope to the post-detail container (lhremote#800).  Cascades down
+  // to the SDUI screen and finally <main> if the componentkey prefix
+  // changes.
+  const scope =
+    document.querySelector('[componentkey^="expanded"][componentkey$="FeedType_FEED_DETAIL"]') ||
+    document.querySelector('[data-sdui-screen="com.linkedin.sdui.flagshipnav.feed.UpdateDetail"]') ||
+    document.querySelector('main') ||
+    document;
 
   // --- Author info ---
-  const authorLink = scope.querySelector('a[href*="/in/"], a[href*="/company/"]');
+  // The post-author has 3 anchors inside scope: avatar (text empty),
+  // name link ("<Name>  • <degree>"), and a height-zero "extended click
+  // area".  All point to the same /in/{publicId}/.  Use the first
+  // anchor for the URL; find the first anchor with non-empty text for
+  // the display name.
+  //
+  // Defense-in-depth (lhremote#800): when the primary post-detail
+  // selector misses and we fall back to the SDUI screen or <main>, the
+  // scope includes the comment list as descendants.  Skip anchors that
+  // sit inside any [componentkey^="replaceableComment_"] subtree so a
+  // commenter never gets picked as the post author — which is exactly
+  // the failure mode this fallback chain is meant to recover from.
+  let authorLink = null;
+  for (const a of scope.querySelectorAll('a[href*="/in/"], a[href*="/company/"]')) {
+    if (a.closest('[componentkey^="replaceableComment_"]')) continue;
+    authorLink = a;
+    break;
+  }
   if (authorLink) {
-    authorProfileUrl = authorLink.href.split('?')[0] || null;
+    authorProfileUrl = (authorLink.href || '').split('?')[0] || null;
 
-    // Try name from span inside the link first
-    const nameSpan = authorLink.querySelector('span[dir="ltr"], span[aria-hidden="true"]');
-    let rawName = nameSpan ? (nameSpan.textContent || '').trim() : '';
-
-    // Fallback: link's own textContent (trimmed, first line only)
-    if (!rawName) {
-      rawName = (authorLink.textContent || '').trim().split('\\n')[0].trim();
+    // Find a sibling anchor with the same href but non-empty text.  Iterate
+    // and compare attribute values directly rather than building a CSS
+    // attribute selector via concatenation — the latter throws on hrefs
+    // containing CSS-special characters (quotes, backslashes), and the raw
+    // attribute can include LinkedIn-injected query strings.
+    const targetHref = authorLink.getAttribute('href');
+    let nameText = '';
+    for (const a of scope.querySelectorAll('a')) {
+      if (a.getAttribute('href') !== targetHref) continue;
+      const t = (a.textContent || '').trim();
+      if (t.length > 0) { nameText = t; break; }
     }
 
-    // Fallback: look for a nearby heading or span that contains the name
-    // (LinkedIn sometimes renders the name outside the <a> tag)
-    if (!rawName) {
-      const parent = authorLink.closest('div');
-      if (parent) {
-        const nearby = parent.querySelector('span[dir="ltr"], span[aria-hidden="true"]');
-        if (nearby) rawName = (nearby.textContent || '').trim();
-      }
-    }
-
-    authorName = rawName || null;
+    // Strip the SDUI " • <degree>" suffix from the name link text.
+    // Format: "<Name>  • 1st" / "<Name> • 2nd" / "<Name>  • You" /
+    // "<Name>  • 3rd".  Connection-degree separator is bullet (•).
+    const m = nameText.match(/^(.+?)\\s+•\\s+(?:1st|2nd|3rd|Out of network|You)\\s*$/);
+    authorName = (m ? m[1] : nameText).trim() || null;
   }
 
   // --- Author headline ---
-  // Search within <main> scope, skip navigation text and the author name
-  const allSpans = scope.querySelectorAll('span');
-  for (const span of allSpans) {
-    const txt = (span.textContent || '').trim();
+  // After the author block, there's a headline element in <p> or <span>
+  // form. Scan post container for a non-empty text leaf with length
+  // 5..200 that is NOT the author name, NOT a relative-time marker,
+  // NOT a UI label, and NOT a composite "<Name> • <degree>" span.
+  //
+  // Defense-in-depth (lhremote#800): same filter as the author-link
+  // lookup above — when the SDUI-screen / <main> fallback fires, the
+  // comment list is a descendant of scope, and a commenter's headline
+  // would otherwise win.
+  const headlineCandidates = scope.querySelectorAll('p, span');
+  for (const el of headlineCandidates) {
+    if (el.closest('[componentkey^="replaceableComment_"]')) continue;
+    const txt = (el.textContent || '').trim();
     if (
       txt &&
       txt.length > 5 &&
@@ -144,9 +170,13 @@ const SCRAPE_POST_DETAIL_SCRIPT = `(() => {
       txt !== authorName &&
       !txt.match(/^\\d+[smhdw]$/) &&
       !txt.match(/^\\d[\\d,]*\\s+(reactions?|comments?|reposts?|likes?)$/i) &&
-      !txt.match(/^Follow$|^Promoted$/i) &&
+      !txt.match(/^Follow$|^Promoted$|^Boost$|^Author$|^You$/i) &&
       !txt.match(/^Skip to|^Keyboard shortcuts$|^Close jump menu$/i) &&
-      !txt.match(/^Feed detail update$|^Feed post$/i)
+      !txt.match(/^Feed\\s+(?:post|detail\\s+update)$/i) &&
+      !txt.match(/^Promote\\s+this\\s+post/i) &&
+      !txt.match(/Reaction button state:/) &&
+      !txt.includes('•') &&
+      !txt.match(/^https?:\\/\\//)
     ) {
       authorHeadline = txt;
       break;
@@ -154,19 +184,22 @@ const SCRAPE_POST_DETAIL_SCRIPT = `(() => {
   }
 
   // --- Post text ---
-  const ltrSpans = scope.querySelectorAll('span[dir="ltr"]');
-  let longestText = '';
-  for (const span of ltrSpans) {
-    const txt = (span.textContent || '').trim();
-    if (txt.length > longestText.length && txt !== authorName && txt !== authorHeadline) {
-      longestText = txt;
-    }
+  // Cascade per research: data-testid leaf -> componentkey wrapper.
+  // Both selectors are stable and verified across all 4 post types
+  // (regular / share / ugcPost / self).  Very short posts may have
+  // neither — accept null in that case rather than synthesizing.
+  let textEl = scope.querySelector('[data-testid="expandable-text-box"]');
+  if (!textEl) {
+    textEl = scope.querySelector('[componentkey^="feed-commentary_"]');
   }
-  if (longestText.length > 20) {
-    text = longestText;
+  if (textEl) {
+    const t = (textEl.textContent || '').trim();
+    if (t.length > 0) text = t;
   }
 
-  // --- Engagement counts ---
+  // --- Engagement counts (UNCHANGED — text-content regex survives
+  // the DOM rewrite; verified by lhremote#800 reporting correct counts
+  // even when other fields are placeholder data) ---
   const countText = document.body.textContent || '';
 
   function parseCount(pattern) {
@@ -182,16 +215,15 @@ const SCRAPE_POST_DETAIL_SCRIPT = `(() => {
   shareCount = parseCount(/(\\d[\\d,]*)\\s+reposts?/i);
 
   // --- Timestamp ---
-  const timeEl = scope.querySelector('time');
-  if (timeEl) {
-    const dt = timeEl.getAttribute('datetime');
-    if (dt) timestamp = dt;
-  }
-  if (!timestamp) {
-    const scopeText = scope.textContent || '';
-    const timeMatch = scopeText.match(/(?:^|\\s)(\\d+[smhdw])(?:\\s|$|\\u00B7|\\xB7)/);
-    if (timeMatch) timestamp = timeMatch[1];
-  }
+  // The SDUI post-detail page has NO <time> element inside the post
+  // container (verified across all 4 post types).  Extract the
+  // relative-time prefix from container textContent: "<degree>2w •",
+  // "<degree>1mo •", etc.  "Edited" is a status flag, not a timestamp,
+  // so it is intentionally excluded from the alternation.
+  const scopeText = scope.textContent || '';
+  const timeMatch = scopeText.match(/(?:1st|2nd|3rd|You)(\\d+[smhdw]|[1-9]\\d*mo)\\s+•/) ||
+                     scopeText.match(/(?:^|\\s)(\\d+[smhdw]|[1-9]\\d*mo)\\s+•/);
+  if (timeMatch) timestamp = timeMatch[1];
 
   return {
     authorName,
@@ -209,46 +241,85 @@ const SCRAPE_POST_DETAIL_SCRIPT = `(() => {
  * JavaScript source evaluated inside the LinkedIn post detail page to
  * extract visible comments from the DOM.
  *
- * Comments are rendered as `article` elements containing an author link
- * and text content.  Only first-page (visible) comments are extracted;
- * "Load more" is not clicked.
+ * Post-2026-05 LinkedIn migrated comments from
+ * `<article class="comments-comment-entity" data-id="urn:li:comment:..." />`
+ * to `<div componentkey="replaceableComment_<URN>">` (lhremote#776).
+ * Each logical comment renders as 3 nested elements sharing the same
+ * `componentkey`; pick the OUTERMOST (max descendants) per URN to avoid
+ * triple-counting.  See `research/linkedin/post-detail-comment-dom-react-sdui-20260506.md`
+ * § 3 (comment DOM) and `post-detail-body-dom-react-sdui-20260507.md` § 6
+ * (sister regression for `get-post.ts`).
  */
 const SCRAPE_COMMENTS_SCRIPT = `(() => {
-  const comments = [];
-  const articles = document.querySelectorAll('article');
+  // SDUI: dedupe by componentkey, picking the outermost element per URN.
+  // Each logical comment renders as 3 nested elements sharing the same
+  // componentkey (per the May 6 research).  The outermost element is the
+  // one whose parent does NOT share its componentkey — checking the
+  // parent is O(1) per element vs O(subtree-size) for descendant counting,
+  // which matters on long comment lists.
+  const allEls = document.querySelectorAll('[componentkey^="replaceableComment_"]');
+  const byUrn = new Map();
+  for (const el of allEls) {
+    const ck = el.getAttribute('componentkey') || '';
+    const parentCk = el.parentElement && el.parentElement.getAttribute('componentkey');
+    if (parentCk === ck) continue; // not outermost
+    const urn = ck.replace(/^replaceableComment_/, '');
+    byUrn.set(urn, el);
+  }
 
-  for (const article of articles) {
-    if (article.offsetHeight < 30) continue;
+  const comments = [];
+  for (const comment of byUrn.values()) {
+    if (comment.offsetHeight < 30) continue;
 
     // --- Author ---
     let authorName = '';
     let authorHeadline = null;
     let authorPublicId = null;
-    const authorLink = article.querySelector('a[href*="/in/"]');
 
+    const authorLink = comment.querySelector('a[href*="/in/"]');
     if (authorLink) {
-      const nameSpan = authorLink.querySelector('span[dir="ltr"], span[aria-hidden="true"]');
-      authorName = nameSpan ? (nameSpan.textContent || '').trim() : '';
-      if (!authorName) {
-        authorName = (authorLink.textContent || '').trim().split('\\n')[0].trim();
-      }
-      if (!authorName) {
-        const parent = authorLink.closest('div');
-        if (parent) {
-          const nearby = parent.querySelector('span[dir="ltr"], span[aria-hidden="true"]');
-          if (nearby) authorName = (nearby.textContent || '').trim();
-        }
-      }
-
-      const href = authorLink.href.split('?')[0] || '';
+      const href = (authorLink.href || '').split('?')[0] || '';
       const idMatch = href.match(/\\/in\\/([^/?]+)/);
       if (idMatch) authorPublicId = idMatch[1];
+
+      // Find an anchor (same href as authorLink) with non-empty text.
+      // The textContent has these verified forms:
+      //   "<Name>Author<Headline>"          (post-author commenting)
+      //   "<Name>  • <degree><Name>  • <degree><Headline>" (regular other user)
+      //   "<Name> Verified Profile <degree><Name>  • <degree><Headline>"
+      //   "<Name> Premium Profile You<Name>  • You<Headline>"
+      // Take everything before the first " • <degree>" or "Author" suffix.
+      //
+      // Iterate and compare attribute values directly rather than building a
+      // CSS attribute selector via concatenation — see post-author scraper
+      // above (same defense against CSS-special characters in raw hrefs).
+      const targetHref = authorLink.getAttribute('href');
+      for (const a of comment.querySelectorAll('a')) {
+        if (a.getAttribute('href') !== targetHref) continue;
+        const t = (a.textContent || '').trim();
+        if (t.length === 0) continue;
+        const m = t.match(/^(.+?)(?:\\s+•\\s+(?:1st|2nd|3rd|Out of network|You)|Author)/);
+        let raw = m ? m[1] : t.split('\\n')[0];
+        // Strip "Verified Profile" / "Premium Profile" decorations and any
+        // duplicated name that LinkedIn injects after them.  The badge
+        // can appear mid-string in forms like
+        //   "Alexey Pelykh Premium Profile YouAlexey Pelykh" (regex match
+        //    captured up to the first " • You" position),
+        // so anchoring on Profile-end-of-string would miss it.  Truncate
+        // from the first badge-token occurrence onwards.
+        raw = raw.replace(/\\s+(?:Verified|Premium)\\s+Profile\\b.*$/, '').trim();
+        if (raw.length > 0) {
+          authorName = raw;
+          break;
+        }
+      }
     }
 
     // --- Author headline ---
-    const spans = article.querySelectorAll('span');
-    for (const span of spans) {
-      const txt = (span.textContent || '').trim();
+    // Apply same headline heuristics as the post body, scoped to comment.
+    const headlineCandidates = comment.querySelectorAll('p, span');
+    for (const el of headlineCandidates) {
+      const txt = (el.textContent || '').trim();
       if (
         txt &&
         txt.length > 5 &&
@@ -256,7 +327,10 @@ const SCRAPE_COMMENTS_SCRIPT = `(() => {
         txt !== authorName &&
         !txt.match(/^\\d+[smhdw]$/) &&
         !txt.match(/^\\d[\\d,]*\\s+(reactions?|comments?|reposts?|likes?)$/i) &&
-        !txt.match(/^Reply$|^Like$/i)
+        !txt.match(/^Reply$|^Like$|^Author$|^You$/i) &&
+        !txt.match(/^(?:Verified|Premium)\\s+Profile$/) &&
+        !txt.match(/Reaction button state:/) &&
+        !txt.includes('•')
       ) {
         authorHeadline = txt;
         break;
@@ -264,11 +338,19 @@ const SCRAPE_COMMENTS_SCRIPT = `(() => {
     }
 
     // --- Comment text ---
+    // expandable-text-box does NOT exist inside comments (only in post
+    // body); use longest text leaf approach scoped to the comment.
     let text = '';
-    const ltrSpans = article.querySelectorAll('span[dir="ltr"]');
-    for (const span of ltrSpans) {
-      const txt = (span.textContent || '').trim();
+    const textCandidates = comment.querySelectorAll('p, span');
+    for (const el of textCandidates) {
+      const txt = (el.textContent || '').trim();
       if (txt.length > text.length && txt !== authorName && txt !== authorHeadline) {
+        // Skip composite spans that contain author info
+        if (authorName && authorHeadline && txt.includes(authorName) && txt.includes(authorHeadline)) continue;
+        // Skip Reaction button state mirrors
+        if (/Reaction button state:/.test(txt)) continue;
+        // Skip degree-suffix composites
+        if (/\\s+•\\s+(?:1st|2nd|3rd|You|Out of network)/.test(txt) && txt.length < 60) continue;
         text = txt;
       }
     }
@@ -276,21 +358,20 @@ const SCRAPE_COMMENTS_SCRIPT = `(() => {
     // Skip if no meaningful content
     if (!text && !authorName) continue;
 
-    // --- Comment URN ---
-    const commentUrn = article.getAttribute('data-id') || null;
+    // --- Comment URN (from componentkey, SDUI format) ---
+    const ck = comment.getAttribute('componentkey') || '';
+    const commentUrn = ck.replace(/^replaceableComment_/, '') || null;
 
-    // --- Timestamp ---
+    // --- Timestamp (relative time pattern; SDUI page has no <time>) ---
     let createdAt = null;
-    const timeEl = article.querySelector('time');
-    if (timeEl) {
-      const dt = timeEl.getAttribute('datetime');
-      if (dt) createdAt = dt;
-    }
+    const commentText = comment.textContent || '';
+    const timeMatch = commentText.match(/(?:1st|2nd|3rd|You)(\\d+[smhdw]|[1-9]\\d*mo)/) ||
+                      commentText.match(/(?:^|\\s)(\\d+[smhdw]|[1-9]\\d*mo)(?:\\s|$)/);
+    if (timeMatch) createdAt = timeMatch[1];
 
-    // --- Reaction count ---
+    // --- Reaction count (existing pattern) ---
     let reactionCount = 0;
-    const articleText = article.textContent || '';
-    const likesMatch = articleText.match(/(\\d[\\d,]*)\\s+reactions?/i);
+    const likesMatch = commentText.match(/(\\d[\\d,]*)\\s+reactions?/i);
     if (likesMatch) {
       reactionCount = parseInt(likesMatch[1].replace(/,/g, ''), 10) || 0;
     }
@@ -439,11 +520,18 @@ export async function getPost(input: GetPostInput): Promise<GetPostOutput> {
     // --- Comment loading ---
     // Click "Load more comments" repeatedly until we have enough or no more
     // are available.  Each click loads an additional batch of comments.
+    //
+    // Post-2026-05 SDUI: comments are 3-nested elements sharing
+    // `componentkey="replaceableComment_<URN>"`.  Count distinct logical
+    // comments by picking the OUTERMOST element per URN (parent componentkey
+    // differs from this element's), matching the SCRAPE_COMMENTS_SCRIPT
+    // dedupe heuristic.  Raw element count would triple-overshoot
+    // maxComments.  See lhremote#776 / #800.
     const maxLoadMoreAttempts = 20;
     if (maxComments > 0) {
       for (let attempt = 0; attempt < maxLoadMoreAttempts; attempt++) {
         const currentCount = await client.evaluate<number>(
-          `document.querySelectorAll('article').length`,
+          `(function () { let n = 0; document.querySelectorAll('[componentkey^="replaceableComment_"]').forEach(function (el) { const ck = el.getAttribute('componentkey'); if (!ck) return; const parentCk = el.parentElement && el.parentElement.getAttribute('componentkey'); if (parentCk !== ck) n++; }); return n; })()`,
         );
         if (currentCount >= maxComments) break;
 
@@ -460,7 +548,12 @@ export async function getPost(input: GetPostInput): Promise<GetPostOutput> {
     const limited = maxComments > 0 ? allRaw.slice(0, maxComments) : [];
 
     const comments: PostComment[] = limited.map((c) => ({
-      commentUrn: c.commentUrn,
+      // Renormalize to legacy URN shape so get-post's API output stays
+      // backward-compatible with pre-SDUI consumers (the SDUI rewrite
+      // changed the in-DOM URN format from `(activity:N,M)` to
+      // `(urn:li:activity:N,M)`; without renormalization we'd silently
+      // break that contract).
+      commentUrn: c.commentUrn ? denormalizeCommentUrnToLegacy(c.commentUrn) : null,
       authorName: c.authorName,
       authorHeadline: c.authorHeadline,
       authorPublicId: c.authorPublicId,

--- a/packages/e2e/src/get-post.e2e.test.ts
+++ b/packages/e2e/src/get-post.e2e.test.ts
@@ -21,14 +21,33 @@ import { createMockServer } from "@lhremote/mcp/testing";
 
 /**
  * Fetch a fresh post URL by scraping the feed.  Returns the URL of the
- * first feed post, or `undefined` when the feed returns no posts or the
- * first post has no URL.
+ * first member-authored feed post that ALSO has at least one comment
+ * (i.e. `authorProfileUrl` contains `/in/{publicId}/` AND
+ * `commentCount > 0`).  Two filters, both load-bearing for the
+ * lhremote#800 regression guards below:
+ *
+ * - The `/in/` filter excludes company posts, promoted slots, and edge
+ *   feed items that legitimately yield `authorPublicId: null` and
+ *   would trip the `authorPublicId !== null` regression guard.
+ * - The `commentCount > 0` filter ensures the
+ *   `commentCount > 0 → comments.length > 0` regression guard
+ *   actually fires; without it, picking a comment-less post would
+ *   silently bypass that check and leave broken comment scraping
+ *   undetected.
+ *
+ * Returns `undefined` when no qualifying post is in the first 10 feed
+ * items.
  */
 async function fetchPostUrlFromFeed(cdpPort: number): Promise<string | undefined> {
   const { getFeed } = await import("@lhremote/core");
-  const result = await getFeed({ cdpPort, count: 1 });
-  const first = result.posts[0];
-  return first?.url ?? undefined;
+  const result = await getFeed({ cdpPort, count: 10 });
+  for (const post of result.posts) {
+    if (!post.url) continue;
+    if (!post.authorProfileUrl?.includes("/in/")) continue;
+    if (post.commentCount <= 0) continue;
+    return post.url;
+  }
+  return undefined;
 }
 
 describeE2E("get-post operation", () => {
@@ -128,6 +147,7 @@ describeE2E("get-post operation", () => {
         .join("");
       const parsed = JSON.parse(output) as GetPostOutput;
 
+      // ── Structural assertions ──────────────────────────────────
       expect(parsed.post).toHaveProperty("postUrn");
       expect(typeof parsed.post.postUrn).toBe("string");
       expect(typeof parsed.post.authorName).toBe("string");
@@ -137,7 +157,51 @@ describeE2E("get-post operation", () => {
       expect(Array.isArray(parsed.comments)).toBe(true);
       expect(parsed.commentsPaging).toHaveProperty("total");
 
-      // Verify commentUrn extraction (was previously hardcoded to null)
+      // ── Semantic assertions (lhremote#800 regression guards) ───
+      // The 2026-05 regression returned `authorName === "Premium"`,
+      // empty text, and empty comments[] even when commentCount > 0.
+      // These assertions catch that exact failure mode.
+
+      // (1) authorName must NOT be a LinkedIn UI string (the regression's
+      // signature value was "Premium" — the badge text from the Premium
+      // upsell banner).
+      const UI_STRING_BLOCKLIST = [
+        "Premium",
+        "Following",
+        "Follow",
+        "Connect",
+        "Pending",
+        "Comment",
+        "Share",
+        "Like",
+        "Repost",
+        "Send",
+        "Save",
+        "Report",
+        "Promoted",
+        "Boost",
+      ];
+      expect(parsed.post.authorName).not.toBe("");
+      expect(UI_STRING_BLOCKLIST).not.toContain(parsed.post.authorName);
+
+      // (2) authorPublicId must be set (the regression returned the
+      // current user's publicId — without an account-publicId helper the
+      // strict "!== currentAccountPublicId" check is deferred; use the
+      // weaker "non-null" check here).
+      expect(parsed.post.authorPublicId).not.toBeNull();
+
+      // (3) Comments array must populate.  fetchPostUrlFromFeed
+      // selected a post with commentCount > 0, so this assertion is
+      // unconditional — the regression returned `comments: []` even
+      // for posts with non-zero commentCount, and a conditional guard
+      // would silently let comment-scraping regressions through if
+      // the precondition ever drifted.
+      expect(parsed.post.commentCount).toBeGreaterThan(0);
+      expect(parsed.commentsPaging.total).toBeGreaterThan(0);
+      expect(parsed.comments.length).toBeGreaterThan(0);
+
+      // (4) Verify commentUrn extraction (was previously hardcoded to
+      // null; SDUI format includes the `(urn:li:activity:` qualifier).
       if (parsed.comments.length > 0) {
         const firstComment = parsed.comments[0];
         expect(firstComment.commentUrn).not.toBeNull();


### PR DESCRIPTION
Closes #800.

LinkedIn migrated `/posts/...` to a React + CSS Modules + SDUI stack on
2026-05-06.  The legacy DOM scrapers in `get-post.ts` silently fall through
to `<main>` after the rewrite, causing the FIRST `a[href*="/in/"]` inside
`<main>` (which is the Premium upsell banner pointing at the current user)
to be selected as the post author.  Sister regression to #776; the May 6
fix explicitly deferred `get-post.ts` to a follow-up issue (this one).

## Symptoms

- `authorName: "Premium"` (LinkedIn UI badge text)
- `authorPublicId: <currentAccount>` (Premium banner href)
- `text: ""` (`span[dir="ltr"]` gone)
- `comments: []` (`<article>` elements gone)

Top-level `reactionCount` / `commentCount` / `shareCount` remain correct
because they're parsed from `document.body.textContent` regex and survive
the rewrite unchanged.

## Changes

### `linkedin/selectors.ts`

5 new SDUI exports for the post-detail page:

- `POST_DETAIL_CONTAINER` — `[componentkey^="expanded"][componentkey$="FeedType_FEED_DETAIL"]`
- `POST_DETAIL_SDUI_SCREEN` — `[data-sdui-screen="com.linkedin.sdui.flagshipnav.feed.UpdateDetail"]`
- `POST_DETAIL_BODY_TEXT_LEAF` — `[data-testid="expandable-text-box"]`
- `POST_DETAIL_BODY_COMMENTARY_WRAPPER` — `[componentkey^="feed-commentary_"]`
- `POST_REACTIONS_MENU` — `button[aria-label="Open reactions menu"]`

### `operations/get-post.ts` (`SCRAPE_POST_DETAIL_SCRIPT`)

Rewrote to scope by `[componentkey^="expanded"][componentkey$="FeedType_FEED_DETAIL"]` — the SDUI post-detail container, which structurally excludes Premium banner / sidebar / comment list (verified across 4 post types: regular, share-, ugcPost-, self-authored).  Author name extraction strips the SDUI ` • <degree>` suffix.  Text extraction cascades `[data-testid="expandable-text-box"]` (leaf SPAN) → `[componentkey^="feed-commentary_"]` (wrapper P) → null.  Timestamp switched from `<time>` (gone) to relative-time text pattern.

### `operations/get-post.ts` (`SCRAPE_COMMENTS_SCRIPT`)

Replaced `document.querySelectorAll('article')` with `[componentkey^="replaceableComment_"]` + outermost-element-per-URN dedupe (3-elements-per-comment ratio per #776 research).  Comment URN extracted from componentkey (SDUI form `urn:li:comment:(urn:li:activity:N,M)`).

### `operations/get-post.ts` (load-more counter)

Replaced `document.querySelectorAll('article').length` with deduped componentkey count to avoid 3x-overshoot of `maxComments`.

### `cdp/wait-for-post-load.ts` (readiness predicate hardening)

Added two new markers — `main button[aria-label="Open reactions menu"]` (new post-level reactions opener; verified across 4 post types) and the structural componentkey marker (immune to aria-label rotation).  The legacy `React Like to ` and `Comment on` aria-labels are dead but retained for defensive coverage.  Diagnostic probe extended with `hasReactionsMenu` and `hasPostDetailContainer` for future timeouts.

### `e2e/src/get-post.e2e.test.ts` (regression guards)

Replaced structural-only assertions (`typeof authorName === "string"`, `Array.isArray(comments)`) with semantic regression guards: a 14-entry UI-string blocklist (`Premium`, `Following`, `Connect`, `Comment`, `Share`, ...) for `authorName`, `authorPublicId` not-null, and the `commentCount > 0 → comments.length > 0` invariant.  These would reject the original regression's placeholder data while accepting real post data.

## Test plan

- [x] `pnpm test` — 1707 unit tests pass
- [x] `pnpm lint` — 8 packages clean
- [x] `pnpm build` — 5 packages clean
- [x] `pnpm test:e2e:file get-post` — 3/3 E2E tests pass against real LinkedIn (1st-degree connection's post via `fetchPostUrlFromFeed`)

## Research

`research/linkedin/post-detail-body-dom-react-sdui-20260507.md` — 704 lines; 5 TBDs verified across 4-URL DOM probe sweep (regular activity, share-, ugcPost-, self-authored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)