### PR TITLE
(chore) release: bump claude-plugin/marketplace/server JSONs to 0.20.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
       "name": "lhremote",
       "source": "./",
       "description": "LinkedHelper automation toolkit — MCP server and workflow guidance for Claude Code",
-      "version": "0.20.0",
+      "version": "0.20.1",
       "author": {
         "name": "Alexey Pelykh"
       },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "lhremote",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "LinkedHelper automation toolkit — MCP server and workflow guidance for Claude Code",
   "author": {
     "name": "Alexey Pelykh",

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/alexey-pelykh/lhremote",
     "source": "github"
   },
-  "version": "0.20.0",
+  "version": "0.20.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "lhremote",
-      "version": "0.20.0",
+      "version": "0.20.1",
       "transport": {
         "type": "stdio"
       },


### PR DESCRIPTION
## Summary

- Bump `version` field to `0.20.1` in `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, and `server.json` to match the v0.20.1 npm package release
- Per CLAUDE.md § Infrastructure: the release workflow doesn't auto-bump these files — they must be bumped via PR after each release tag

v0.20.1 release: https://github.com/alexey-pelykh/lhremote/releases/tag/v0.20.1

## Test plan

- [x] `pnpm lint` clean
- [ ] CI green